### PR TITLE
remove trackback_post actions

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2155,15 +2155,6 @@ class Antispam_Bee {
 
 		// Save IP hash, if comment is spam.
 		add_action(
-			'trackback_post',
-			array(
-				__CLASS__,
-				'save_ip_hash',
-			),
-			10,
-			3
-		);
-		add_action(
 			'comment_post',
 			array(
 				__CLASS__,
@@ -2194,14 +2185,7 @@ class Antispam_Bee {
 		);
 
 		// Send e-mail
-		add_filter(
-			'trackback_post',
-			array(
-				__CLASS__,
-				'send_mail_notification'
-			)
-		);
-		add_filter(
+		add_action(
 			'comment_post',
 			array(
 				__CLASS__,
@@ -2211,7 +2195,7 @@ class Antispam_Bee {
 
 		// Spam reason as comment meta
 		if ( $spam_notice ) {
-			add_filter(
+			add_action(
 				'comment_post',
 				array(
 					__CLASS__,


### PR DESCRIPTION
We have several `trackback_post` actions (one for saving the hashed ip, one for sending email notifications). Those actions are also called when we call `comment_post`. When you look into the code, you see the following:

befoore `trackback_post` gets called `comment_post` will be called as well. This basically means, we can get rid of those hooks, as we are hooked in `comment_post` anyway.

closes #203 