### PR TITLE
Set the secret in the behat test with a `Given` step

### DIFF
--- a/tests/Acceptance/Behat/advanced.feature
+++ b/tests/Acceptance/Behat/advanced.feature
@@ -2,6 +2,7 @@ Feature: Advanced settings
 
   @db
   Scenario: Spam is saved in database
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam" is set
     Then I fill in "comment" with "Release the hounds!"
@@ -21,6 +22,7 @@ Feature: Advanced settings
 
   @db
   Scenario: Spam is not saved in database
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam" is not set
     Then I fill in "comment" with "Release the hounds!"
@@ -41,6 +43,7 @@ Feature: Advanced settings
 
   @db
   Scenario: Save spam reason
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam" is set
     Given the option "no_notice" is not set
@@ -61,6 +64,7 @@ Feature: Advanced settings
 
   @db
   Scenario: Do not save spam reason
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam,no_notice" is set
     Then I fill in "comment" with "Release the hounds!"

--- a/tests/Acceptance/Behat/bootstrap/PluginContext.php
+++ b/tests/Acceptance/Behat/bootstrap/PluginContext.php
@@ -77,4 +77,17 @@ class PluginContext extends RawWordpressContext implements Context {
 		$this->getDriver()->plugin->deactivate( $pluginSlug );
 	}
 
+	/**
+	 * @Given the secret is fixed
+	 */
+	public function secretPluginIsActive()
+	{
+		$wpcli_args = [
+			'secret_plugin_option',
+			'--format=json',
+			"'" . json_encode(1) . "'",
+		];
+		$this->getDriver()->wpcli('option', 'set', $wpcli_args );
+	}
+
 }

--- a/tests/Acceptance/Behat/env/mu-plugins/change-antispam-bee-salt.php
+++ b/tests/Acceptance/Behat/env/mu-plugins/change-antispam-bee-salt.php
@@ -3,12 +3,15 @@
  * Plugin Name: Change Antispam Bee Salt
  */
 
-add_filter(
-	'ab_get_secret_name_for_post',
-	function() {
-		return 'secret';
-	}
-);
+if ( 1 === (int) get_option( 'secret_plugin_option', 0 ) ) {
+	add_filter(
+		'ab_get_secret_name_for_post',
+		function () {
+
+			return 'secret';
+		}
+	);
+}
 add_action(
 	'wp_dashboard_setup',
 	function() {

--- a/tests/Acceptance/Behat/filter.feature
+++ b/tests/Acceptance/Behat/filter.feature
@@ -2,6 +2,7 @@ Feature: Filter settings
 
   @db
   Scenario: Honeypot
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam" is set
     Then I fill in "comment" with "Release the hounds!"
@@ -21,6 +22,7 @@ Feature: Filter settings
 
   @db
   Scenario: Spam is not saved in database
+    Given the secret is fixed
     Given I am on "/?p=1"
     Given the option "flag_spam" is not set
     Then I fill in "comment" with "Release the hounds!"


### PR DESCRIPTION
closes #245 

During our Pluginkollektiv Hackaton, we realized, that the way, we overwrote the secret in all our scenarios by using the mu-plugin, we basically would blind us to bugs, which would relate to the way we create and check our honeypot.

This PR fixes this issue by introducing a `Given` command in our Acceptance tests:
`Given the secret is fixed`

This command will set an option in the `wp_options` table and the mu-plugin will filter the secret (using the `ab_get_secret_name_for_post` hook) only, if the option is set.