### PR TITLE
switch from label 'Mark as Spam' to value 'spam' in behat test

### DIFF
--- a/tests/Acceptance/Behat/filter.feature
+++ b/tests/Acceptance/Behat/filter.feature
@@ -357,7 +357,7 @@ Feature: Filter settings
     Given I am on "/wp-admin/edit-comments.php"
     Then I should see "Monty"
     Then I check "cb-select-all-1"
-    Then I select "Mark as Spam" from "bulk-action-selector-top"
+    Then I select "spam" from "bulk-action-selector-top"
     Then I press "doaction"
 
     Given I am an anonymous user


### PR DESCRIPTION
With WordPress 5.5 the wording of "Mark as Spam" has changed to "Mark as spam". In our acceptance test, we relied on this wording and as this selector is case sensitive, I switched from the label "Mark as Spam" to the option value "spam", so we can tests WordPress <5.5 as well as >=5.5

fixes #347 