### PR TITLE
Add files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -24,3 +24,6 @@
 /phpcs.xml
 /phpunit.xml.dist
 /README.md
+/output.log
+/docker_tag
+/behat.yml


### PR DESCRIPTION
Adds the three files to `.distignore` that were included in the 2.10.0 deploy by accident.