### PR TITLE
ci: enable test workflows on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests, Behat, Coding Standards
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have required workflows for a PR to be merged into the _master_ branch, but only trigger actions on push.

Enable pull requests explicitly to run the required checks on PRs from forks independently of the fork owner's repo settings.