### PR TITLE
remove unused private methods

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2246,27 +2246,6 @@ class Antispam_Bee {
 
 
 	/**
-	 * Rotates the IP address
-	 *
-	 * @since   2.4.5
-	 *
-	 * @param   string $ip  IP address.
-	 * @return  string      Turned IP address.
-	 */
-	private static function _reverse_ip( $ip ) {
-		return implode(
-			'.',
-			array_reverse(
-				explode(
-					'.',
-					$ip
-				)
-			)
-		);
-	}
-
-
-	/**
 	 * Check for an IPv4 address
 	 *
 	 * @since  2.4
@@ -2280,24 +2259,6 @@ class Antispam_Bee {
 			return filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) !== false;
 		} else {
 			return preg_match( '/^\d{1,3}(\.\d{1,3}){3}$/', $ip );
-		}
-	}
-
-
-	/**
-	 * Check for an IPv6 address
-	 *
-	 * @since  2.6.2
-	 * @since  2.6.4
-	 *
-	 * @param   string $ip  IP to validate.
-	 * @return  boolean       TRUE if IPv6.
-	 */
-	private static function _is_ipv6( $ip ) {
-		if ( function_exists( 'filter_var' ) ) {
-			return filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) !== false;
-		} else {
-			return ! self::_is_ipv4( $ip );
 		}
 	}
 


### PR DESCRIPTION
`Antispam_Bee::_is_ipv6( $ip )` is unused since 2.9.2 (https://github.com/pluginkollektiv/antispam-bee/commit/a14bbe3f5c630a97c541b5f6c93dcf5ca7c6c1e4)

`Antispam_Bee::_reverse_ip( $ip )` is unused since at least 2.6.7 (before the first GitHub commit, did not check the old SVN data)