### PR TITLE
Raise minimum words, before checking for comment language

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1850,7 +1850,24 @@ class Antispam_Bee {
 			return ! in_array( $detected_lang, $allowed_lang, true );
 		}
 
-		if ( mb_strlen( $comment_text ) < 10 ) {
+		$word_count = 0;
+		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $comment_text ), ' ' );
+		/*
+		 * translators: If your word count is based on single characters (e.g. East Asian characters),
+		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		 * Do not translate into your own language.
+		 */
+		if ( strpos( _x( 'words', 'Word count type. Do not translate!' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+			preg_match_all( '/./u', $text, $words_array );
+			if ( isset( $words_array[0] ) ) {
+				$word_count = count($words_array[0]);
+			}
+		} else {
+			$words_array = preg_split( "/[\n\r\t ]+/", $text, -1, PREG_SPLIT_NO_EMPTY );
+			$word_count = count($words_array);
+		}
+
+		if ( $word_count < 10 ) {
 			return false;
 		}
 

--- a/tests/Acceptance/Behat/filter.feature
+++ b/tests/Acceptance/Behat/filter.feature
@@ -207,7 +207,7 @@ Feature: Filter settings
     Given the option "translate_api,flag_spam" is set
     Given the option "translate_lang" has the array value "de"
     Given I am on "/?p=1"
-    Then I fill in "comment" with "But English is my mothers tongue! This is outrageous!"
+    Then I fill in "comment" with "But English is my mothers tongue! This is outrageous! I send a comment anyway"
     Then I fill in "author" with "Monty"
     Then I fill in "email" with "monty.1983@nuclear-secrets.com"
     Then I fill in "url" with "http://nuclear-secrets.com"
@@ -220,6 +220,26 @@ Feature: Filter settings
     Given I am on "/wp-admin/edit-comments.php?comment_status=spam"
     Then I should see "Monty"
     Then I should see "Comment Language"
+
+  Scenario: Comment Language Too Short
+    Given the option "translate_api,flag_spam" is set
+    Given the option "translate_lang" has the array value "de"
+    Given I am on "/?p=1"
+    Then I fill in "comment" with "A small text passes the test. Lets check this."
+    Then I fill in "author" with "Monty"
+    Then I fill in "email" with "monty.1983@nuclear-secrets.com"
+    Then I fill in "url" with "http://nuclear-secrets.com"
+    Then I press "submit"
+    Then I should not see "Fatal"
+    Then I should see "Hello world"
+    Then I should not see "Notice"
+
+    Given I am logged in as admin
+    Given I am on "/wp-admin/edit-comments.php?comment_status=spam"
+    Then I should not see "Monty"
+    Then I should not see "Comment Language"
+    Given I am on "/wp-admin/edit-comments.php"
+    Then I should see "Monty"
 
   @javascript @db
   Scenario: Comment Language Array


### PR DESCRIPTION
In order to reduce false positives, we raise the minimum of words, before we run the language check.

This closes #257 