### PR TITLE
remove superfluous type attribute from inline script tag (#448)

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1272,7 +1272,10 @@ class Antispam_Bee {
 		if ( ! empty( $matches['id1'] ) || ! empty( $matches['id2'] ) ) {
 			$output .= 'id="' . self::get_secret_id_for_post( self::$_current_post_id ) . '" ';
 			if ( ! self::_is_amp() ) {
-				$id_script = '<script data-noptimize type="text/javascript">document.getElementById("comment").setAttribute( "id", "a' . substr( esc_js( md5( time() ) ), 0, 31 ) . '" );document.getElementById("' . esc_js( self::get_secret_id_for_post( self::$_current_post_id ) ) . '").setAttribute( "id", "comment" );</script>';
+				$id_script = '<script data-noptimize>' .
+							'document.getElementById("comment").setAttribute( "id", "a' . substr( esc_js( md5( time() ) ), 0, 31 ) . '" );' .
+							'document.getElementById("' . esc_js( self::get_secret_id_for_post( self::$_current_post_id ) ) . '").setAttribute( "id", "comment" );' .
+							'</script>';
 			}
 		}
 


### PR DESCRIPTION
The "type" attribute is technically not invalid, but not necessary
either, and it might raise warnings in markup validations.
Remove the attribute and add some line-breaks for readability.