### PR TITLE
Fix empty data error

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2458,7 +2458,7 @@ class Antispam_Bee {
 	 */
 	public static function get_client_ip() {
 		/**
-		 * WordPress hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
+		 * Hook for allowing to modify the client IP used by Antispam Bee. Default value is the `REMOTE_ADDR`.
 		 *
 		 * @link https://developer.wordpress.org/reference/hooks/pre_comment_user_ip/
 		 *

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2450,6 +2450,7 @@ class Antispam_Bee {
 	 *
 	 * @since   2.6.1
 	 * @since   2.11.4 Only use `REMOTE_ADDR` to get the IP, make it filterable with `pre_comment_user_ip`
+	 * @since   2.11.5 Switch to own filter `antispam_bee_trusted_ip`
 	 *
 	 * @hook    string  pre_comment_user_ip  The Client IP
 	 *
@@ -2466,7 +2467,7 @@ class Antispam_Bee {
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		return self::_sanitize_ip( (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
+		return self::_sanitize_ip( (string) apply_filters( 'antispam_bee_trusted_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) );
 		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/tests/Unit/AntispamBeeTest.php
+++ b/tests/Unit/AntispamBeeTest.php
@@ -74,7 +74,7 @@ class FactoryTest extends TestCase {
 		$result = Testee::handle_incoming_request( $comment );
 		$this->assertSame( '192.0.2.1', $result['comment_author_IP'], 'Unexpected IP with default detection' );
 
-		Filters::expectApplied( 'pre_comment_user_ip' )
+		Filters::expectApplied( 'antispam_bee_trusted_ip' )
 				->once()
 				->with( '192.0.2.1' )
 				->andReturn( '192.0.2.2' );


### PR DESCRIPTION
Usage of the core filter pre_comment_user_ip does trigger our empty data check for the IP address if the IP is removed intentionally for GDPR compliance. Switching to own filter.

Fixes #527 