### PR TITLE
fix regex for saving country data

### DIFF
--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -99,7 +99,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 		// Blacklist clean
 		if ( !empty($options['country_black']) ) {
 			$options['country_black'] = preg_replace(
-				'/[^A-Z ]/',
+				'/[^A-Z ,;]/',
 				'',
 				strtoupper($options['country_black'])
 			);
@@ -108,7 +108,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 		// Whitelist clean
 		if ( !empty($options['country_white']) ) {
 			$options['country_white'] = preg_replace(
-				'/[^A-Z ]/',
+				'/[^A-Z ,;]/',
 				'',
 				strtoupper($options['country_white'])
 			);


### PR DESCRIPTION
Solves #121 

We did adjust the regex to split the country list string in _antispam_bee.php_ to `/[\s,;]+/` in #86 and changes the placeholder accordingly in #87. The idea was to be able to use comma or semicolon as well to seperate the country codes.

However, we have missed, the rexeg sanitizing the input in _inc/gui.class.php_, which still just allowed A-Z as well as space. This PR extends the allowed characters to comma and semicolon: `/[^A-Z ,;]/`

> I Would expect a comma separated list (like in the placeholder)

It is not exactly the output like the format of the placeholder, you can also use just space or semicolons. But I think its good enough, if we see the placeholder more as a guide, while we actually provide more possibilities to save the data correctly in order to reduce errors. But you could argue, we should format different allowed inputs into the same output string, like `DE UK, US; DK` as input should be saved as `DE, UK, US, DK`. For me this doesn't look necessary, but we could go this route.