### PR TITLE
make multiple commentforms possible again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * New check for incoming Trackbacks.
   * Introduction of behat tests.
   * Updates the used JavaScript library for the statistics widget.
+  * Bugfix in the "Comment form used outside of posts" option.
 
 * **Deutsch**
   * Einführung von Coding Standards.
@@ -28,6 +29,7 @@
   * Ein neuer Check für eingehende Trackbacks.
   * Einführung von Behat tests.
   * Aktualisiert die genutzte JavaScript Bibliothek für das Statistik Widget.
+  * Bugfix in der "Kommentarformular wird außerhalb von Beiträgen verwendet" Einstellung
 
 ### 2.8.1 ###
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1155,7 +1155,7 @@ class Antispam_Bee {
 			)/x',
 			array( 'Antispam_Bee', 'replace_comment_field_callback' ),
 			$data,
-			1
+			-1
 		);
 	}
 
@@ -2656,18 +2656,24 @@ class Antispam_Bee {
 	 */
 	public static function get_secret_name_for_post( $post_id ) {
 
-		$secret = substr( sha1( md5( self::$_salt . (int) $post_id ) ), 0, 10 );
+		if ( self::get_option( 'always_allowed' ) ) {
+			$secret = substr( sha1( md5( 'comment-id' . self::$_salt ) ), 0, 10 );
+		} else {
+			$secret = substr( sha1( md5( 'comment-id' . self::$_salt . (int) $post_id ) ), 0, 10 );
+		}
 
 		/**
 		 * Filters the secret for a post, which is used in the textarea name attribute.
 		 *
 		 * @param string $secret The secret.
 		 * @param int    $post_id The post ID.
+		 * @param bool   $always_allowed Whether the comment form is used outside of the single post view or not.
 		 */
 		return apply_filters(
 			'ab_get_secret_name_for_post',
 			$secret,
-			(int) $post_id
+			(int) $post_id,
+			(bool) self::get_option( 'always_allowed' )
 		);
 
 	}
@@ -2681,18 +2687,24 @@ class Antispam_Bee {
 	 */
 	public static function get_secret_id_for_post( $post_id ) {
 
-		$secret = substr( sha1( md5( 'comment-id' . self::$_salt . (int) $post_id ) ), 0, 10 );
+		if ( self::get_option( 'always_allowed' ) ) {
+			$secret = substr( sha1( md5( 'comment-id' . self::$_salt ) ), 0, 10 );
+		} else {
+			$secret = substr( sha1( md5( 'comment-id' . self::$_salt . (int) $post_id ) ), 0, 10 );
+		}
 
 		/**
 		 * Filters the secret for a post, which is used in the textarea id attribute.
 		 *
 		 * @param string $secret The secret.
 		 * @param int    $post_id The post ID.
+		 * @param bool   $always_allowed Whether the comment form is used outside of the single post view or not.
 		 */
 		return apply_filters(
 			'ab_get_secret_id_for_post',
 			$secret,
-			(int) $post_id
+			(int) $post_id,
+			(bool) self::get_option( 'always_allowed' )
 		);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,7 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
   * New check for incoming Trackbacks.
   * Introduction of behat tests.
   * Updates the used JavaScript library for the statistics widget.
+  * Bugfix in the "Comment form used outside of posts" option.
   
 ### 2.8.1 ###
   * PHP 5.3 compatibility


### PR DESCRIPTION
We have an option to use comment forms outside of the single view. This option is basically broken since quite a while.

This PR fixes it.

Closes #235 
Closes #128

Basically, what it does:
1. If the option is set, we use a static secret
2. We limit `preg_replace_callback()` no longer to 1