### PR TITLE
add the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: php
 
 php:
-  - '5.2'
-  - '5.3'
-  - '5.4'
+#  - '5.2'
+#  - '5.3'
+#  - '5.4'
   - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
-  - hhvm
-  - nightly
+#  - nightly
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: php
+
+php:
+  - '5.2'
+  - '5.3'
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - hhvm
+  - nightly
+
+before_script:
+  - composer install
+
+script:
+  - mkdir -p .build/logs
+  - vendor/bin/phpunit -c phpunit.xml.dist
+
+# We should also add codecov.
+#after_success:
+#- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Adds a basic travis.yml

Since we support PHP from 5.2x on, I've PHP support from 5.2 upwards.