### PR TITLE
Changing the order of IP checks (fixes #286)

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2351,6 +2351,8 @@ class Antispam_Bee {
 		// Sanitization of $ip takes place further down.
 		if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
 			$ip = wp_unslash( $_SERVER['HTTP_CLIENT_IP'] );
+		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+			$ip = wp_unslash( $_SERVER['REMOTE_ADDR'] );
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 			$ip = wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED'] ) ) {
@@ -2359,8 +2361,6 @@ class Antispam_Bee {
 			$ip = wp_unslash( $_SERVER['HTTP_FORWARDED_FOR'] );
 		} elseif ( isset( $_SERVER['HTTP_FORWARDED'] ) ) {
 			$ip = wp_unslash( $_SERVER['HTTP_FORWARDED'] );
-		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
-			$ip = wp_unslash( $_SERVER['REMOTE_ADDR'] );
 		} else {
 			return '';
 		}


### PR DESCRIPTION
Since the HTTP_FORWARDED doesn’t necessarily contains an IP address, the function get_client_ip may fail if there is just a HTTP_FORWARDED and the REMOTE_ADDR with the following values: [REMOTE_ADDR] => 127.0.0.1 and [HTTP_FORWARDED] => proto=https. Therefore REMOTE_ADDR is moved above the HTTP_FORWARDED checks.