### PR TITLE
Add possibility to reanalyze pending comments

### DIFF
--- a/inc/gui.class.php
+++ b/inc/gui.class.php
@@ -565,4 +565,61 @@ class Antispam_Bee_GUI extends Antispam_Bee {
 		 */
 		return apply_filters( 'ab_get_allowed_translate_languages', $lang );
 	}
+
+	/**
+	 * Add reanalyze button to edit-comments page.
+	 *
+	 * @since 2.10
+	 * @return void
+	 */
+	public static function add_reanalyze_button( $hook_suffix ) {
+		if ( 'edit-comments.php' !== $hook_suffix ) {
+			return;
+		}
+
+		// Create HTML for form and input button.
+		$form_markup = sprintf(
+			'<form method="post" id="antispam-bee-reanalyze-all-form">%s</form>',
+			wp_nonce_field( 'antispam_bee_reanalyze_all', 'antispam_bee_reanalyze_all_nonce' )
+		);
+
+		$button_markup = sprintf(
+			'<input class="button" id="antispam-bee-reanalyze-all" name="antispam_bee_reanalyze_all" type="submit" value="Reanalyze with Antispam Bee" form="antispam-bee-reanalyze-all-form">'
+		);
+
+		printf(
+			'<script>
+				( function() {
+					document.addEventListener( "DOMContentLoaded", function() {
+						var commentsForm = document.querySelector( "#comments-form" ),
+							actionsDiv = document.querySelector( "#comments-form .tablenav.top" );
+						if ( ! commentsForm || ! actionsDiv ) {
+							return;
+						}
+
+						var tablenavPagesDiv = actionsDiv.querySelector( ".tablenav-pages" );
+						if ( ! tablenavPagesDiv ) {
+							return;
+						}
+
+						// Create submit input.
+						var actionDiv = document.createElement( "div" );
+						actionDiv.classList.add( "alignleft", "actions" );
+
+						var submit = \'%s\';
+						
+						actionDiv.innerHTML = submit;
+
+						// Add action div before tablenavPagesDiv.
+						tablenavPagesDiv.parentNode.insertBefore( actionDiv, tablenavPagesDiv );
+
+						// Add form before comments form list.
+						commentsForm.outerHTML = \'%s\' + commentsForm.outerHTML;
+					} );
+				} )();
+			</script>',
+			$button_markup,
+			$form_markup
+		);
+	}
 }


### PR DESCRIPTION
I started work on #281 with a button that allows the user to reanalyze all pending comments.

For now, the button lives in the row with the filter and bulk actions:

![Screenshot_2020-12-10 Comments ‹ WordPress oder — WordPress(1)](https://user-images.githubusercontent.com/2310924/101769008-a03a5a80-3ae6-11eb-94b7-780460bc8293.png)

The button label is a little bit long, but I am not sure if `Reanalyze` or something like that would be clear enough.