### PR TITLE
prepare release 2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Changelog ##
 
+### 2.11.2 ###
+* **English**
+  * Tweak: remove superfluous translations
+  * Tweak: make FAQ link an anchor link
+  * Fix: spam counter no longer raises a warning with PHP 8.1 if no spam is present yet
+  * Fix: spam reasons are now localized correctly
+  * Maintenance: Tested up to WordPress 6.1
+
+* **Deutsch**
+  * Tweak: Überflüssiges Übersetzungen entfernt
+  * Tweak: Link zu den FAQ ist jetzt ein Anker-Link
+  * Fix: Der Spam-Zähler erzeugt mit PHP 8.1 keine Warnung mehr, wenn noch kein Spam vorhanden ist
+  * Fix: Spam-Gründe werden nun korrekt übersetzt
+  * Wartung: Getestet mit WordPress 6.1
+
 ### 2.11.1 ###
 * **English**
   * Tweak: remove superfluous type attribute from inline script tag

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -9,7 +9,7 @@
  * Domain Path: /lang
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.11.1
+ * Version:     2.11.2
  *
  * @package Antispam Bee
  **/

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@
 * Tags:              anti-spam, antispam, block spam, comment, comments, comment spam, pingback, spam, spam filter, trackback, GDPR
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.5
-* Tested up to:      6.0
+* Tested up to:      6.1
 * Requires PHP:      5.2
-* Stable tag:        2.11.1
+* Stable tag:        2.11.2
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -95,6 +95,13 @@ No, Antispam Bee is free forever, for both private and commercial projects. You 
 A complete documentation is available on [pluginkollektiv.org](https://antispambee.pluginkollektiv.org/documentation/).
 
 ## Changelog ##
+
+### 2.11.2 ###
+  * Tweak: remove superfluous translations
+  * Tweak: make FAQ link an anchor link
+  * Fix: spam counter no longer raises a warning with PHP 8.1 if no spam is present yet
+  * Fix: spam reasons are now localized correctly
+  * Maintenance: Tested up to WordPress 6.1
 
 ### 2.11.1 ###
   * Tweak: remove superfluous type attribute from inline script tag


### PR DESCRIPTION
With the milestone 2.11.2 being complete now, this PR prepares the release of version 2.11.2.

see #479 :
* update changelog
* raise version number
* update tested and stable tags

