### PR TITLE
Add pattern to counter some trackback spam

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1580,6 +1580,9 @@ class Antispam_Bee {
 				'body'  => 'dating|sex|lotto|pharmacy',
 				'email' => '@mail\.ru|@yandex\.',
 			),
+			array(
+				'body' => '^\[…\] ((Here |There )you (can |will ))?(((R|r)ead |(F|f)ind )(\d* )?)?((M|m)ore )?(Information |Info )?(here )?(to |on )+that Topic: \S* \[…\]$',
+			),
 		);
 
 		$quoted_author = preg_quote( $comment['author'], '/' );


### PR DESCRIPTION
Hi!
Thank you for developing this great extension!

I recently received some trackback spam (basically trackback comments like below, but with slightly different wordings)
```
[…] Here you can find 61912 more Information to that Topic: <url to my blog post> […]
```

This PR adds a regex that should catch all those comments.
I haven't yet received a new spam comment since applying this pattern, so I cannot yet verify if it's working, but I will come back here once I get "lucky".