### PR TITLE
Update tests matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '7.4', '5.4']
+        php-versions: ['7.3', '7.2', '5.4']
     steps:
     - uses: actions/checkout@master
     - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.2', '5.4']
+        php-versions: ['8.0', '7.4', '5.4']
     steps:
     - uses: actions/checkout@master
     - name: Setup PHP
@@ -35,9 +35,19 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       matrix:
-        php: ['8']
+        php: ['8.1']
         wordpress: ['nightly', 'latest']
         include:
+          - php: '8.0'
+            wordpress: '6.0'
+          - php: '8.0'
+            wordpress: '5.9'
+          - php: '8.0'
+            wordpress: '5.8'
+          - php: '8.0'
+            wordpress: '5.7'
+          - php: '8.0'
+            wordpress: '5.6'
           - php: '7.4'
             wordpress: '5.5'
           - php: '7.4'

--- a/bin/behat.sh
+++ b/bin/behat.sh
@@ -14,7 +14,7 @@ which google-chrome
 mkdir -p $WORDPRESS_PATH
 vendor/bin/wp core download --force --version=$WORDPRESS_VERSION --path=$WORDPRESS_PATH
 rm -f ${WORDPRESS_PATH}wp-config.php
-vendor/bin/wp config create --path=$WORDPRESS_PATH --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-salts  --extra-php="define('WP_DEBUG', true); define('WP_DEBUG_DISPLAY', false); define('WP_DEBUG_LOG', true):"
+vendor/bin/wp config create --path=$WORDPRESS_PATH --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-salts  --extra-php="define('WP_DEBUG', true); define('WP_DEBUG_DISPLAY', false); define('WP_DEBUG_LOG', true);"
 vendor/bin/wp core install --path=$WORDPRESS_PATH --url=$WORDPRESS_URL --title="wordpress.dev" --admin_user="admin" --admin_password="abc" --admin_email="admin@example.com"
 
 wait_for_port() {

--- a/bin/behat.sh
+++ b/bin/behat.sh
@@ -14,7 +14,7 @@ which google-chrome
 mkdir -p $WORDPRESS_PATH
 vendor/bin/wp core download --force --version=$WORDPRESS_VERSION --path=$WORDPRESS_PATH
 rm -f ${WORDPRESS_PATH}wp-config.php
-vendor/bin/wp config create --path=$WORDPRESS_PATH --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-salts  --extra-php="define('WP_DEBUG', true);"
+vendor/bin/wp config create --path=$WORDPRESS_PATH --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --skip-salts  --extra-php="define('WP_DEBUG', true); define('WP_DEBUG_DISPLAY', false); define('WP_DEBUG_LOG', true):"
 vendor/bin/wp core install --path=$WORDPRESS_PATH --url=$WORDPRESS_URL --title="wordpress.dev" --admin_user="admin" --admin_password="abc" --admin_email="admin@example.com"
 
 wait_for_port() {


### PR DESCRIPTION
Add test workflows for _WordPress_ 5.6 to 6.0 with PHP 8.0 and use PHP 8.1 for _latest_ and _nightly_.

Silence deprecation warnings that are raised by testing artifacts.