### PR TITLE
Add spam reason for manually marked spam

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -103,6 +103,22 @@ class Antispam_Bee {
 			)
 		);
 
+		add_action(
+			'comment_unapproved_to_spam',
+			array(
+				__CLASS__,
+				'update_antispam_bee_reason',
+			)
+		);
+
+		add_action(
+			'comment_approved_to_spam',
+			array(
+				__CLASS__,
+				'update_antispam_bee_reason',
+			)
+		);
+
 		if ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) {
 			return;
 		}
@@ -438,6 +454,7 @@ class Antispam_Bee {
 				'lang'          => esc_attr__( 'Comment Language', 'antispam-bee' ),
 				'regexp'        => esc_attr__( 'Regular Expression', 'antispam-bee' ),
 				'title_is_name' => esc_attr__( 'Identical Post title and blog title', 'antispam-bee' ),
+				'manually'      => esc_attr__( 'Manually', 'antispam-bee' ),
 			),
 		);
 	}
@@ -2390,6 +2407,21 @@ class Antispam_Bee {
 			'antispam_bee_reason'
 		);
 	}
+
+	/**
+	 * Updates the Antispam Bee reason for manual transitions
+	 *
+	 * @since   2.9.2
+	 * @param  [int] $comment Comment Object or comment ID.
+	 */
+	public static function update_antispam_bee_reason( $comment ) {
+		if ( ! is_object( $comment ) ) {
+			$comment = get_comment( $comment );
+		}
+		$id = $comment->comment_ID;
+		update_comment_meta( $id, 'antispam_bee_reason', 'manual' );
+	}
+
 
 	/**
 	 * Get the current post ID.

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2412,7 +2412,7 @@ class Antispam_Bee {
 	 * Updates the Antispam Bee reason for manual transitions
 	 *
 	 * @since   2.9.2
-	 * @param  [obj] $comment Comment Object.
+	 * @param  WP_Comment $comment Comment Object.
 	 */
 	public static function update_antispam_bee_reason( $comment ) {
 		update_comment_meta( $comment->comment_ID, 'antispam_bee_reason', 'manually' );

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2412,14 +2412,10 @@ class Antispam_Bee {
 	 * Updates the Antispam Bee reason for manual transitions
 	 *
 	 * @since   2.9.2
-	 * @param  [int] $comment Comment Object or comment ID.
+	 * @param  [obj] $comment Comment Object.
 	 */
 	public static function update_antispam_bee_reason( $comment ) {
-		if ( ! is_object( $comment ) ) {
-			$comment = get_comment( $comment );
-		}
-		$id = $comment->comment_ID;
-		update_comment_meta( $id, 'antispam_bee_reason', 'manually' );
+		update_comment_meta( $comment->comment_ID, 'antispam_bee_reason', 'manually' );
 	}
 
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2419,7 +2419,7 @@ class Antispam_Bee {
 			$comment = get_comment( $comment );
 		}
 		$id = $comment->comment_ID;
-		update_comment_meta( $id, 'antispam_bee_reason', 'manual' );
+		update_comment_meta( $id, 'antispam_bee_reason', 'manually' );
 	}
 
 


### PR DESCRIPTION
Fixes #324 

The action hooks `comment_unapproved_to_spam` and `comment_approved_to_spam` are not used for comment moderation list or comment blocklist (from discussion settings) as the first is setting as "Pending" and the last is sending to "Trash". This means the filter is just used if the spam is marked manually. I think. ;)