### PR TITLE
Remove Coderisk URL

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -11,8 +11,6 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Version:     2.9.4
  *
- * [](http://coderisk.com/wp/plugin/antispam-bee/RIPS-lAHLcgvqY8)
- *
  * @package Antispam Bee
  **/
 


### PR DESCRIPTION
After CodeRisk is acquired and we moved to SonarCloud, this line could be removed safely

Fixes #398 