### PR TITLE
explicitly parse spam_count to integer, to prevent null warning

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2703,7 +2703,7 @@ class Antispam_Bee {
 	 */
 	private static function _get_spam_count() {
 		// Init.
-		$count = self::get_option( 'spam_count' );
+		$count = intval( self::get_option( 'spam_count' ) );
 
 		// Fire.
 		return ( get_locale() === 'de_DE' ? number_format( $count, 0, '', '.' ) : number_format_i18n( $count ) );


### PR DESCRIPTION
**Issue**
The spam counter is not initialized by default, so before the very first spam comment, we load `null` from the database. This triggers a deprecation warning, because `null` is passed to `number_format()` in subsequent calls:
> Deprecated: number_format(): Passing null to parameter #1 ($num) of type float is deprecated in /var/www/html/wordpress/wp-includes/functions.php on line 425

**Steps to reproduce**
Assume a WP site running on PHP 8.1. Install and activate_Antispam Bee_, enable the "Spam counter on the dashboard" option and visit the dashboard.
If PHP warnings are enabled, e.g. because `WP_DEBUG` is set, there will be a PHP warning block above the "0 Blocked" line within the "At a Glance" widget.

**Solution**
Explicitly parse the value as integer yields 0 which perfectly represents the desired value without any warning.

We yet do the very same when updating the counter: https://github.com/pluginkollektiv/antispam-bee/blob/c105eaa0d739bdc47fea2d884c4aaa5a662c7973/antispam_bee.php#L2738