### PR TITLE
Allow empty comments via core filter

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1425,6 +1425,7 @@ class Antispam_Bee {
 		$author    = self::get_key( $comment, 'comment_author' );
 		$useragent = self::get_key( $comment, 'comment_agent' );
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$allow_empty_comment = apply_filters( 'allow_empty_comment', false, $comment );
 
 		if ( empty( $body ) && ! $allow_empty_comment ) {

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1117,11 +1117,11 @@ class Antispam_Bee {
 		$hidden_field = self::get_key( $_POST, 'comment' );
 		$plugin_field = self::get_key( $_POST, self::get_secret_name_for_post( $post_id ) );
 
-		if ( empty( $hidden_field ) && ! empty( $plugin_field ) ) {
+		if ( ! empty( $hidden_field ) ) {
+			$_POST['ab_spam__hidden_field'] = 1;
+		} else {
 			$_POST['comment'] = $plugin_field;
 			unset( $_POST[ self::get_secret_name_for_post( $post_id ) ] );
-		} else {
-			$_POST['ab_spam__hidden_field'] = 1;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
@@ -1425,7 +1425,9 @@ class Antispam_Bee {
 		$author    = self::get_key( $comment, 'comment_author' );
 		$useragent = self::get_key( $comment, 'comment_agent' );
 
-		if ( empty( $body ) ) {
+		$allow_empty_comment = apply_filters( 'allow_empty_comment', false, $comment );
+
+		if ( empty( $body ) && ! $allow_empty_comment ) {
 			return array(
 				'reason' => 'empty',
 			);


### PR DESCRIPTION
With WordPress 5.1 a filter `allow_empty_comment` was introduced. If this filter is set to true we need to allow empty comments.

Fixes #421 