### PR TITLE
Compatibility with PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       php: '7.3'
       script: ./vendor/bin/phpunit -c ./phpunit.xml.dist
     - stage: behat
-      php: '7.3'
+      php: '7.4'
       env: WORDPRESS_VERSION=nightly
       script: ./bin/behat.sh
     - stage: behat

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -858,6 +858,10 @@ class Antispam_Bee {
 			);
 		}
 
+		if ( null === self::$defaults ) {
+			self::_init_internal_vars();
+		}
+
 		return wp_parse_args(
 			$options,
 			self::$defaults['options']

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "^4",
 		"brain/monkey": "^1.4",
-		"wp-cli/wp-cli": "~1.3",
+		"wp-cli/wp-cli-bundle": "@stable",
 		"paulgibbs/behat-wordpress-extension": "^1.0",
 		"behat/mink-extension": "v2.2",
 		"behat/mink-goutte-driver": "^1.2",


### PR DESCRIPTION
This PR closes #315 

It makes sure our test suite is executed in PHP 7.4
In those tests, it turned out, the plugin activation produced some unexpected output in PHP 7.4

This was due to the fact that the `self::$defaults` where not set when running through the plugin activation. This issue is fixed in the current PR.

Other than that I encountered no problems with PHP 7.4