### PR TITLE
Add aria label to honeypot textarea

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1278,7 +1278,7 @@ class Antispam_Bee {
 		$output .= $matches['between1'] . $matches['between2'] . $matches['between3'];
 		$output .= $matches['after'] . '>';
 		$output .= $matches['content'];
-		$output .= '</textarea><textarea id="comment" aria-hidden="true" name="comment" autocomplete="new-password" style="padding:0 !important;clip:rect(1px, 1px, 1px, 1px) !important;position:absolute !important;white-space:nowrap !important;height:1px !important;width:1px !important;overflow:hidden !important;" tabindex="-1"></textarea>';
+		$output .= '</textarea><textarea id="comment" aria-label="hp-comment" aria-hidden="true" name="comment" autocomplete="new-password" style="padding:0 !important;clip:rect(1px, 1px, 1px, 1px) !important;position:absolute !important;white-space:nowrap !important;height:1px !important;width:1px !important;overflow:hidden !important;" tabindex="-1"></textarea>';
 
 		$output .= $id_script;
 		$output .= $init_time_field;


### PR DESCRIPTION
Adds an aria label to honeypot textarea to fix the failing WAVE test.

Fixes #434 