### PR TITLE
change the default value for email_notify to 0 (solves #151)

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -384,7 +384,7 @@ class Antispam_Bee {
 
 				// Advanced
 				'flag_spam' 		=> 1,
-				'email_notify' 		=> 1,
+				'email_notify' 		=> 0,
 				'no_notice' 		=> 0,
 				'cronjob_enable' 	=> 0,
 				'cronjob_interval'	=> 0,


### PR DESCRIPTION
This PR changes the default value of `email_notify` to 0. So by default, we do not send "Comment marked as spam" notifications.

closes #151