### PR TITLE
introduce SonarCloud analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,7 @@
 /.eslintrc.json
 /.gitattributes
 /.gitignore
+/.sonarcloud.properties
 /.stylelintrc.json
 /composer.json
 /composer.lock

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /.eslintrc.json export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.sonarcloud.properties export-ignore
 /.stylelintrc.json export-ignore
 /behat.yml export-ignore
 /composer.json export-ignore

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,9 @@
+# Path to sources
+sonar.sources=inc,js,css,antispam_bee.php
+sonar.exclusions=**/*.min.css,**/*.min.js
+#sonar.inclusions=
+
+# Path to tests
+sonar.tests=tests
+sonar.test.exclusions=tests/_stubs
+#sonar.test.inclusions=


### PR DESCRIPTION
This PR adds a _.sonarcloud.properties_ file to add some configuration for the SonarCloud [automatic analysis](https://sonarcloud.io/documentation/analysis/automatic-analysis/).

This mode does not support test coverage (obviously, without running tests), but tells the analyzer which files to scan and thus reduces a number of false positives on test files and external resources.

We might go one step further and replace the automatic by manual analysis from CI, if we do want coverage analysis. Requires some tweaks to properly work with multiple test frameworks involved though, so this seems to be a good choice to start for now.