### PR TITLE
Clarify in changelog: compatible with the amp plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * **English**
   * Improved backend accessibility
   * Prefilled comment textareas do now work with the honeypot
-  * AMP compatibility
+  * Compatible with the AMP plugin (https://wordpress.org/plugins/amp/)
   * Improved dashboard tooltips
   * Improvements for the language detection API
   * Scalable IP look up for local spam database
@@ -14,7 +14,7 @@
 * **Deutsch**
   * Verbesserte Barrierefreiheit im Backend
   * Vorausgefüllte Kommentarfelder arbeiten jetzt mit dem Honeypot zusammen
-  * Kompatibilität mit AMP
+  * Kompatibel mit dem AMP Plugin (https://wordpress.org/plugins/amp/)
   * Verbesserte Tooltips im Dashboard
   * Verbesserte Kommunikation mit der Spracherkennungs-API
   * Skalierbarer IP-Abgleich für den lokalen Datenbank-Check.

--- a/readme.txt
+++ b/readme.txt
@@ -93,7 +93,7 @@ A complete documentation is available in the [GitHub repository Wiki](https://gi
 ### 2.9.1 ###
   * Improved backend accessibility
   * Prefilled comment textareas do now work with the honeypot
-  * AMP compatibility
+  * Compatible with the AMP plugin (https://wordpress.org/plugins/amp/)
   * Improved dashboard tooltips
   * Improvements for the language detection API
   * Scalable IP look up for local spam database


### PR DESCRIPTION
To avoid confusion about _how_ compatible we are with amp, we should adjust the text in the changelog just claiming compatibility with the amp plugin.

For more information see #283 and #242