### PR TITLE
only determine client IP from trusted headers

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2423,7 +2423,7 @@ class Antispam_Bee {
 	 *
 	 * @since   2.6.1
 	 *
-	 * @hook    string  antispam_bee_trusted_ip  The Client IP
+	 * @hook    string  pre_comment_user_ip  The Client IP
 	 *
 	 * @return  string  $ip  Client IP
 	 */
@@ -2433,7 +2433,7 @@ class Antispam_Bee {
 		 *
 		 * @return string
 		 */
-		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
+		return self::_sanitize_ip( (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
 	}
 
 	/**

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2433,7 +2433,7 @@ class Antispam_Bee {
 		 *
 		 * @return string
 		 */
-		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ) ) );
+		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
 	}
 
 	/**

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2433,7 +2433,7 @@ class Antispam_Bee {
 		 *
 		 * @return string
 		 */
-		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', $_SERVER[ 'REMOTE_ADDR' ] ) );
+		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ) ) );
 	}
 
 	/**

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2435,10 +2435,13 @@ class Antispam_Bee {
 		 *
 		 * @return string
 		 */
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return self::_sanitize_ip( (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	}
 
 	/**

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2429,8 +2429,10 @@ class Antispam_Bee {
 	 */
 	public static function get_client_ip() {
 		/**
-		 * Hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
+		 * WordPress hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
 		 *
+   		 * @link https://developer.wordpress.org/reference/hooks/pre_comment_user_ip/
+      		 *
 		 * @return string
 		 */
 		return self::_sanitize_ip( (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2431,10 +2431,13 @@ class Antispam_Bee {
 		/**
 		 * WordPress hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
 		 *
-   		 * @link https://developer.wordpress.org/reference/hooks/pre_comment_user_ip/
-      		 *
+		 * @link https://developer.wordpress.org/reference/hooks/pre_comment_user_ip/
+		 *
 		 * @return string
 		 */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return self::_sanitize_ip( (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
 	}
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2423,26 +2423,17 @@ class Antispam_Bee {
 	 *
 	 * @since   2.6.1
 	 *
-	 * @hook    array  antispam_bee_trusted_ip_headers  List of trusted headers for client IP detection
+	 * @hook    string  antispam_bee_trusted_ip  The Client IP
 	 *
 	 * @return  string  $ip  Client IP
 	 */
 	public static function get_client_ip() {
-		// Determine trusted headers for the client IP.
-		$trusted_headers = apply_filters( 'antispam_bee_trusted_ip_headers', array( 'REMOTE_ADDR' ) );
-
-		// Loop through headers and try to determine a valid IP address.
-		foreach ( $trusted_headers as $header ) {
-			if ( is_string( $header ) && isset( $_SERVER[ $header ] ) ) {
-                // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$ip = self::_sanitize_ip( wp_unslash( $_SERVER[ $header ] ) );
-				if ( ! empty( $ip ) ) {
-					return $ip;
-				}
-			}
-		}
-
-		return '';
+		/**
+		 * Hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
+		 *
+		 * @return string
+		 */
+		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', $_SERVER[ 'REMOTE_ADDR' ] ) );
 	}
 
 	/**

--- a/tests/Unit/AntispamBeeTest.php
+++ b/tests/Unit/AntispamBeeTest.php
@@ -74,10 +74,10 @@ class FactoryTest extends TestCase {
 		$result = Testee::handle_incoming_request( $comment );
 		$this->assertSame( '192.0.2.1', $result['comment_author_IP'], 'Unexpected IP with default detection' );
 
-		Filters::expectApplied( 'antispam_bee_trusted_ip_headers' )
+		Filters::expectApplied( 'antispam_bee_trusted_ip' )
 				->once()
-				->with( array( 'REMOTE_ADDR' ) )
-				->andReturn( array( 'HTTP_X_REAL_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR' ) );
+				->with( '192.0.2.1' )
+				->andReturn( '192.0.2.2' );
 
         $result = Testee::handle_incoming_request( $comment );
         $this->assertSame( '192.0.2.2', $result['comment_author_IP'], 'Unexpected IP with custom hook' );

--- a/tests/Unit/AntispamBeeTest.php
+++ b/tests/Unit/AntispamBeeTest.php
@@ -74,7 +74,7 @@ class FactoryTest extends TestCase {
 		$result = Testee::handle_incoming_request( $comment );
 		$this->assertSame( '192.0.2.1', $result['comment_author_IP'], 'Unexpected IP with default detection' );
 
-		Filters::expectApplied( 'antispam_bee_trusted_ip' )
+		Filters::expectApplied( 'pre_comment_user_ip' )
 				->once()
 				->with( '192.0.2.1' )
 				->andReturn( '192.0.2.2' );


### PR DESCRIPTION
Code change and description by @stklcode

 By default, we only look for the client's IP address in the REMOTE_ADDR header. This can be extended via hook if there is a need to use headers like X-Forwarded-For ("HTTP_X_FORWARDED_FOR") instead.

Headers will be processed in the provided order and return the first valid IP address found.