### PR TITLE
remove usage of get_the_title()

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2601,7 +2601,7 @@ class Antispam_Bee {
 	 */
 	public static function get_secret_name_for_post( $post_id ) {
 
-		$secret = substr( sha1( md5( self::$_salt . get_the_title( (int) $post_id ) ) ), 0, 10 );
+		$secret = substr( sha1( md5( self::$_salt . (int) $post_id ) ), 0, 10 );
 
 		/**
 		 * Filters the secret for a post, which is used in the textarea name attribute.
@@ -2626,7 +2626,7 @@ class Antispam_Bee {
 	 */
 	public static function get_secret_id_for_post( $post_id ) {
 
-		$secret = substr( sha1( md5( 'comment-id' . self::$_salt . get_the_title( (int) $post_id ) ) ), 0, 10 );
+		$secret = substr( sha1( md5( 'comment-id' . self::$_salt . (int) $post_id ) ), 0, 10 );
 
 		/**
 		 * Filters the secret for a post, which is used in the textarea id attribute.

--- a/readme.txt
+++ b/readme.txt
@@ -155,7 +155,7 @@ For the complete changelog, check out our [GitHub repository](https://github.com
 == Upgrade Notice ==
 
 = 2.7.1 =
-Please flush your cache, after you have updated.
+This update changes the actual markup of your comment fields. Please make sure that you flush your caches after the plugin was updated!
 
 ## Screenshots ##
 1. Antispam Bee settings

--- a/readme.txt
+++ b/readme.txt
@@ -152,5 +152,10 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
 
 For the complete changelog, check out our [GitHub repository](https://github.com/pluginkollektiv/antispam-bee).
 
+== Upgrade Notice ==
+
+= 2.7.1 =
+Please flush your cache, after you have updated.
+
 ## Screenshots ##
 1. Antispam Bee settings


### PR DESCRIPTION
Removes `get_the_title()` to generate the secrets.

Fixes #131.