### PR TITLE
Disable PHP nightly temporarily in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,11 @@ jobs:
     - stage: test
       php: '7.2'
       script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
+    - stage: test
+      php: '7.3'
+      script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
     - stage: behat
-      php: '7.2'
+      php: '7.3'
       env: WORDPRESS_VERSION=nightly
       script: ./bin/behat.sh
     - stage: behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ jobs:
       php: '7.0'
       script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
     - stage: test
-      php: 'nightly'
-      script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
-    - stage: test
       php: '7.2'
       script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
     - stage: behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,14 @@ jobs:
       php: '7.0'
       env: WORDPRESS_VERSION=4.6
       script: ./bin/behat.sh
+    - stage: behat
+      php: '7.0'
+      env: WORDPRESS_VERSION=5.0
+      script: ./bin/behat.sh
+    - stage: behat
+      php: '7.0'
+      env: WORDPRESS_VERSION=5.1
+      script: ./bin/behat.sh
     - stage: quality
       php: '7.0'
       script: ./vendor/bin/phpcs ./ --standard=./phpcs.config.xml -s

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -9,7 +9,7 @@
  * Domain Path: /lang
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.9.0
+ * Version:     2.9.1
  *
  * @package Antispam Bee
  **/

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -12,6 +12,7 @@
  * Version:     2.9.1
  *
  * [](http://coderisk.com/wp/plugin/antispam-bee/RIPS-lAHLcgvqY8)
+ *
  * @package Antispam Bee
  **/
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.5
 * Tested up to:      5.0
-* Stable tag:        2.9.0
+* Stable tag:        2.9.1
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Our tests do also run in PHP nightly. This is now PHP 8. Our dependencies do not support PHP 8 yet, so we disable nightly temporarily.

Additionally, this PR adds WordPress 5.0 and WordPress 5.1 explicitly to the test environment.

closes 276