### PR TITLE
Add `apt-get update` before installing xvfb in GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Start mysql service
       run: sudo /etc/init.d/mysql start
     - name: Install XVFB
-      run: sudo apt-get install xvfb
+      run: sudo apt-get update && sudo apt-get install xvfb
     - name: Run tests
       run: |
         composer install --ignore-platform-req=php


### PR DESCRIPTION
The last workflow runs for #374 failed because of 404 errors during the installation of XVFB. This PR fixes that with adding a `sudo apt-get update` before installing XVFB.