### PR TITLE
Add back fake IP reason to prevent notice

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -449,6 +449,7 @@ class Antispam_Bee {
 				'time'          => esc_attr__( 'Comment time', 'antispam-bee' ),
 				'empty'         => esc_attr__( 'Empty Data', 'antispam-bee' ),
 				'localdb'       => esc_attr__( 'Local DB Spam', 'antispam-bee' ),
+				'server'        => esc_attr__( 'Fake IP', 'antispam-bee' ),
 				'country'       => esc_attr__( 'Country Check', 'antispam-bee' ),
 				'bbcode'        => esc_attr__( 'BBCode', 'antispam-bee' ),
 				'lang'          => esc_attr__( 'Comment Language', 'antispam-bee' ),

--- a/inc/columns.class.php
+++ b/inc/columns.class.php
@@ -109,6 +109,9 @@ final class Antispam_Bee_Columns {
 			$reasons     = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}commentmeta WHERE meta_key = 'antispam_bee_reason' group by meta_value", ARRAY_A );
 
 			foreach ( $reasons as $reason ) {
+				if ( ! isset( Antispam_Bee::$defaults['reasons'][ $reason['meta_value'] ] ) ) {
+					continue;
+				}
 				$label = Antispam_Bee::$defaults['reasons'][ $reason['meta_value'] ];
 				echo "\t" . '<option value="' . esc_attr( $reason['meta_value'] ) . '"' . selected( $spam_reason, $reason['meta_value'], false ) . '>' . esc_html( $label ) . "</option>\n";
 			}


### PR DESCRIPTION
If there are still some spam comments with reason "Fake IP" the plugin throws a undefined index notice.

This commit re-adds the reason to prevent this.

Fixes #334