### PR TITLE
Replace link in notification

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2573,7 +2573,7 @@ class Antispam_Bee {
 		) . sprintf(
 			"%s\r\n%s\r\n",
 			esc_html__( 'Notify message by Antispam Bee', 'antispam-bee' ),
-			esc_html__( 'https://antispambee.com', 'antispam-bee' )
+			esc_html__( 'https://antispambee.pluginkollektiv.org/', 'antispam-bee' )
 		);
 
 		wp_mail(


### PR DESCRIPTION
https://antispambee.com does not redirect to https://antispambee.pluginkollektiv.org/de/ (only HTTP works). However, we can directly link to the website as done in other locations already.