### PR TITLE
save hashed ip in meta and compare current ip with hashes

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1689,11 +1689,11 @@ class Antispam_Bee {
 
 		$hashed_ip = self::hash_ip( wp_unslash($ip) );
 
-		$args = [
+		$args = array(
 			'meta_key' => 'antispam_bee_iphash',
 			'meta_value' => $hashed_ip,
 			'status' => 'spam',
-		];
+		);
 		$query = new WP_Comment_Query($args);
 
 		if ( ! empty( $query->get_comments() ) ) {


### PR DESCRIPTION
closes #177 

with gdpr coming up, the comment_author_ip column won't be reliable anymore as more and more people will rightfully start to anonymize this column. even core might follow up on this.

on the other hand the ip address is a very valuable source to determine spam and has been proven effective in preventing spam when stored in the local database.

this approach tries to bring privacy and spam protection together. it stores a salted/hashed version of the ip address of spam comments. if a comment is incoming, we check against this hashed ip.