### PR TITLE
delete meta data on uninstall (closes #232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   * Do not show "Trust commenters with a Gravatar" if the "Show Gravatar" option is not set.
   * Skip the checks, when I ping myself.
   * Fixes some wrong usages of the translation functions.
-  * Use the regular expressions check also for trackbacks. 
+  * Use the regular expressions check also for trackbacks.
+  * Add option to delete Antispam Bee related data when plugin gets deleted via the admin interface.
   * Save a hashed + salted IP for every comment
   * New check for incoming Trackbacks.
   * Introduction of behat tests.
@@ -19,6 +20,7 @@
   * Überspringe die Filter, wenn ich mich selbst anpinge.
   * Repariert einige falsche Verwendungsweisen der Übersetzungsfunktionalitäten.
   * Wende den reguläre Ausdrücke Check auch auf Trackbacks an.
+  * Option hinzugefügt, dass Daten von Antispam Bee gelöscht werden, wenn das Plugin über das Admin Interface gelöscht wird.
   * Speichere für jeden Kommentar eine salted Hash der IP Adresse.
   * Ein neuer Check für eingehende Trackbacks.
   * Einführung von Behat tests.

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -343,6 +343,9 @@ class Antispam_Bee {
 		global $wpdb;
 		delete_option( 'antispam_bee' );
 		$wpdb->query( 'OPTIMIZE TABLE `' . $wpdb->options . '`' );
+
+		$sql = 'delete from `' . $wpdb->commentmeta . '` where `meta_key` IN ("antispam_bee_iphash", "antispam_bee_reason")';
+		$wpdb->query( $sql );
 	}
 
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -340,7 +340,7 @@ class Antispam_Bee {
 	 * @change  2.4
 	 */
 	public static function uninstall() {
-		if ( ! self::get_option('delete_data_on_uninstall') ) {
+		if ( ! self::get_option( 'delete_data_on_uninstall' ) ) {
 			return;
 		}
 		global $wpdb;
@@ -348,8 +348,10 @@ class Antispam_Bee {
 		delete_option( 'antispam_bee' );
 		$wpdb->query( 'OPTIMIZE TABLE `' . $wpdb->options . '`' );
 
+		//phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 		$sql = 'delete from `' . $wpdb->commentmeta . '` where `meta_key` IN ("antispam_bee_iphash", "antispam_bee_reason")';
 		$wpdb->query( $sql );
+		//phpcs:enable WordPress.WP.PreparedSQL.NotPrepared
 	}
 
 
@@ -374,38 +376,38 @@ class Antispam_Bee {
 
 		self::$defaults = array(
 			'options' => array(
-				'advanced_check'    => 1,
-				'regexp_check'      => 1,
-				'spam_ip'           => 1,
-				'already_commented' => 1,
-				'gravatar_check'    => 0,
-				'time_check'        => 0,
-				'ignore_pings'      => 0,
-				'always_allowed'    => 0,
+				'advanced_check'           => 1,
+				'regexp_check'             => 1,
+				'spam_ip'                  => 1,
+				'already_commented'        => 1,
+				'gravatar_check'           => 0,
+				'time_check'               => 0,
+				'ignore_pings'             => 0,
+				'always_allowed'           => 0,
 
-				'dashboard_chart'   => 0,
-				'dashboard_count'   => 0,
+				'dashboard_chart'          => 0,
+				'dashboard_count'          => 0,
 
-				'country_code'      => 0,
-				'country_black'     => '',
-				'country_white'     => '',
+				'country_code'             => 0,
+				'country_black'            => '',
+				'country_white'            => '',
 
-				'translate_api'     => 0,
-				'translate_lang'    => array(),
+				'translate_api'            => 0,
+				'translate_lang'           => array(),
 
-				'bbcode_check'      => 1,
+				'bbcode_check'             => 1,
 
-				'flag_spam'         => 1,
-				'email_notify'      => 0,
-				'no_notice'         => 0,
-				'cronjob_enable'    => 0,
-				'cronjob_interval'  => 0,
+				'flag_spam'                => 1,
+				'email_notify'             => 0,
+				'no_notice'                => 0,
+				'cronjob_enable'           => 0,
+				'cronjob_interval'         => 0,
 
-				'ignore_filter'     => 0,
-				'ignore_type'       => 0,
+				'ignore_filter'            => 0,
+				'ignore_type'              => 0,
 
-				'reasons_enable'    => 0,
-				'ignore_reasons'    => array(),
+				'reasons_enable'           => 0,
+				'ignore_reasons'           => array(),
 
 				'delete_data_on_uninstall' => 1,
 			),
@@ -418,7 +420,6 @@ class Antispam_Bee {
 				'country'       => esc_attr__( 'Country Check', 'antispam-bee' ),
 				'bbcode'        => esc_attr__( 'BBCode', 'antispam-bee' ),
 				'lang'          => esc_attr__( 'Comment Language', 'antispam-bee' ),
-				'regexp'        => esc_attr__( 'Regular Expression', 'antispam-bee' ),
 				'regexp'        => esc_attr__( 'Regular Expression', 'antispam-bee' ),
 				'title_is_name' => esc_attr__( 'Identical Post title and blog title', 'antispam-bee' ),
 			),

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -340,7 +340,11 @@ class Antispam_Bee {
 	 * @change  2.4
 	 */
 	public static function uninstall() {
+		if ( ! self::get_option('delete_data_on_uninstall') ) {
+			return;
+		}
 		global $wpdb;
+
 		delete_option( 'antispam_bee' );
 		$wpdb->query( 'OPTIMIZE TABLE `' . $wpdb->options . '`' );
 
@@ -402,6 +406,8 @@ class Antispam_Bee {
 
 				'reasons_enable'    => 0,
 				'ignore_reasons'    => array(),
+
+				'delete_data_on_uninstall' => 1,
 			),
 			'reasons' => array(
 				'css'           => esc_attr__( 'Honeypot', 'antispam-bee' ),

--- a/inc/columns.class.php
+++ b/inc/columns.class.php
@@ -100,6 +100,6 @@ final class Antispam_Bee_Columns {
 				width: 10%;
 			}
 		</style>
-	<?php
+		<?php
 	}
 }

--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -475,7 +475,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 							<li class="delete_data_on_uninstall">
 								<input type="checkbox" name="delete_data_on_uninstall" id="delete_data_on_uninstall" value="1" <?php checked( $options['delete_data_on_uninstall'], 1 ); ?> />
 								<label for="delete_data_on_uninstall">
-									<?php esc_html_e( 'Delete Antispamm Bee data when uninstalling', 'antispam-bee' ); ?>
+									<?php esc_html_e( 'Delete Antispam Bee data when uninstalling', 'antispam-bee' ); ?>
 									<span><?php esc_html_e( 'If checked, you will delete all data Antispam Bee creates, when uninstalling the plugin.', 'antispam-bee' ); ?></span>
 								</label>
 							</li>

--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -300,7 +300,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 											'https'
 										)
 									);
-										?>
+									?>
 									<li>
 										<textarea name="ab_country_black" id="ab_country_black" class="ab-medium-field code" placeholder="<?php esc_attr_e( 'e.g. BF, SG, YE', 'antispam-bee' ); ?>"><?php echo esc_attr( $options['country_black'] ); ?></textarea>
 										<label for="ab_country_black">
@@ -354,7 +354,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 											wp_kses_post( $link1 ),
 											'</a>'
 										);
-										?>
+									?>
 										</span>
 								</label>
 
@@ -365,7 +365,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 											$lang               = self::get_allowed_translate_languages();
 											$selected_languages = (array) $options['translate_lang'];
 											foreach ( $lang as $k => $v ) {
-											?>
+												?>
 												<option <?php echo in_array( $k, $selected_languages, true ) ? 'selected="selected"' : ''; ?> value="<?php echo esc_attr( $k ); ?>"><?php echo esc_html( $v ); ?></option>
 
 											<?php } ?>
@@ -378,7 +378,6 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 							</li>
 						</ul>
 					</div>
-
 
 					<div class="ab-column ab-join">
 						<h3 class="icon advanced">
@@ -546,7 +545,7 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 				</div>
 			</form>
 		</div>
-	<?php
+		<?php
 	}
 
 	/**

--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -77,6 +77,8 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 			'translate_api'     => (int) ( ! empty( $_POST['ab_translate_api'] ) ),
 			'translate_lang'    => $selected_languages,
 
+			'delete_data_on_uninstall' => (int) ( ! empty( $_POST['delete_data_on_uninstall'] ) ),
+
 		);
 
 		foreach ( $options['ignore_reasons'] as $key => $val ) {
@@ -469,7 +471,16 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 									</li>
 								</ul>
 							</li>
+
+							<li class="delete_data_on_uninstall">
+								<input type="checkbox" name="delete_data_on_uninstall" id="delete_data_on_uninstall" value="1" <?php checked( $options['delete_data_on_uninstall'], 1 ); ?> />
+								<label for="delete_data_on_uninstall">
+									<?php esc_html_e( 'Delete Antispamm Bee data when uninstalling', 'antispam-bee' ); ?>
+									<span><?php esc_html_e( 'If checked, you will delete all data Antispam Bee creates, when uninstalling the plugin.', 'antispam-bee' ); ?></span>
+								</label>
+							</li>
 						</ul>
+
 					</div>
 
 

--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -45,37 +45,37 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 			$selected_languages[] = $value;
 		}
 		$options = array(
-			'flag_spam'         => (int) ( ! empty( $_POST['ab_flag_spam'] ) ),
-			'email_notify'      => (int) ( ! empty( $_POST['ab_email_notify'] ) ),
-			'cronjob_enable'    => (int) ( ! empty( $_POST['ab_cronjob_enable'] ) ),
-			'cronjob_interval'  => (int) self::get_key( $_POST, 'ab_cronjob_interval' ),
+			'flag_spam'                => (int) ( ! empty( $_POST['ab_flag_spam'] ) ),
+			'email_notify'             => (int) ( ! empty( $_POST['ab_email_notify'] ) ),
+			'cronjob_enable'           => (int) ( ! empty( $_POST['ab_cronjob_enable'] ) ),
+			'cronjob_interval'         => (int) self::get_key( $_POST, 'ab_cronjob_interval' ),
 
-			'no_notice'         => (int) ( ! empty( $_POST['ab_no_notice'] ) ),
+			'no_notice'                => (int) ( ! empty( $_POST['ab_no_notice'] ) ),
 
-			'dashboard_count'   => (int) ( ! empty( $_POST['ab_dashboard_count'] ) ),
-			'dashboard_chart'   => (int) ( ! empty( $_POST['ab_dashboard_chart'] ) ),
-			'advanced_check'    => (int) ( ! empty( $_POST['ab_advanced_check'] ) ),
-			'regexp_check'      => (int) ( ! empty( $_POST['ab_regexp_check'] ) ),
-			'spam_ip'           => (int) ( ! empty( $_POST['ab_spam_ip'] ) ),
-			'already_commented' => (int) ( ! empty( $_POST['ab_already_commented'] ) ),
-			'time_check'        => (int) ( ! empty( $_POST['ab_time_check'] ) ),
-			'always_allowed'    => (int) ( ! empty( $_POST['ab_always_allowed'] ) ),
+			'dashboard_count'          => (int) ( ! empty( $_POST['ab_dashboard_count'] ) ),
+			'dashboard_chart'          => (int) ( ! empty( $_POST['ab_dashboard_chart'] ) ),
+			'advanced_check'           => (int) ( ! empty( $_POST['ab_advanced_check'] ) ),
+			'regexp_check'             => (int) ( ! empty( $_POST['ab_regexp_check'] ) ),
+			'spam_ip'                  => (int) ( ! empty( $_POST['ab_spam_ip'] ) ),
+			'already_commented'        => (int) ( ! empty( $_POST['ab_already_commented'] ) ),
+			'time_check'               => (int) ( ! empty( $_POST['ab_time_check'] ) ),
+			'always_allowed'           => (int) ( ! empty( $_POST['ab_always_allowed'] ) ),
 
-			'ignore_pings'      => (int) ( ! empty( $_POST['ab_ignore_pings'] ) ),
-			'ignore_filter'     => (int) ( ! empty( $_POST['ab_ignore_filter'] ) ),
-			'ignore_type'       => (int) self::get_key( $_POST, 'ab_ignore_type' ),
+			'ignore_pings'             => (int) ( ! empty( $_POST['ab_ignore_pings'] ) ),
+			'ignore_filter'            => (int) ( ! empty( $_POST['ab_ignore_filter'] ) ),
+			'ignore_type'              => (int) self::get_key( $_POST, 'ab_ignore_type' ),
 
-			'reasons_enable'    => (int) ( ! empty( $_POST['ab_reasons_enable'] ) ),
-			'ignore_reasons'    => (array) self::get_key( $_POST, 'ab_ignore_reasons' ),
+			'reasons_enable'           => (int) ( ! empty( $_POST['ab_reasons_enable'] ) ),
+			'ignore_reasons'           => (array) self::get_key( $_POST, 'ab_ignore_reasons' ),
 
-			'bbcode_check'      => (int) ( ! empty( $_POST['ab_bbcode_check'] ) ),
-			'gravatar_check'    => (int) ( ! empty( $_POST['ab_gravatar_check'] ) ),
-			'country_code'      => (int) ( ! empty( $_POST['ab_country_code'] ) ),
-			'country_black'     => sanitize_text_field( wp_unslash( self::get_key( $_POST, 'ab_country_black' ) ) ),
-			'country_white'     => sanitize_text_field( wp_unslash( self::get_key( $_POST, 'ab_country_white' ) ) ),
+			'bbcode_check'             => (int) ( ! empty( $_POST['ab_bbcode_check'] ) ),
+			'gravatar_check'           => (int) ( ! empty( $_POST['ab_gravatar_check'] ) ),
+			'country_code'             => (int) ( ! empty( $_POST['ab_country_code'] ) ),
+			'country_black'            => sanitize_text_field( wp_unslash( self::get_key( $_POST, 'ab_country_black' ) ) ),
+			'country_white'            => sanitize_text_field( wp_unslash( self::get_key( $_POST, 'ab_country_white' ) ) ),
 
-			'translate_api'     => (int) ( ! empty( $_POST['ab_translate_api'] ) ),
-			'translate_lang'    => $selected_languages,
+			'translate_api'            => (int) ( ! empty( $_POST['ab_translate_api'] ) ),
+			'translate_lang'           => $selected_languages,
 
 			'delete_data_on_uninstall' => (int) ( ! empty( $_POST['delete_data_on_uninstall'] ) ),
 

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
   * Skip the checks, when I ping myself.
   * Fixes some wrong usages of the translation functions.
   * Use the regular expressions check also for trackbacks.
+  * Add option to delete Antispam Bee related data when plugin gets deleted via the admin interface.
   * Save a hashed + salted IP for every comment
   * New check for incoming Trackbacks.
   * Introduction of behat tests.


### PR DESCRIPTION
This PR closes #232,

If you uninstall, this PR will delete the meta data spam reason and ip hash by default. It provides also an UI and option, so you can prevent this behaviour.