### PR TITLE
Update links from Google+ and old website to GitHub wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,14 +153,14 @@
 * **English**
    * Removal of functions *Block comments from specific countries* and *Allow comments only in certain language* for financial reasons
 * **Deutsch**
-   * Entfernung der Funktionen *Kommentare nur in einer Sprache zulassen* und *Bestimmte Länder blockieren bzw. erlauben* aus finanziellen Gründen - [Hintergrund-Informationen](https://plus.google.com/u/0/+SergejMüller/posts/ZyquhoYjUyF)
+   * Entfernung der Funktionen *Kommentare nur in einer Sprache zulassen* und *Bestimmte Länder blockieren bzw. erlauben* aus finanziellen Gründen - [Hintergrund-Informationen](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2015-04-10)
 
 ### 2.6.6 ###
 * **English**
     * Switch to the official Google Translation API
     * *Release time investment (Development & QA): 2.5 h*
 * **Deutsch**
-    * (Testweise) Umstellung auf die offizielle Google Translation API - [Hintergrund-Informationen](https://plus.google.com/u/0/+SergejMüller/posts/ZyquhoYjUyF)
+    * (Testweise) Umstellung auf die offizielle Google Translation API - [Hintergrund-Informationen](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2015-04-10)
     * *Release-Zeitaufwand (Development & QA): 2,5 Stunden*
 
 ### 2.6.5 ###
@@ -180,7 +180,7 @@
    * Consideration of the comment time (Spam if a comment was written in less than 5 seconds)
    * *Release time investment (Development & QA): 6.25 h*
 * **Deutsch**
-   * Berücksichtigung der Kommentarzeit (Spam, wenn ein Kommentar in unter 5 Sekunden verfasst) - [Hintergrund-Informationen](https://plus.google.com/+SergejMüller/posts/73EbP6F1BgC)
+   * Berücksichtigung der Kommentarzeit (Spam, wenn ein Kommentar in unter 5 Sekunden verfasst) - [Hintergrund-Informationen](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2014-11-17)
    * *Release-Zeitaufwand (Development & QA): 6,25 Stunden*
 
 ### 2.6.3 ###
@@ -234,7 +234,7 @@
 * **Deutsch**
    * Umstellung von TornevallDNSBL zu [Stop Forum Spam](http://www.stopforumspam.com)
    * Neue JS-Bibliothek für das Dashboard-Widget
-   * [Mehr Informationen auf Google+](https://plus.google.com/110569673423509816572/posts/VCFr3fDAYDs)
+   * [Mehr Informationen auf ~~Google+~~_GitHub_](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2013-08-14)
 
 ### 2.5.7 ###
 * **English**
@@ -243,19 +243,19 @@
 * **Deutsch**
    * Optionale Spam-Logdatei z.B. für [Fail2Ban](https://wiki.ubuntuusers.de/fail2ban/)
    * Filter `antispam_bee_notification_subject` für eigenen Betreff in Benachrichtigungen
-   * Detaillierte Informationen zum Update auf [Google+](https://plus.google.com/110569673423509816572/posts/iCfip2ggYt9)
+   * Detaillierte Informationen zum Update auf [~~Google+~~_GitHub_](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2013-06-03)
 
 ### 2.5.6 ###
 * **English**
    * Added new detection/patterns for spam comments
 * **Deutsch**
-   * Neue Erkennungsmuster für Spam hinzugefügt / [Google+](https://plus.google.com/110569673423509816572/posts/9BSURheN3as)
+   * Neue Erkennungsmuster für Spam hinzugefügt / [~~Google+~~_GitHub_](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2013-05-18)
 
 ### 2.5.5 ###
 * **English**
    * Detection and filtering of spam comments that try to exploit the latest [W3 Total Cache and WP Super Cache Vulnerability](http://blog.sucuri.net/2013/05/w3-total-cache-and-wp-super-cache-vulnerability-being-targeted-in-the-wild.html).
 * **Deutsch**
-   * Erkennung und Ausfilterung von Spam-Kommentaren, die versuchen, [Sicherheitslücken von W3 Total Cache und WP Super Cache](http://blog.sucuri.net/2013/05/w3-total-cache-and-wp-super-cache-vulnerability-being-targeted-in-the-wild.html) auszunutzen. [Ausführlicher auf Google+](https://plus.google.com/110569673423509816572/posts/afWWQbUh4at).
+   * Erkennung und Ausfilterung von Spam-Kommentaren, die versuchen, [Sicherheitslücken von W3 Total Cache und WP Super Cache](http://blog.sucuri.net/2013/05/w3-total-cache-and-wp-super-cache-vulnerability-being-targeted-in-the-wild.html) auszunutzen. [Ausführlicher auf ~~Google+~~_GitHub_](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2013-05-04).
 
 ### 2.5.4 ###
 * **English**
@@ -263,7 +263,7 @@
    * New mascot for Antispam Bee
    * Advanced Scanning on IP, URL and e-mail address of incoming comments in local blog spam database
 * **Deutsch**
-   * Jubiläumsausgabe: [Details zum Update](https://plus.google.com/110569673423509816572/posts/3dq9Re5vTY5)
+   * Jubiläumsausgabe: [Details zum Update](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2013-01-19)
    * Neues Maskottchen für Antispam Bee
    * Erweiterte Prüfung eingehender Kommentare in lokaler Blog-Spamdatenbank auf IP, URL und E-Mail-Adresse
 
@@ -282,7 +282,7 @@
    * Neu: [Reguläre Ausdrücke anwenden](https://github.com/pluginkollektiv/antispam-bee/wiki/Dokumentation) mit vordefinierten und eigenen Erkennungsmustern
    * Änderung der Filter-Reihenfolge
    * Verbesserungen an der Sprachdatei
-   * [Hintergrundinformationen zum Update](https://plus.google.com/110569673423509816572/posts/CwtbSoMkGrT)
+   * [Hintergrundinformationen zum Update](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2012-12-10)
 
 ### 2.5.1 ###
 * **English**
@@ -293,14 +293,14 @@
 * **Deutsch**
    * [BBCode im Kommentar als Spamgrund](https://github.com/pluginkollektiv/antispam-bee/wiki/Dokumentation)
    * IP-Anonymisierung bei der Länderprüfung
-   * [Mehr Transparenz](https://plus.google.com/110569673423509816572/posts/ZMU6RfyRK29) durch hinzugefügte Datenschutzhinweise
+   * [Mehr Transparenz](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2012-11-29) durch hinzugefügte Datenschutzhinweise
    * PHP 5.2.4 als Voraussetzung (ist zugleich die Voraussetzung für WP 3.4)
 
 ### 2.5.0 ###
 * **English**
    * Edition 2012
 * **Deutsch**
-   * [Edition 2012](https://plus.google.com/110569673423509816572/posts/6JUC6PHXd6A)
+   * [Edition 2012](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2012-11-24)
 
 ### 2.4.6 ###
 * **English**

--- a/readme.txt
+++ b/readme.txt
@@ -161,10 +161,10 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
    * updated [plugin authors](https://gist.github.com/glueckpress/f058c0ab973d45a72720)
 
 ### 2.6.7 ###
-   * Removal of functions *Block comments from specific countries* and *Allow comments only in certain language* for financial reasons - [more information](https://plus.google.com/u/0/+SergejMüller/posts/ZyquhoYjUyF) (only german)
+   * Removal of functions *Block comments from specific countries* and *Allow comments only in certain language* for financial reasons - [more information](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2015-04-10) (only german)
 
 ### 2.6.6 ###
-   * Switch to the official Google Translation API - [more information](https://plus.google.com/u/0/+SergejMüller/posts/ZyquhoYjUyF) (only german)
+   * Switch to the official Google Translation API - [more information](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2015-04-10) (only german)
    * *Release time investment (Development & QA): 2.5 h*
 
 ### 2.6.5 ###
@@ -174,7 +174,7 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
    * *Release time investment (Development & QA): 12 h*
 
 ### 2.6.4 ###
-   * Consideration of the comment time (Spam if a comment was written in less than 5 seconds) - [more information on Google+](https://plus.google.com/+SergejMüller/posts/73EbP6F1BgC) (only german)
+   * Consideration of the comment time (Spam if a comment was written in less than 5 seconds) - [more information on ~~Google+~~_GitHub_](https://github.com/pluginkollektiv/antispam-bee/wiki/de-News-2014-11-17) (only german)
    * *Release time investment (Development & QA): 6.25 h*
 
 ### 2.6.3 ###


### PR DESCRIPTION
I've created a `news` branch in the wiki with the archived Google+ pages. When the wiki branch is merged, this PR would link to the new news pages. I also updated some links that pointed to the old website to the matching wiki pages.