### PR TITLE
[v3] add type hints to function signatures

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -30,7 +30,7 @@ pre_init();
 /**
  * Pre init function to check the plugins compatibility.
  */
-function pre_init() {
+function pre_init(): void {
 	// Load the translation, as they might be needed in pre_init.
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load_textdomain', 5 );
 
@@ -72,14 +72,14 @@ function pre_init() {
  *
  * @since 1.0.0
  */
-function load_textdomain() {
+function load_textdomain(): void {
 	load_plugin_textdomain( 'antispam-bee' );
 }
 
 /**
  * Show a admin notice error message, if the PHP version is too low
  */
-function min_php_version_error() {
+function min_php_version_error(): void {
 	echo '<div class="error"><p>';
 	esc_html_e( 'Antispam Bee requires PHP version 7.2 or higher to function properly. Please upgrade PHP or deactivate Antispam Bee.', 'antispam-bee' );
 	echo '</p></div>';
@@ -88,7 +88,7 @@ function min_php_version_error() {
 /**
  * Show a admin notice error message, if the PHP version is too low
  */
-function domdocument_class_error() {
+function domdocument_class_error(): void {
 	echo '<div class="error"><p>';
 	esc_html_e( 'Antispam Bee requires the DOMDocument PHP class. Please install the PHP DOM/XML extension.', 'antispam-bee' );
 	echo '</p></div>';
@@ -97,7 +97,7 @@ function domdocument_class_error() {
 /**
  * Show a admin notice error message, if the PHP version is too low
  */
-function autoloader_missing() {
+function autoloader_missing(): void {
 	echo '<div class="error"><p>';
 	esc_html_e( 'Antispam Bee is missing the Composer autoloader file. Please run `composer install --no-dev -o` in the root folder of the plugin or use a release version including the `vendor` folder.', 'antispam-bee' );
 	echo '</p></div>';

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "type": "wordpress-plugin",
   "license": "GPL-v2",
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.2"
   },
   "require-dev": {
     "behat/mink": "^v1.11.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -87,7 +87,7 @@
 	-->
 
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.5
 * Tested up to:      6.2
-* Requires PHP:      7.0
+* Requires PHP:      7.2
 * Stable tag:        2.11.0
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/Admin/CommentsColumns.php
+++ b/src/Admin/CommentsColumns.php
@@ -24,7 +24,7 @@ class CommentsColumns {
 	/**
 	 * Registers the module hooks.
 	 */
-	public static function init() {
+	public static function init(): void {
 		if ( ! DashboardHelper::is_edit_spam_comments_page() ) {
 			return;
 		}
@@ -59,7 +59,7 @@ class CommentsColumns {
 	 * @since   2.6.0
 	 * @change  2.6.0
 	 */
-	public static function register_plugin_columns( $columns ) {
+	public static function register_plugin_columns( array $columns ): array {
 		return array_merge(
 			$columns,
 			[
@@ -77,7 +77,7 @@ class CommentsColumns {
 	 * @since   2.6.0
 	 * @change  2.6.0
 	 */
-	public static function print_plugin_column( $column, $comment_id ) {
+	public static function print_plugin_column( string $column, int $comment_id ): void {
 		if ( 'antispam_bee_reason' !== $column ) {
 			return;
 		}
@@ -106,7 +106,7 @@ class CommentsColumns {
 	 * @since   2.6.3
 	 * @change  2.6.3
 	 */
-	public static function register_sortable_columns( $columns ) {
+	public static function register_sortable_columns( array $columns ): array {
 		$columns['antispam_bee_reason'] = 'antispam_bee_reason';
 
 		return $columns;
@@ -120,7 +120,7 @@ class CommentsColumns {
 	 * @since   2.6.3
 	 * @change  2.6.3
 	 */
-	public static function set_orderby_query( $query ) {
+	public static function set_orderby_query( WP_Comment_Query $query ): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
 
@@ -138,7 +138,7 @@ class CommentsColumns {
 	 *
 	 * @global wpdb $wpdb
 	 */
-	public static function filter_columns() {
+	public static function filter_columns(): void {
 		global $wpdb;
 		?>
 		<label class="screen-reader-text"
@@ -182,7 +182,7 @@ class CommentsColumns {
 	 *
 	 * @param WP_Comment_Query $query Current WordPress query.
 	 */
-	public static function filter_by_spam_reason( $query ) {
+	public static function filter_by_spam_reason( WP_Comment_Query $query ): void {
 		$spam_reason = isset( $_GET['comment_spam_reason'] ) ? sanitize_text_field( wp_unslash( $_GET['comment_spam_reason'] ) ) : '';
 		if ( empty( $spam_reason ) ) {
 			return;
@@ -221,7 +221,7 @@ class CommentsColumns {
 	 * @since   2.6.1
 	 * @change  2.6.1
 	 */
-	public static function print_column_styles() {
+	public static function print_column_styles(): void {
 		?>
 		<style>
 			.column-antispam_bee_reason {

--- a/src/Admin/DashboardWidgets.php
+++ b/src/Admin/DashboardWidgets.php
@@ -18,7 +18,7 @@ class DashboardWidgets {
 	/**
 	 * Initialize the dashboard widgets.
 	 */
-	public static function init() {
+	public static function init(): void {
 		if ( DashboardHelper::is_dashboard_page() ) {
 			add_action( 'antispam_bee_count', [ __CLASS__, 'the_spam_count' ] );
 			add_filter( 'dashboard_glance_items', [ __CLASS__, 'add_dashboard_count' ] );
@@ -34,7 +34,7 @@ class DashboardWidgets {
 	 * @since  0.1
 	 * @since  2.6.5
 	 */
-	public static function add_dashboard_count( $items = array() ) {
+	public static function add_dashboard_count( array $items = array() ): array {
 		if ( ! current_user_can( 'manage_options' ) || ! Statistics::is_active() ) {
 			return $items;
 		}
@@ -68,7 +68,7 @@ class DashboardWidgets {
 	 * @since  0.1
 	 * @since  2.4
 	 */
-	private static function get_spam_count() {
+	private static function get_spam_count(): string {
 		$count = intval( Settings::get_option( 'spam_count', '' ) );
 
 		return self::format_number( $count );
@@ -77,10 +77,10 @@ class DashboardWidgets {
 	/**
 	 * Format a number.
 	 *
-	 * @param float $number Number to format.
+	 * @param float|int $number Number to format.
 	 * @return string
 	 */
-	private static function format_number( $number ) {
+	private static function format_number( $number ): string {
 		return ( get_locale() === 'de_DE' ? number_format( $number, 0, '', '.' ) : number_format_i18n( $number ) );
 	}
 
@@ -90,7 +90,7 @@ class DashboardWidgets {
 	 * @since  0.1
 	 * @since  2.4
 	 */
-	public static function the_spam_count() {
+	public static function the_spam_count(): void {
 		echo esc_html( self::get_spam_count() );
 	}
 }

--- a/src/Admin/Fields/Checkbox.php
+++ b/src/Admin/Fields/Checkbox.php
@@ -16,7 +16,7 @@ class Checkbox extends Field implements RenderElement {
 	/**
 	 * Get HTML.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$label = ! empty( $this->get_label() ) ? sprintf(

--- a/src/Admin/Fields/CheckboxGroup.php
+++ b/src/Admin/Fields/CheckboxGroup.php
@@ -17,7 +17,7 @@ class CheckboxGroup extends Field implements RenderElement {
 	/**
 	 * Render HTML.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$options = isset( $this->option['options'] ) ? $this->option['options'] : [];
@@ -49,7 +49,7 @@ class CheckboxGroup extends Field implements RenderElement {
 	 *
 	 * @return mixed Value stored in database.
 	 */
-	protected function get_custom_value( $key ) {
+	protected function get_custom_value( string $key ) {
 		$options = Settings::get_option( "{$this->controllable_option_name}", $this->type );
 
 		return isset( $options[ $key ] ) ? $options[ $key ] : null;

--- a/src/Admin/Fields/CheckboxGroup.php
+++ b/src/Admin/Fields/CheckboxGroup.php
@@ -20,7 +20,7 @@ class CheckboxGroup extends Field implements RenderElement {
 	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		$options = isset( $this->option['options'] ) ? $this->option['options'] : [];
+		$options = $this->option['options'] ?? [];
 		if ( ! is_array( $options ) ) {
 			return;
 		}
@@ -52,6 +52,6 @@ class CheckboxGroup extends Field implements RenderElement {
 	protected function get_custom_value( string $key ) {
 		$options = Settings::get_option( "{$this->controllable_option_name}", $this->type );
 
-		return isset( $options[ $key ] ) ? $options[ $key ] : null;
+		return $options[ $key ] ?? null;
 	}
 }

--- a/src/Admin/Fields/Field.php
+++ b/src/Admin/Fields/Field.php
@@ -38,11 +38,11 @@ abstract class Field {
 	/**
 	 * Initializing field
 	 *
-	 * @param string                     $type Item type.
-	 * @param array                      $option Field options.
-	 * @param class-string<Controllable> $controllable The related controllable.
+	 * @param string $type         Item type.
+	 * @param array  $option       Field options.
+	 * @param string $controllable The related controllable (class name).
 	 */
-	public function __construct( $type, $option, $controllable ) {
+	public function __construct( string $type, array $option, string $controllable ) {
 		$this->type                     = $type;
 		$this->option                   = $option;
 		$this->controllable_option_name = $controllable::get_option_name( $this->option['option_name'] );
@@ -79,7 +79,7 @@ abstract class Field {
 	 *
 	 * @return string
 	 */
-	public function get_placeholder() {
+	public function get_placeholder(): string {
 		return isset( $this->option['placeholder'] ) ? $this->option['placeholder'] : '';
 	}
 
@@ -88,7 +88,7 @@ abstract class Field {
 	 *
 	 * @return string Description of the field.
 	 */
-	public function get_description() {
+	public function get_description(): string {
 		return isset( $this->option['description'] ) ? $this->option['description'] : '';
 	}
 
@@ -106,14 +106,14 @@ abstract class Field {
 	 *
 	 * @return array
 	 */
-	public function get_option() {
+	public function get_option(): array {
 		return $this->option;
 	}
 
 	/**
 	 * Show description if not empty.
 	 */
-	protected function maybe_show_description() {
+	protected function maybe_show_description(): void {
 		if ( ! empty( $this->get_description() ) ) {
 			printf(
 				'<p class="description">%s</p>',
@@ -125,7 +125,7 @@ abstract class Field {
 	/**
 	 * Get HTML for field.
 	 *
-	 * @return string Element HTML.
+	 * @return void
 	 */
-	abstract public function render();
+	abstract public function render(): void;
 }

--- a/src/Admin/Fields/Field.php
+++ b/src/Admin/Fields/Field.php
@@ -66,8 +66,8 @@ abstract class Field {
 	 * @return string Label of the field.
 	 */
 	public function get_label() {
-		$kses  = isset( $this->option['label_kses'] ) ? $this->option['label_kses'] : [];
-		$label = isset( $this->option['label'] ) ? $this->option['label'] : '';
+		$kses  = $this->option['label_kses'] ?? [];
+		$label = $this->option['label'] ?? '';
 		if ( ! $kses ) {
 			return esc_html( $label );
 		}
@@ -80,7 +80,7 @@ abstract class Field {
 	 * @return string
 	 */
 	public function get_placeholder(): string {
-		return isset( $this->option['placeholder'] ) ? $this->option['placeholder'] : '';
+		return $this->option['placeholder'] ?? '';
 	}
 
 	/**
@@ -89,7 +89,7 @@ abstract class Field {
 	 * @return string Description of the field.
 	 */
 	public function get_description(): string {
-		return isset( $this->option['description'] ) ? $this->option['description'] : '';
+		return $this->option['description'] ?? '';
 	}
 
 	/**

--- a/src/Admin/Fields/Inline.php
+++ b/src/Admin/Fields/Inline.php
@@ -17,9 +17,9 @@ class Inline extends Field implements RenderElement {
 	/**
 	 * Get HTML for field.
 	 *
-	 * @return string Element HTML.
+	 * @return void
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( ! $this->option['input'] instanceof Field ) {

--- a/src/Admin/Fields/Select.php
+++ b/src/Admin/Fields/Select.php
@@ -17,7 +17,7 @@ class Select extends Field implements RenderElement {
 	/**
 	 * Get HTML.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$name     = $this->get_name();

--- a/src/Admin/Fields/Text.php
+++ b/src/Admin/Fields/Text.php
@@ -33,7 +33,7 @@ class Text extends Field implements RenderElement {
 	/**
 	 * Get HTML.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		printf(
@@ -50,7 +50,7 @@ class Text extends Field implements RenderElement {
 	 *
 	 * @return string
 	 */
-	public function get_injectable_markup() {
+	public function get_injectable_markup(): string {
 		return sprintf(
 			'<input type="%1$s" id="%2$s" name="%2$s" value="%3$s" class="%4$s" placeholder="%5$s">',
 			esc_attr( $this->get_type() ),
@@ -66,7 +66,7 @@ class Text extends Field implements RenderElement {
 	 *
 	 * @return string
 	 */
-	protected function get_class() {
+	protected function get_class(): string {
 		$classes    = [
 			'small'   => 'small-text',
 			'regular' => 'regular-text',
@@ -85,7 +85,7 @@ class Text extends Field implements RenderElement {
 	 *
 	 * @return string
 	 */
-	protected function get_type() {
+	protected function get_type(): string {
 		return isset( $this->option['input_type'] ) ? $this->option['input_type'] : 'text';
 	}
 }

--- a/src/Admin/Fields/Text.php
+++ b/src/Admin/Fields/Text.php
@@ -71,7 +71,7 @@ class Text extends Field implements RenderElement {
 			'small'   => 'small-text',
 			'regular' => 'regular-text',
 		];
-		$field_size = isset( $this->option['input_size'] ) ? $this->option['input_size'] : '';
+		$field_size = $this->option['input_size'] ?? '';
 
 		if ( isset( $classes[ $field_size ] ) ) {
 			return $classes[ $field_size ];
@@ -86,6 +86,6 @@ class Text extends Field implements RenderElement {
 	 * @return string
 	 */
 	protected function get_type(): string {
-		return isset( $this->option['input_type'] ) ? $this->option['input_type'] : 'text';
+		return $this->option['input_type'] ?? 'text';
 	}
 }

--- a/src/Admin/Fields/Textarea.php
+++ b/src/Admin/Fields/Textarea.php
@@ -16,7 +16,7 @@ class Textarea extends Field implements RenderElement {
 	/**
 	 * Render HTML.
 	 */
-	public function render() {
+	public function render(): void {
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		printf(

--- a/src/Admin/RenderElement.php
+++ b/src/Admin/RenderElement.php
@@ -14,7 +14,7 @@ interface RenderElement {
 	/**
 	 * Render function.
 	 *
-	 * @return string Rendered Element.
+	 * @return void
 	 */
-	public function render();
+	public function render(): void;
 }

--- a/src/Admin/Section.php
+++ b/src/Admin/Section.php
@@ -9,12 +9,12 @@ namespace AntispamBee\Admin;
 
 use AntispamBee\Admin\Fields\Checkbox;
 use AntispamBee\Admin\Fields\CheckboxGroup;
+use AntispamBee\Admin\Fields\Field;
 use AntispamBee\Admin\Fields\Inline;
 use AntispamBee\Admin\Fields\Select;
 use AntispamBee\Admin\Fields\Text;
 use AntispamBee\Admin\Fields\Textarea;
 use AntispamBee\Interfaces\Controllable;
-use Exception;
 
 /**
  * Sections for admin.
@@ -64,7 +64,7 @@ class Section {
 	 * @param string      $description Description of the tab.
 	 * @param string|null $type Item type (e.g. comment, trackback).
 	 */
-	public function __construct( $slug, $title, $description = '', $type = null ) {
+	public function __construct( string $slug, string $title, string $description = '', string $type = null ) {
 		$this->slug        = $slug;
 		$this->title       = $title;
 		$this->description = $description;
@@ -77,7 +77,7 @@ class Section {
 	 * @param array|null $controllables List of controllable items to add.
 	 * @return void
 	 */
-	public function add_controllables( $controllables ) {
+	public function add_controllables( ?array $controllables ): void {
 		if ( ! empty( $controllables ) ) {
 			$this->generate_fields( $controllables );
 		}
@@ -89,7 +89,7 @@ class Section {
 	 * @param Controllable[] $controllables List of controllable items to add.
 	 * @return void
 	 */
-	private function generate_fields( $controllables ) {
+	private function generate_fields( array $controllables ): void {
 		foreach ( $controllables as $controllable ) {
 			$label       = $controllable::get_label();
 			$description = $controllable::get_description();
@@ -127,11 +127,11 @@ class Section {
 	/**
 	 * Generate field for a controllable item's option.
 	 *
-	 * @param array        $option       Option name.
-	 * @param Controllable $controllable Controllable item.
+	 * @param array  $option       Option name.
+	 * @param string $controllable Controllable item (class name).
 	 * @return Checkbox|CheckboxGroup|Inline|Select|Text|Textarea|null
 	 */
-	private function generate_field( $option, $controllable ) {
+	private function generate_field( array $option, string $controllable ): ?Field {
 		switch ( $option['type'] ) {
 			case 'input':
 				return new Text( $this->type, $option, $controllable );
@@ -156,7 +156,7 @@ class Section {
 	 *
 	 * @return string Name of the field.
 	 */
-	public function get_slug() {
+	public function get_slug(): string {
 		return $this->slug;
 	}
 
@@ -165,7 +165,7 @@ class Section {
 	 *
 	 * @return string Title of the field.
 	 */
-	public function get_title() {
+	public function get_title(): string {
 		return $this->title;
 	}
 
@@ -174,7 +174,7 @@ class Section {
 	 *
 	 * @return string Title of the field.
 	 */
-	public function get_description() {
+	public function get_description(): string {
 		return $this->description;
 	}
 
@@ -183,7 +183,7 @@ class Section {
 	 *
 	 * @return array
 	 */
-	public function get_rows() {
+	public function get_rows(): array {
 		return $this->rows;
 	}
 
@@ -202,7 +202,7 @@ class Section {
 	/**
 	 * Renders the settings section.
 	 */
-	public function render() {
+	public function render(): void {
 		add_settings_section(
 			$this->get_slug(),
 			$this->get_title(),
@@ -231,7 +231,7 @@ class Section {
 	 *
 	 * @param array $row Row of fields.
 	 */
-	protected function render_row_fields( $row ) {
+	protected function render_row_fields( array $row ): void {
 		foreach ( $row['fields'] as $key => $field ) {
 			$field->render();
 

--- a/src/Admin/Section.php
+++ b/src/Admin/Section.php
@@ -109,7 +109,7 @@ class Section {
 			$options = $controllable::get_options();
 			if ( ! empty( $options ) ) {
 				foreach ( $options as $option ) {
-					$valid_for = isset( $option['valid_for'] ) ? $option['valid_for'] : null;
+					$valid_for = $option['valid_for'] ?? null;
 					if ( null !== $valid_for && $this->type !== $valid_for ) {
 						continue;
 					}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -58,7 +58,7 @@ class SettingsPage {
 	/**
 	 * Add Hooks.
 	 */
-	public function init() {
+	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'setup_settings' ] );
 
@@ -69,7 +69,7 @@ class SettingsPage {
 	/**
 	 * Add settings page.
 	 */
-	public function add_menu() {
+	public function add_menu(): void {
 		add_options_page(
 			__( 'Antispam Bee', 'antispam-bee' ),
 			__( 'Antispam Bee', 'antispam-bee' ),
@@ -82,7 +82,7 @@ class SettingsPage {
 	/**
 	 * Setup tabs content.
 	 */
-	public function setup_settings() {
+	public function setup_settings(): void {
 		// Todo: Add a way to build rows and fields with a fluent interface? (Nice-to-have).
 
 		/*
@@ -145,7 +145,7 @@ class SettingsPage {
 	 *
 	 * @return void
 	 */
-	protected function populate_tabs() {
+	protected function populate_tabs(): void {
 		$type = $this->active_tab;
 
 		$data = [];
@@ -193,7 +193,7 @@ class SettingsPage {
 	/**
 	 * Settings page content.
 	 */
-	public function options_page() {
+	public function options_page(): void {
 		?>
 		<div class="wrap" id="ab_main">
 			<h1><?php esc_html_e( 'Antispam Bee', 'antispam-bee' ); ?></h1>

--- a/src/Admin/Tab.php
+++ b/src/Admin/Tab.php
@@ -39,7 +39,7 @@ class Tab {
 	 * @param string    $title Title for tab.
 	 * @param Section[] $sections Sections object array.
 	 */
-	public function __construct( $slug, $title, $sections = [] ) {
+	public function __construct( string $slug, string $title, array $sections = [] ) {
 		$this->slug     = $slug;
 		$this->title    = $title;
 		$this->sections = $sections;
@@ -50,7 +50,7 @@ class Tab {
 	 *
 	 * @return string Name of the field.
 	 */
-	public function get_slug() {
+	public function get_slug(): string {
 		return $this->slug;
 	}
 
@@ -59,7 +59,7 @@ class Tab {
 	 *
 	 * @return string Title of the field.
 	 */
-	public function get_title() {
+	public function get_title(): string {
 		return $this->title;
 	}
 
@@ -68,7 +68,7 @@ class Tab {
 	 *
 	 * @return Section[]
 	 */
-	public function get_sections() {
+	public function get_sections(): array {
 		return $this->sections;
 	}
 
@@ -78,7 +78,7 @@ class Tab {
 	 * @param Section $section Section to add.
 	 * @return void
 	 */
-	public function add_section( Section $section ) {
+	public function add_section( Section $section ): void {
 		$this->sections[] = $section;
 	}
 }

--- a/src/Crons/DeleteSpamCron.php
+++ b/src/Crons/DeleteSpamCron.php
@@ -22,7 +22,7 @@ class DeleteSpamCron {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_action(
 			'update_option_' . Settings::OPTION_NAME,
 			[ __CLASS__, 'maybe_change_cron_state' ]
@@ -39,7 +39,7 @@ class DeleteSpamCron {
 	 *
 	 * @return void
 	 */
-	public static function maybe_change_cron_state() {
+	public static function maybe_change_cron_state(): void {
 		if ( ! Settings::get_option( 'delete_spam_cronjob_enabled' ) ) {
 			self::unregister();
 
@@ -54,7 +54,7 @@ class DeleteSpamCron {
 	 *
 	 * @return void
 	 */
-	public static function register() {
+	public static function register(): void {
 		if ( ! wp_next_scheduled( self::CRONJOB_NAME ) ) {
 			wp_schedule_event(
 				time(),
@@ -69,7 +69,7 @@ class DeleteSpamCron {
 	 *
 	 * @return void
 	 */
-	public static function unregister() {
+	public static function unregister(): void {
 		if ( wp_next_scheduled( self::CRONJOB_NAME ) ) {
 			wp_clear_scheduled_hook( self::CRONJOB_NAME );
 		}
@@ -81,7 +81,7 @@ class DeleteSpamCron {
 	 *
 	 * @return void
 	 */
-	public static function run() {
+	public static function run(): void {
 		if ( ! defined( 'DOING_CRON' ) ) {
 			return;
 		}

--- a/src/GeneralOptions/Base.php
+++ b/src/GeneralOptions/Base.php
@@ -42,7 +42,7 @@ abstract class Base implements Controllable {
 	 *
 	 * @return string
 	 */
-	public static function get_slug() {
+	public static function get_slug(): string {
 		return static::$slug;
 	}
 
@@ -51,9 +51,9 @@ abstract class Base implements Controllable {
 	 *
 	 * {@inheritDoc}
 	 *
-	 * @return mixed
+	 * @return array|null
 	 */
-	public static function get_options() {
+	public static function get_options(): ?array {
 		return null;
 	}
 
@@ -63,7 +63,7 @@ abstract class Base implements Controllable {
 	 * @return void
 	 * @since 3.0.0
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter( 'antispam_bee_general_options', [ static::class, 'add_general_option' ] );
 	}
 
@@ -75,7 +75,7 @@ abstract class Base implements Controllable {
 	 * @return array Updated options.
 	 * @since 3.0.0
 	 */
-	public static function add_general_option( $options ) {
+	public static function add_general_option( array $options ): array {
 		$options[] = static::class;
 
 		return $options;
@@ -88,7 +88,7 @@ abstract class Base implements Controllable {
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( $type = 'general' ) {
+	public static function is_active( string $type = 'general' ) {
 		return Settings::get_option( static::get_option_name( 'active' ), $type );
 	}
 
@@ -98,7 +98,7 @@ abstract class Base implements Controllable {
 	 *
 	 * @return bool
 	 */
-	public static function only_print_custom_options() {
+	public static function only_print_custom_options(): bool {
 		return static::$only_custom_options;
 	}
 
@@ -107,7 +107,7 @@ abstract class Base implements Controllable {
 	 *
 	 * @return string[]
 	 */
-	public static function get_supported_types() {
+	public static function get_supported_types(): array {
 		return [ 'general' ];
 	}
 
@@ -116,7 +116,7 @@ abstract class Base implements Controllable {
 	 *
 	 * @return string
 	 */
-	public static function get_type() {
+	public static function get_type(): string {
 		return static::$type;
 	}
 
@@ -127,7 +127,7 @@ abstract class Base implements Controllable {
 	 * @param string $name Name suffix.
 	 * @return string Corresponding option name
 	 */
-	public static function get_option_name( $name ) {
+	public static function get_option_name( string $name ): string {
 		$type        = static::get_type();
 		$slug        = static::get_slug();
 		$option_name = "{$type}_{$slug}_{$name}";

--- a/src/GeneralOptions/DeleteOldSpam.php
+++ b/src/GeneralOptions/DeleteOldSpam.php
@@ -27,7 +27,7 @@ class DeleteOldSpam extends Base {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Delete old spam', 'antispam-bee' );
 	}
 
@@ -36,7 +36,7 @@ class DeleteOldSpam extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return null;
 	}
 
@@ -45,7 +45,7 @@ class DeleteOldSpam extends Base {
 	 *
 	 * @return null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return null;
 	}
 
@@ -54,9 +54,9 @@ class DeleteOldSpam extends Base {
 	 *
 	 * {@inheritDoc}
 	 *
-	 * @return array
+	 * @return array|null
 	 */
-	public static function get_options() {
+	public static function get_options(): array {
 		return [
 			[
 				'type'        => 'inline',

--- a/src/GeneralOptions/IgnoreLinkbacks.php
+++ b/src/GeneralOptions/IgnoreLinkbacks.php
@@ -24,7 +24,7 @@ class IgnoreLinkbacks extends Base {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Linkbacks', 'antispam-bee' );
 	}
 
@@ -33,7 +33,7 @@ class IgnoreLinkbacks extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Do not check linkbacks (pingbacks, trackbacks)', 'antispam-bee' );
 	}
 
@@ -42,7 +42,7 @@ class IgnoreLinkbacks extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'No spam check for link notifications', 'antispam-bee' );
 	}
 }

--- a/src/GeneralOptions/Statistics.php
+++ b/src/GeneralOptions/Statistics.php
@@ -24,7 +24,7 @@ class Statistics extends Base {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Statistics', 'antispam-bee' );
 	}
 
@@ -33,7 +33,7 @@ class Statistics extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return esc_html__( 'Spam counter on the dashboard', 'antispam-bee' );
 	}
 
@@ -42,7 +42,7 @@ class Statistics extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return esc_html__( 'Amount of identified spam comments', 'antispam-bee' );
 	}
 }

--- a/src/GeneralOptions/Uninstall.php
+++ b/src/GeneralOptions/Uninstall.php
@@ -24,7 +24,7 @@ class Uninstall extends Base {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Uninstall', 'antispam-bee' );
 	}
 
@@ -33,7 +33,7 @@ class Uninstall extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Delete Antispam Bee data when uninstalling', 'antispam-bee' );
 	}
 
@@ -42,7 +42,7 @@ class Uninstall extends Base {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'If checked, you will delete all data Antispam Bee creates, when uninstalling the plugin.', 'antispam-bee' );
 	}
 }

--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -22,7 +22,7 @@ class Comment extends Reaction {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_action(
 			'init',
 			function () {
@@ -42,7 +42,7 @@ class Comment extends Reaction {
 	 * @param array $comment Comment to process.
 	 * @return array Processed comment.
 	 */
-	public static function process( $comment ) {
+	public static function process( array $comment ): array {
 		/**
 		 * Filter processable comment types.
 		 *

--- a/src/Handlers/GeneralOptions.php
+++ b/src/Handlers/GeneralOptions.php
@@ -20,11 +20,11 @@ class GeneralOptions {
 	protected $type;
 
 	/**
-	 * Constuctor.
+	 * Constructor.
 	 *
 	 * @param string $type Option type.
 	 */
-	public function __construct( $type ) {
+	public function __construct( string $type ) {
 		$this->type = $type;
 	}
 
@@ -34,7 +34,7 @@ class GeneralOptions {
 	 * @param string $type Option type.
 	 * @return array List of controllable items.
 	 */
-	public static function get_controllables( $type = 'general' ) {
+	public static function get_controllables( string $type = 'general' ): array {
 		if ( 'general' !== $type ) {
 			return [];
 		}

--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -29,7 +29,7 @@ class Linkback extends Reaction {
 	 * @param array $linkback Linkback to process.
 	 * @return array Processed linkback.
 	 */
-	public static function process( $linkback ) {
+	public static function process( array $linkback ): array {
 		if ( ! ContentTypeHelper::reaction_is_one_of( $linkback, [ 'pingback', 'trackback', 'pings' ], 'linkback' ) ) {
 			return $linkback;
 		}

--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -40,6 +40,6 @@ class Linkback extends Reaction {
 
 		$linkback['comment_author_IP'] = IpHelper::get_client_ip();
 
-		parent::process( $linkback );
+		return parent::process( $linkback );
 	}
 }

--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -19,7 +19,7 @@ class PluginStateChangeHandler {
 	/**
 	 * Activate callback.
 	 */
-	public static function activate() {
+	public static function activate(): void {
 		if ( ! is_blog_installed() ) {
 			return;
 		}
@@ -31,7 +31,7 @@ class PluginStateChangeHandler {
 	/**
 	 * Deactivate callback.
 	 */
-	public static function deactivate() {
+	public static function deactivate(): void {
 		DeleteSpamCron::unregister();
 		flush_rewrite_rules();
 	}
@@ -39,7 +39,7 @@ class PluginStateChangeHandler {
 	/**
 	 * Uninstall callback.
 	 */
-	public static function uninstall() {
+	public static function uninstall(): void {
 		if ( ! is_multisite() ) {
 			self::maybe_remove_antispam_bee_data();
 			return;
@@ -66,7 +66,7 @@ class PluginStateChangeHandler {
 	 *
 	 * @return void
 	 */
-	private static function maybe_remove_antispam_bee_data() {
+	private static function maybe_remove_antispam_bee_data(): void {
 		if ( ! Uninstall::is_active() ) {
 			return;
 		}
@@ -84,7 +84,7 @@ class PluginStateChangeHandler {
 	/**
 	 * Initialization of the cronjobs.
 	 */
-	public static function init_scheduled_hook() {
+	public static function init_scheduled_hook(): void {
 		DeleteSpamCron::maybe_change_cron_state();
 	}
 }

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -51,7 +51,7 @@ class PluginUpdate {
 	/**
 	 * Runs after Antispam Bee was upgraded.
 	 */
-	public static function maybe_run_plugin_updated_logic() {
+	public static function maybe_run_plugin_updated_logic(): void {
 		if ( self::db_version_is_current() || self::$db_update_triggered ) {
 			return;
 		}
@@ -62,7 +62,7 @@ class PluginUpdate {
 	/**
 	 * Makes database changes, if needed.
 	 */
-	private static function maybe_update_database() {
+	private static function maybe_update_database(): void {
 		// Prevent further update triggers during the same request that run before the DB version is updated.
 		self::$db_update_triggered = true;
 
@@ -190,7 +190,7 @@ class PluginUpdate {
 	 *
 	 * @return array Converted array of selected options.
 	 */
-	private static function convert_multiselect_values( $values, $mapping = [] ) {
+	private static function convert_multiselect_values( array $values, array $mapping = [] ): array {
 		if ( ! is_array( $values ) || empty( $values ) ) {
 			return $values;
 		}
@@ -212,7 +212,7 @@ class PluginUpdate {
 	 *
 	 * @return string
 	 */
-	private static function get_plugin_version() {
+	private static function get_plugin_version(): string {
 		$meta = get_file_data( MAIN_PLUGIN_FILE, [ 'Version' => 'Version' ] );
 
 		return $meta['Version'];
@@ -223,7 +223,7 @@ class PluginUpdate {
 	 *
 	 * @return bool
 	 */
-	private static function db_version_is_current() {
+	private static function db_version_is_current(): bool {
 		if ( ! is_null( self::$db_version_is_current ) ) {
 			return self::$db_version_is_current;
 		}

--- a/src/Handlers/PostProcessors.php
+++ b/src/Handlers/PostProcessors.php
@@ -22,9 +22,9 @@ class PostProcessors {
 	 * @param array  $item          Item to process.
 	 * @param array  $reasons       List of reasons.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
-	public static function apply( $reaction_type, $item, $reasons = [] ) {
+	public static function apply( string $reaction_type, array $item, array $reasons = [] ): array {
 		$post_processors = self::get( $reaction_type, true );
 
 		$item['asb_reasons']   = $reasons;
@@ -55,7 +55,7 @@ class PostProcessors {
 	 * @param bool        $only_active   Get only active post processors.
 	 * @return array List of suitable post processors.
 	 */
-	public static function get( $reaction_type = null, $only_active = false ) {
+	public static function get( ?string $reaction_type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
 				'reaction_type' => $reaction_type,
@@ -68,11 +68,11 @@ class PostProcessors {
 	/**
 	 * Get controllable items.
 	 *
-	 * @param string $reaction_type Reaction type.
-	 * @param bool   $only_active   Get only active items.
+	 * @param string|null $reaction_type Reaction type.
+	 * @param bool        $only_active   Get only active items.
 	 * @return array List of suitable controllables.
 	 */
-	public static function get_controllables( $reaction_type = null, $only_active = false ) {
+	public static function get_controllables( ?string $reaction_type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
 				'reaction_type' => $reaction_type,
@@ -88,7 +88,7 @@ class PostProcessors {
 	 * @param array $options Filter options.
 	 * @return array List of filtered elements.
 	 */
-	private static function filter( $options ) {
+	private static function filter( array $options ): array {
 		return ComponentsHelper::filter( apply_filters( 'antispam_bee_post_processors', [] ), $options );
 	}
 }

--- a/src/Handlers/Reaction.php
+++ b/src/Handlers/Reaction.php
@@ -26,7 +26,7 @@ abstract class Reaction {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter(
 			'preprocess_comment',
 			[ static::class, 'process' ],
@@ -48,7 +48,7 @@ abstract class Reaction {
 	 *
 	 * @return void
 	 */
-	public static function always_init() {
+	public static function always_init(): void {
 		add_action( 'transition_comment_status', [ __CLASS__, 'handle_comment_status_changes' ], 10, 3 );
 	}
 
@@ -58,7 +58,7 @@ abstract class Reaction {
 	 * @param array $reaction Reaction to process.
 	 * @return array Processed reaction.
 	 */
-	public static function process( $reaction ) {
+	public static function process( array $reaction ): array {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		$rules   = new Rules( static::$type );
 		$is_spam = $rules->apply( $reaction );
@@ -77,7 +77,7 @@ abstract class Reaction {
 	 * @param Rules $rules    Ruleset to apply.
 	 * @return array|never-return Handled reaction (or die, if item was deleted)
 	 */
-	protected static function handle_spam( $reaction, $rules ) {
+	protected static function handle_spam( array $reaction, Rules $rules ) {
 		$item = PostProcessors::apply( static::$type, $reaction, $rules->get_spam_reasons() );
 		if ( ! isset( $item['asb_marked_as_delete'] ) ) {
 			add_filter(
@@ -101,7 +101,7 @@ abstract class Reaction {
 	 * @param int|string $old_status The old comment status.
 	 * @param WP_Comment $comment    Comment object.
 	 */
-	public static function handle_comment_status_changes( $new_status, $old_status, $comment ) {
+	public static function handle_comment_status_changes( $new_status, $old_status, WP_Comment $comment ): void {
 		if ( 'spam' === $new_status && 'spam' !== $old_status ) {
 			update_comment_meta( $comment->comment_ID, 'antispam_bee_reason', 'asb-marked-manually' );
 			return;

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -44,7 +44,7 @@ class Rules {
 	 *
 	 * @param string $type Item type.
 	 */
-	public function __construct( $type ) {
+	public function __construct( string $type ) {
 		$this->type = $type;
 	}
 
@@ -54,7 +54,7 @@ class Rules {
 	 * @param array $item Item to apply rules to.
 	 * @return bool Item identified as spam.
 	 */
-	public function apply( $item ) {
+	public function apply( array $item ): bool {
 		$item['reaction_type'] = $this->type;
 		$rules                 = self::get( $this->type, true );
 
@@ -104,11 +104,11 @@ class Rules {
 	/**
 	 * Get applicable rules.
 	 *
-	 * @param string $type        Reaction type.
-	 * @param bool   $only_active Get only active rules.
+	 * @param string|null $type        Reaction type.
+	 * @param bool        $only_active Get only active rules.
 	 * @return array List of applicable rules.
 	 */
-	public static function get( $type = null, $only_active = false ) {
+	public static function get( ?string $type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
 				'reaction_type' => $type,
@@ -121,11 +121,11 @@ class Rules {
 	/**
 	 * Get controllable items.
 	 *
-	 * @param string $type        Reaction type.
-	 * @param bool   $only_active Get only active items.
+	 * @param string|null $type        Reaction type.
+	 * @param bool        $only_active Get only active items.
 	 * @return array List of suitable controllables.
 	 */
-	public static function get_controllables( $type = null, $only_active = false ) {
+	public static function get_controllables( ?string $type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
 				'reaction_type' => $type,
@@ -142,7 +142,7 @@ class Rules {
 	 * @param bool        $only_active Get only active rules.
 	 * @return array List of applicable rules.
 	 */
-	public static function get_spam_rules( $type = null, $only_active = false ) {
+	public static function get_spam_rules( ?string $type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
 				'reaction_type' => $type,
@@ -158,7 +158,7 @@ class Rules {
 	 * @param array $options Filter options.
 	 * @return array List of filtered elements.
 	 */
-	private static function filter( $options ) {
+	private static function filter( array $options ): array {
 		// Todo: discuss if our rules should be filterable or not.
 		return ComponentsHelper::filter( apply_filters( 'antispam_bee_rules', [] ), $options );
 	}
@@ -168,7 +168,7 @@ class Rules {
 	 *
 	 * @return array
 	 */
-	public function get_spam_reasons() {
+	public function get_spam_reasons(): array {
 		return $this->spam_reasons;
 	}
 
@@ -177,7 +177,7 @@ class Rules {
 	 *
 	 * @return array
 	 */
-	public function get_no_spam_reasons() {
+	public function get_no_spam_reasons(): array {
 		return $this->no_spam_reasons;
 	}
 }

--- a/src/Helpers/ComponentsHelper.php
+++ b/src/Helpers/ComponentsHelper.php
@@ -29,7 +29,7 @@ class ComponentsHelper {
 	 * }
 	 * @return array Filtered list.
 	 */
-	public static function filter( $components, $options ) {
+	public static function filter( array $components, array $options ): array {
 		$reaction_type = isset( $options['reaction_type'] ) ? $options['reaction_type'] : null;
 		$only_active   = isset( $options['only_active'] ) ? $options['only_active'] : false;
 

--- a/src/Helpers/ComponentsHelper.php
+++ b/src/Helpers/ComponentsHelper.php
@@ -23,9 +23,10 @@ class ComponentsHelper {
 	 * @param array $options {
 	 *     Filter options.
 	 *
-	 *     @type string $reaction_type   Reaction type (e.g. "comment").
-	 *     @type bool   $only_active     Only active components.
-	 *     @type bool   $is_controllable Is controllable type.
+	 *     @type string       $reaction_type   Reaction type (e.g. "comment").
+	 *     @type bool         $only_active     Only active components.
+	 *     @type bool         $is_controllable Is controllable type.
+	 *     @type string|array $implements      Interface(s) that should be implemented.
 	 * }
 	 * @return array Filtered list.
 	 */
@@ -40,10 +41,10 @@ class ComponentsHelper {
 
 				if ( is_string( $implements ) ) {
 					$implements_interfaces = InterfaceHelper::class_implements_interface( $component, $implements );
-				}
-
-				if ( is_array( $implements ) ) {
+				} elseif ( is_array( $implements ) ) {
 					$implements_interfaces = InterfaceHelper::class_implements_interfaces( $component, $implements );
+				} else {
+					$implements_interfaces = false;
 				}
 
 				if ( ! $implements_interfaces ) {

--- a/src/Helpers/ComponentsHelper.php
+++ b/src/Helpers/ComponentsHelper.php
@@ -31,8 +31,8 @@ class ComponentsHelper {
 	 * @return array Filtered list.
 	 */
 	public static function filter( array $components, array $options ): array {
-		$reaction_type = isset( $options['reaction_type'] ) ? $options['reaction_type'] : null;
-		$only_active   = isset( $options['only_active'] ) ? $options['only_active'] : false;
+		$reaction_type = $options['reaction_type'] ?? null;
+		$only_active   = $options['only_active'] ?? false;
 
 		$filtered_components = [];
 		foreach ( $components as $component ) {

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -22,7 +22,7 @@ class ContentTypeHelper {
 	 * @param string $item_type Type name.
 	 * @return string Readable type name.
 	 */
-	public static function get_type_name( $item_type ) {
+	public static function get_type_name( string $item_type ): string {
 		$type_names = [
 			self::GENERAL_TYPE  => __( 'General', 'antispam-bee' ),
 			self::COMMENT_TYPE  => __( 'Comment', 'antispam-bee' ),
@@ -44,7 +44,7 @@ class ContentTypeHelper {
 	 *
 	 * @return bool
 	 */
-	public static function reaction_is_one_of( $reaction, $reaction_types, $context = '' ) {
+	public static function reaction_is_one_of( array $reaction, array $reaction_types, string $context = '' ): bool {
 		// This `comment_type` is set from WordPress.
 		$reaction_type = $reaction['comment_type'] ?? '';
 

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -32,7 +32,7 @@ class ContentTypeHelper {
 		// Todo: Write a doc how to add custom types.
 		$type_names = array_merge( apply_filters( 'antispam_bee_item_types', [] ), $type_names );
 
-		return isset( $type_names[ $item_type ] ) ? $type_names[ $item_type ] : $item_type;
+		return $type_names[ $item_type ] ?? $item_type;
 	}
 
 	/**

--- a/src/Helpers/DashboardHelper.php
+++ b/src/Helpers/DashboardHelper.php
@@ -19,7 +19,7 @@ class DashboardHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_dashboard_page() {
+	public static function is_dashboard_page(): bool {
 		return ( empty( $GLOBALS['pagenow'] ) || ( ! empty( $GLOBALS['pagenow'] ) && 'index.php' === $GLOBALS['pagenow'] ) );
 	}
 
@@ -28,7 +28,7 @@ class DashboardHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_edit_comments_page() {
+	public static function is_edit_comments_page(): bool {
 		return ( ! empty( $GLOBALS['pagenow'] ) && 'edit-comments.php' === $GLOBALS['pagenow'] );
 	}
 
@@ -37,7 +37,7 @@ class DashboardHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_edit_spam_comments_page() {
+	public static function is_edit_spam_comments_page(): bool {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return self::is_edit_comments_page() && ! empty( $_GET['comment_status'] ) && 'spam' === $_GET['comment_status'];
 	}

--- a/src/Helpers/DataHelper.php
+++ b/src/Helpers/DataHelper.php
@@ -19,7 +19,7 @@ class DataHelper {
 	 * @param array $data Data to filter.
 	 * @return array Data elements with matching keys.
 	 */
-	public static function get_values_by_keys( $keys, $data ) {
+	public static function get_values_by_keys( array $keys, array $data ): array {
 		$results = [];
 		foreach ( $keys as $key ) {
 			if ( isset( $data[ $key ] ) ) {
@@ -37,7 +37,7 @@ class DataHelper {
 	 * @param array    $data    Data to filter.
 	 * @return array Data elements with matching keys.
 	 */
-	public static function get_values_where_key_contains( $substrs, $data ) {
+	public static function get_values_where_key_contains( array $substrs, array $data ): array {
 		$results = [];
 		foreach ( $data as $key => $value ) {
 			foreach ( $substrs as $substr ) {
@@ -57,7 +57,7 @@ class DataHelper {
 	 * @param string $component URL component (default: "host").
 	 * @return string URL component.
 	 */
-	public static function parse_url( $url, $component = 'host' ) {
+	public static function parse_url( string $url, string $component = 'host' ): string {
 		$parts = wp_parse_url( $url );
 
 		return ( is_array( $parts ) && isset( $parts[ $component ] ) ) ? $parts[ $component ] : '';

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -23,7 +23,7 @@ class DebugMode {
 	 *
 	 * @return bool
 	 */
-	public static function enabled() {
+	public static function enabled(): bool {
 		if ( null === static::$debug_mode_enabled ) {
 			static::$debug_mode_enabled = defined( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED' ) ? \ANTISPAM_BEE_DEBUG_MODE_ENABLED : false;
 		}
@@ -37,7 +37,7 @@ class DebugMode {
 	 * @param string $message Log message.
 	 * @return void
 	 */
-	public static function log( string $message ) {
+	public static function log( string $message ): void {
 		if ( ! static::enabled() ) {
 			return;
 		}

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -37,7 +37,7 @@ class Honeypot {
 	 *
 	 * @return string
 	 */
-	public static function inject( $markup, $options ) {
+	public static function inject( string $markup, array $options ): string {
 		$dom = new DOMDocument();
 		$dom->loadHTML( $markup, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		$xpath = new DOMXPath( $dom );
@@ -131,7 +131,7 @@ class Honeypot {
 	 * @return string
 	 * @since 2.10.0 Modify secret generation because `always_allowed` option no longer exists
 	 */
-	public static function get_secret_id_for_post() {
+	public static function get_secret_id_for_post(): string {
 		$secret = substr( sha1( md5( 'comment-id' . self::get_salt() ) ), 0, 10 );
 
 		return self::ensure_secret_starts_with_letter( $secret );
@@ -143,7 +143,7 @@ class Honeypot {
 	 * @return string
 	 * @since 2.10.0 Modify secret generation because `always_allowed` option no longer exists
 	 */
-	public static function get_secret_name_for_post() {
+	public static function get_secret_name_for_post(): string {
 		$secret = substr( sha1( md5( 'comment-id' . self::get_salt() ) ), 0, 10 );
 
 		return self::ensure_secret_starts_with_letter( $secret );
@@ -156,7 +156,7 @@ class Honeypot {
 	 *
 	 * @return string
 	 */
-	public static function ensure_secret_starts_with_letter( $secret ) {
+	public static function ensure_secret_starts_with_letter( string $secret ): string {
 		$first_char = substr( $secret, 0, 1 );
 		if ( is_numeric( $first_char ) ) {
 			return chr( $first_char + 97 ) . substr( $secret, 1 );
@@ -173,7 +173,7 @@ class Honeypot {
 	 *
 	 * @return bool
 	 */
-	private static function is_amp() {
+	private static function is_amp(): bool {
 		return ( function_exists( 'amp_is_request' ) && amp_is_request() ) || ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() );
 	}
 
@@ -182,7 +182,7 @@ class Honeypot {
 	 *
 	 * @return string
 	 */
-	private static function get_salt() {
+	private static function get_salt(): string {
 		$salt = defined( 'NONCE_SALT' ) ? NONCE_SALT : ABSPATH;
 
 		return substr( sha1( $salt ), 0, 10 );

--- a/src/Helpers/InterfaceHelper.php
+++ b/src/Helpers/InterfaceHelper.php
@@ -34,7 +34,7 @@ class InterfaceHelper {
 	 * @return bool
 	 */
 	public static function class_implements_interfaces( string $class_name, array $interfaces ): bool {
-		if ( ! is_string( $class_name ) || ! class_exists( $class_name ) ) {
+		if ( ! class_exists( $class_name ) ) {
 			return false;
 		}
 

--- a/src/Helpers/InterfaceHelper.php
+++ b/src/Helpers/InterfaceHelper.php
@@ -21,7 +21,7 @@ class InterfaceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function class_implements_interface( $class_name, $interface_name ) {
+	public static function class_implements_interface( string $class_name, string $interface_name ): bool {
 		return self::class_implements_interfaces( $class_name, [ $interface_name ] );
 	}
 
@@ -33,7 +33,7 @@ class InterfaceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function class_implements_interfaces( $class_name, $interfaces ) {
+	public static function class_implements_interfaces( string $class_name, array $interfaces ): bool {
 		if ( ! is_string( $class_name ) || ! class_exists( $class_name ) ) {
 			return false;
 		}

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -17,7 +17,7 @@ class IpHelper {
 	 *
 	 * @return string Client IP
 	 */
-	public static function get_client_ip() {
+	public static function get_client_ip(): string {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// Sanitization of $ip takes place further down.
 		$ip = '';
@@ -54,7 +54,7 @@ class IpHelper {
 	 *
 	 * @return string The sanitized IP or an empty string.
 	 */
-	private static function sanitize_ip( $raw_ip ) {
+	private static function sanitize_ip( string $raw_ip ): string {
 		if ( strpos( $raw_ip, ',' ) !== false ) {
 			$ips    = explode( ',', $raw_ip );
 			$raw_ip = trim( $ips[0] );
@@ -81,7 +81,7 @@ class IpHelper {
 	 * @return  string     Anonymous IP.
 	 * @since   2.5.1
 	 */
-	public static function anonymize_ip( $ip ) {
+	public static function anonymize_ip( string $ip ): string {
 		preg_match( '/\w+([\.:])\w+/', $ip, $matches );
 		$ip_start = $matches[0];
 		if ( '.' === $matches[1] ) {

--- a/src/Helpers/LangHelper.php
+++ b/src/Helpers/LangHelper.php
@@ -22,7 +22,7 @@ class LangHelper {
 	 * @return string             Mapped ISO code
 	 * @since   2.9.0
 	 */
-	public static function map( $franc_code ) {
+	public static function map( string $franc_code ): string {
 		$codes = [
 			'zha' => 'za',
 			'zho' => 'zh',

--- a/src/Helpers/Sanitize.php
+++ b/src/Helpers/Sanitize.php
@@ -27,7 +27,7 @@ class Sanitize {
 	 * @return array Intersection of values and valid options.
 	 * @since 3.0.0
 	 */
-	public static function checkbox_group( $values, array $valid_options ) {
+	public static function checkbox_group( $values, array $valid_options ): array {
 		if ( ! is_array( $values ) ) {
 			return [];
 		}
@@ -38,12 +38,12 @@ class Sanitize {
 	/**
 	 * Sanitizes an array of strings to match ISO format.
 	 *
-	 * @param array $codes List of potential ISO codes to sanitize.
+	 * @param mixed $codes List of potential ISO codes to sanitize.
 	 *
 	 * @return array Sanitized ISO codes.
 	 * @since 3.0.0
 	 */
-	public static function iso_codes( $codes ) {
+	public static function iso_codes( $codes ): array {
 		if ( ! is_array( $codes ) ) {
 			return [];
 		}
@@ -69,7 +69,7 @@ class Sanitize {
 	 * @param mixed $value Raw checkbox value.
 	 * @return string|null Sanitized value.
 	 */
-	public static function checkbox( $value ) {
+	public static function checkbox( $value ): ?string {
 		if ( 'on' === $value ) {
 			return $value;
 		}
@@ -81,9 +81,9 @@ class Sanitize {
 	 * Sanitize options.
 	 *
 	 * @param array $options Options to sanitize.
-	 * @return array|string Sanitized options.
+	 * @return array Sanitized options.
 	 */
-	public static function sanitize_options( $options ) {
+	public static function sanitize_options( array $options ): array {
 		$current_options = Settings::get_options();
 
 		if ( empty( $_GET['tab'] ) ) {
@@ -107,7 +107,7 @@ class Sanitize {
 	 * @param string $tab     Settings tab.
 	 * @return array Sanitized options.
 	 */
-	private static function sanitize_controllables( $options, $tab ) {
+	private static function sanitize_controllables( array $options, string $tab ): array {
 		$controllables = array_merge(
 			GeneralOptions::get_controllables( $tab ),
 			Rules::get_controllables( $tab ),
@@ -149,13 +149,13 @@ class Sanitize {
 	/**
 	 * Call a sanitization callback.
 	 *
-	 * @param array        $controllable_option Controllable options.
-	 * @param array        $options             Options.
-	 * @param string       $tab                 Settings tab.
-	 * @param Controllable $controllable        Controllable element.
+	 * @param array  $controllable_option Controllable options.
+	 * @param array  $options             Options.
+	 * @param string $tab                 Settings tab.
+	 * @param string $controllable        Controllable element (class name).
 	 * @return void
 	 */
-	private static function call_sanitize_callback( $controllable_option, &$options, $tab, $controllable ) {
+	private static function call_sanitize_callback( array $controllable_option, array &$options, string $tab, string $controllable ): void {
 		if ( ! isset( $controllable_option['sanitize'] ) ) {
 			return;
 		}

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -114,10 +114,6 @@ class Settings {
 	 * @return null|mixed Value at given path, if present.
 	 */
 	public static function get_array_value_by_path( string $path, array $array ) {
-		if ( ! is_array( $array ) ) {
-			return null;
-		}
-
 		$path_array = self::get_path_parts( $path );
 		if ( empty( $path_array ) ) {
 			return null;

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -47,7 +47,7 @@ class Settings {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_action(
 			'update_option_' . self::OPTION_NAME,
 			[ __CLASS__, 'update_cache' ],
@@ -63,16 +63,16 @@ class Settings {
 	 * @param mixed $value     The new option value.
 	 * @return void
 	 */
-	public static function update_cache( $old_value, $value ) {
+	public static function update_cache( $old_value, $value ): void {
 		wp_cache_set( self::OPTION_NAME, $value );
 	}
 
 	/**
 	 * Get all plugin options
 	 *
-	 * @return  array $options Array with option fields.
+	 * @return array $options Array with option fields.
 	 */
-	public static function get_options() {
+	public static function get_options(): array {
 		PluginUpdate::maybe_run_plugin_updated_logic();
 		$options = wp_cache_get( self::OPTION_NAME );
 		if ( $options ) {
@@ -91,9 +91,9 @@ class Settings {
 	 * @param string $option_name Option name.
 	 * @param string $type The type.
 	 *
-	 * @return  mixed Field value.
+	 * @return mixed Field value.
 	 */
-	public static function get_option( $option_name, $type = 'general' ) {
+	public static function get_option( string $option_name, string $type = 'general' ) {
 		$options = self::get_options();
 
 		$value_path = "$option_name";
@@ -113,7 +113,7 @@ class Settings {
 	 *
 	 * @return null|mixed Value at given path, if present.
 	 */
-	public static function get_array_value_by_path( $path, $array ) {
+	public static function get_array_value_by_path( string $path, array $array ) {
 		if ( ! is_array( $array ) ) {
 			return null;
 		}
@@ -145,7 +145,7 @@ class Settings {
 	 *
 	 * @since  0.1
 	 */
-	public static function update_options( $data ) {
+	public static function update_options( array $data ): void {
 		$options = get_option( self::OPTION_NAME );
 
 		if ( is_array( $options ) ) {
@@ -169,7 +169,7 @@ class Settings {
 	 * @since  0.1
 	 * @since  2.4
 	 */
-	public static function update_option( $field, $value ) {
+	public static function update_option( string $field, $value ): void {
 		self::update_options(
 			[
 				$field => $value,
@@ -188,7 +188,7 @@ class Settings {
 	 *
 	 * @since   2.4.2
 	 */
-	public static function get_key( $array, $key ) {
+	public static function get_key( array $array, string $key ) {
 		if ( empty( $array ) || empty( $key ) || ! isset( $array[ $key ] ) ) {
 			return null;
 		}
@@ -203,7 +203,7 @@ class Settings {
 	 * @param array  $array Array to filter.
 	 * @return void
 	 */
-	public static function remove_array_key_by_path( $path, &$array ) {
+	public static function remove_array_key_by_path( string $path, array &$array ): void {
 		if ( ! is_array( $array ) ) {
 			return;
 		}
@@ -233,7 +233,7 @@ class Settings {
 	 * @param mixed $path Dot-separated path to the wanted value.
 	 * @return string[] Path parts.
 	 */
-	private static function get_path_parts( $path ) {
+	private static function get_path_parts( $path ): array {
 		if ( ! is_string( $path ) ) {
 			return [];
 		}
@@ -254,7 +254,7 @@ class Settings {
 	 * @param array  $options   Options array to process.
 	 * @return void
 	 */
-	public static function set_array_value_by_path( $path, $sanitized, &$options ) {
+	public static function set_array_value_by_path( string $path, $sanitized, array &$options ): void {
 		if ( ! is_array( $options ) ) {
 			return;
 		}

--- a/src/Helpers/SpamReasonTextHelper.php
+++ b/src/Helpers/SpamReasonTextHelper.php
@@ -27,7 +27,7 @@ class SpamReasonTextHelper {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_action( 'init', [ __CLASS__, 'populate' ] );
 	}
 
@@ -36,7 +36,7 @@ class SpamReasonTextHelper {
 	 *
 	 * @return void
 	 */
-	public static function populate() {
+	public static function populate(): void {
 		$rules                 = Rules::get_spam_rules();
 		self::$slug_text_array = [];
 		foreach ( $rules as $rule ) {
@@ -59,7 +59,7 @@ class SpamReasonTextHelper {
 	 *
 	 * @return array Texts for given slugs.
 	 */
-	public static function get_texts_by_slugs( array $slugs ) {
+	public static function get_texts_by_slugs( array $slugs ): array {
 		$texts = [];
 		foreach ( $slugs as $slug ) {
 			$text = self::$slug_text_array[ $slug ] ?? null;

--- a/src/Interfaces/Controllable.php
+++ b/src/Interfaces/Controllable.php
@@ -18,21 +18,21 @@ interface Controllable {
 	 *
 	 * @return string
 	 */
-	public static function get_name();
+	public static function get_name(): string;
 
 	/**
 	 * Get element label (optional).
 	 *
 	 * @return string|null
 	 */
-	public static function get_label();
+	public static function get_label(): ?string;
 
 	/**
 	 * Get element description (optional).
 	 *
 	 * @return string|null
 	 */
-	public static function get_description();
+	public static function get_description(): ?string;
 
 	/**
 	 * First thoughts on how a rule can specify what kind of advanced option it is. If `type` is no callable,
@@ -54,9 +54,9 @@ interface Controllable {
 	 *   ]
 	 * ]
 	 *
-	 * @return mixed
+	 * @return array|null
 	 */
-	public static function get_options();
+	public static function get_options(): ?array;
 
 
 	/**
@@ -66,7 +66,7 @@ interface Controllable {
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( $type );
+	public static function is_active( string $type );
 
 	/**
 	 * Only print custom options?
@@ -74,28 +74,28 @@ interface Controllable {
 	 *
 	 * @return bool
 	 */
-	public static function only_print_custom_options();
+	public static function only_print_custom_options(): bool;
 
 	/**
 	 * Get a list of supported types.
 	 *
 	 * @return string[]
 	 */
-	public static function get_supported_types();
+	public static function get_supported_types(): array;
 
 	/**
 	 * Get type of the controllable.
 	 *
 	 * @return string
 	 */
-	public static function get_type();
+	public static function get_type(): string;
 
 	/**
 	 * Get controllable slug.
 	 *
 	 * @return string
 	 */
-	public static function get_slug();
+	public static function get_slug(): string;
 
 	/**
 	 * Get option name.
@@ -104,5 +104,5 @@ interface Controllable {
 	 * @param string $name Name suffix.
 	 * @return string Corresponding option name
 	 */
-	public static function get_option_name( $name );
+	public static function get_option_name( string $name ): string;
 }

--- a/src/Interfaces/PostProcessor.php
+++ b/src/Interfaces/PostProcessor.php
@@ -15,26 +15,26 @@ interface PostProcessor {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item );
+	public static function process( array $item ): array;
 
 	/**
 	 * Get post processor slug.
 	 *
 	 * @return string The slug.
 	 */
-	public static function get_slug();
+	public static function get_slug(): string;
 
 	/**
 	 * Get a list of supported types.
 	 *
 	 * @return string[]
 	 */
-	public static function get_supported_types();
+	public static function get_supported_types(): array;
 
 	/**
 	 * Does this processor mark am element as deleted?
 	 *
 	 * @return bool
 	 */
-	public static function marks_as_delete();
+	public static function marks_as_delete(): bool;
 }

--- a/src/Interfaces/SpamReason.php
+++ b/src/Interfaces/SpamReason.php
@@ -17,5 +17,5 @@ interface SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text();
+	public static function get_reason_text(): string;
 }

--- a/src/Interfaces/Verifiable.php
+++ b/src/Interfaces/Verifiable.php
@@ -18,7 +18,7 @@ interface Verifiable {
 	 * @param array $item Item to verify.
 	 * @return int Weighted result.
 	 */
-	public static function verify( $item );
+	public static function verify( array $item ): int;
 
 	/**
 	 * Get rule weight.
@@ -26,26 +26,26 @@ interface Verifiable {
 	 *
 	 * @return int Weight factor.
 	 */
-	public static function get_weight();
+	public static function get_weight(): int;
 
 	/**
 	 * Get element slug.
 	 *
 	 * @return string The slug.
 	 */
-	public static function get_slug();
+	public static function get_slug(): string;
 
 	/**
 	 * Get a list of supported types.
 	 *
 	 * @return string[]
 	 */
-	public static function get_supported_types();
+	public static function get_supported_types(): array;
 
 	/**
 	 * It this rule final?
 	 *
 	 * @return bool
 	 */
-	public static function is_final();
+	public static function is_final(): bool;
 }

--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -41,7 +41,7 @@ abstract class Base implements PostProcessor {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter( 'antispam_bee_post_processors', [ static::class, 'add_post_processor' ] );
 	}
 
@@ -52,7 +52,7 @@ abstract class Base implements PostProcessor {
 	 *
 	 * @return PostProcessor[] Updated list of post processors.
 	 */
-	public static function add_post_processor( $post_processors ) {
+	public static function add_post_processor( array $post_processors ): array {
 		$post_processors[] = static::class;
 
 		return $post_processors;
@@ -63,7 +63,7 @@ abstract class Base implements PostProcessor {
 	 *
 	 * @return string The slug.
 	 */
-	public static function get_slug() {
+	public static function get_slug(): string {
 		return static::$slug;
 	}
 
@@ -72,7 +72,7 @@ abstract class Base implements PostProcessor {
 	 *
 	 * @return string[]
 	 */
-	public static function get_supported_types() {
+	public static function get_supported_types(): array {
 		// @todo: add filter
 		return static::$supported_types;
 	}
@@ -82,7 +82,7 @@ abstract class Base implements PostProcessor {
 	 *
 	 * @return bool
 	 */
-	public static function marks_as_delete() {
+	public static function marks_as_delete(): bool {
 		return static::$marks_as_delete;
 	}
 }

--- a/src/PostProcessors/ControllableBase.php
+++ b/src/PostProcessors/ControllableBase.php
@@ -35,7 +35,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( $type ) {
+	public static function is_active( string $type ) {
 		return Settings::get_option( static::get_option_name( 'active' ), $type );
 	}
 
@@ -46,7 +46,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return mixed
 	 */
-	public static function get_options() {
+	public static function get_options(): ?array {
 		return null;
 	}
 
@@ -56,7 +56,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return bool
 	 */
-	public static function only_print_custom_options() {
+	public static function only_print_custom_options(): bool {
 		return static::$only_print_custom_options;
 	}
 
@@ -65,7 +65,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return string
 	 */
-	public static function get_type() {
+	public static function get_type(): string {
 		return static::$type;
 	}
 
@@ -76,7 +76,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 * @param string $name Name suffix.
 	 * @return string Corresponding option name
 	 */
-	public static function get_option_name( $name ) {
+	public static function get_option_name( string $name ): string {
 		$type        = static::get_type();
 		$slug        = static::get_slug();
 		$option_name = "{$type}_{$slug}_{$name}";

--- a/src/PostProcessors/Delete.php
+++ b/src/PostProcessors/Delete.php
@@ -32,7 +32,7 @@ class Delete extends ControllableBase {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		$item['asb_marked_as_delete'] = true;
 
 		return $item;
@@ -43,7 +43,7 @@ class Delete extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Delete spam', 'antispam-bee' );
 	}
 
@@ -52,7 +52,7 @@ class Delete extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Delete detected spam instead of marking.', 'antispam-bee' );
 	}
 
@@ -61,7 +61,7 @@ class Delete extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return null;
 	}
 }

--- a/src/PostProcessors/DeleteForReasons.php
+++ b/src/PostProcessors/DeleteForReasons.php
@@ -36,7 +36,7 @@ class DeleteForReasons extends ControllableBase {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		if ( isset( $item['asb_marked_as_delete'] ) && true === $item['asb_marked_as_delete'] ) {
 			return $item;
 		}
@@ -58,7 +58,7 @@ class DeleteForReasons extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Delete by reasons', 'antispam-bee' );
 	}
 
@@ -67,7 +67,7 @@ class DeleteForReasons extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Delete comments by spam reasons', 'antispam-bee' );
 	}
 
@@ -76,7 +76,7 @@ class DeleteForReasons extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return null;
 	}
 
@@ -88,7 +88,7 @@ class DeleteForReasons extends ControllableBase {
 	 *
 	 * @return array
 	 */
-	public static function get_options() {
+	public static function get_options(): array {
 		$options = [];
 		foreach ( self::get_supported_types() as $type ) {
 			// @todo: disable the reasons checkboxes if the rule is not active.

--- a/src/PostProcessors/SaveReason.php
+++ b/src/PostProcessors/SaveReason.php
@@ -26,7 +26,7 @@ class SaveReason extends ControllableBase {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		if ( isset( $item['asb_marked_as_delete'] ) && true === $item['asb_marked_as_delete'] ) {
 			return $item;
 		}
@@ -55,7 +55,7 @@ class SaveReason extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Save reasons', 'antispam-bee' );
 	}
 
@@ -64,7 +64,7 @@ class SaveReason extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Save the spam reasons as comment meta', 'antispam-bee' );
 	}
 
@@ -73,7 +73,7 @@ class SaveReason extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'The reasons are displayed in the spam comments list.', 'antispam-bee' );
 	}
 }

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -9,6 +9,7 @@ namespace AntispamBee\PostProcessors;
 
 use AntispamBee\Helpers\ContentTypeHelper;
 use AntispamBee\Helpers\SpamReasonTextHelper;
+use WP_Post;
 
 /**
  * Post processor that is responsible for sending emails to the user.
@@ -29,7 +30,7 @@ class SendEmail extends ControllableBase {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		if ( isset( $item['asb_marked_as_delete'] ) && true === $item['asb_marked_as_delete'] ) {
 			return $item;
 		}
@@ -85,7 +86,7 @@ class SendEmail extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Send email', 'antispam-bee' );
 	}
 
@@ -94,7 +95,7 @@ class SendEmail extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Spam-Notification by email', 'antispam-bee' );
 	}
 
@@ -103,7 +104,7 @@ class SendEmail extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'Notify admins by e-mail about incoming spam', 'antispam-bee' );
 	}
 
@@ -112,7 +113,7 @@ class SendEmail extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	private static function get_subject() {
+	private static function get_subject(): string {
 		return sprintf(
 			'[%s] %s',
 			stripslashes(
@@ -132,7 +133,7 @@ class SendEmail extends ControllableBase {
 	 * @param array $comment The comment.
 	 * @return string
 	 */
-	private static function get_content( $comment ) {
+	private static function get_content( array $comment ): string {
 		$content = strip_tags( stripslashes( $comment['comment_content'] ) );
 
 		if ( $content ) {
@@ -147,7 +148,7 @@ class SendEmail extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	private static function get_body_template() {
+	private static function get_body_template(): string {
 		$new_spam_comment = sprintf( /* translators: s=post title. */
 			esc_html__( 'New spam comment on your post “%s”,', 'antispam-bee' ),
 			'{{post_title}}'
@@ -201,12 +202,12 @@ EOF;
 	/**
 	 * Generate email body.
 	 *
-	 * @param \WP_Post $post    The post.
-	 * @param array    $comment The comment.
-	 * @param array    $item    Processed item.
+	 * @param WP_Post $post    The post.
+	 * @param array   $comment The comment.
+	 * @param array   $item    Processed item.
 	 * @return string
 	 */
-	protected static function get_body( $post, $comment, $item ) {
+	protected static function get_body( WP_Post $post, array $comment, array $item ): string {
 		$template_content = self::get_body_template();
 
 		$content       = self::get_content( $comment );

--- a/src/PostProcessors/UpdateSpamCount.php
+++ b/src/PostProcessors/UpdateSpamCount.php
@@ -29,7 +29,7 @@ class UpdateSpamCount extends Base {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		if ( ! Statistics::is_active() ) {
 			return $item;
 		}

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -26,7 +26,7 @@ class UpdateSpamLog extends Base {
 	 * @param array $item Item to process.
 	 * @return array Processed item.
 	 */
-	public static function process( $item ) {
+	public static function process( array $item ): array {
 		if ( ! isset( $item['comment_post_ID'] ) || ! isset( $item['comment_author_IP'] ) ) {
 			$item['asb_post_processors_failed'][] = self::get_slug();
 			return $item;

--- a/src/Rules/ApprovedEmail.php
+++ b/src/Rules/ApprovedEmail.php
@@ -37,7 +37,7 @@ class ApprovedEmail extends ControllableBase {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$email = DataHelper::get_values_where_key_contains( [ 'email' ], $item );
 		if ( empty( $email ) ) {
 			return 0;
@@ -65,7 +65,7 @@ class ApprovedEmail extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Approved Email', 'antispam-bee' );
 	}
 
@@ -74,7 +74,7 @@ class ApprovedEmail extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Trust approved commenters', 'antispam-bee' );
 	}
 
@@ -83,7 +83,7 @@ class ApprovedEmail extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'No review of already commented users', 'antispam-bee' );
 	}
 }

--- a/src/Rules/BBCode.php
+++ b/src/Rules/BBCode.php
@@ -29,7 +29,7 @@ class BBCode extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		foreach ( $item as $value ) {
 			if ( true === (bool) preg_match( '/\[url[=\]].*\[\/url\]/is', $value ) ) {
 				return 1;
@@ -44,7 +44,7 @@ class BBCode extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return _x( 'BBCode', 'spam-reason-form-name', 'antispam-bee' );
 	}
 
@@ -53,7 +53,7 @@ class BBCode extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'BBCode links are spam', 'antispam-bee' );
 	}
 
@@ -62,7 +62,7 @@ class BBCode extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'Review the comment contents for BBCode links', 'antispam-bee' );
 	}
 
@@ -71,7 +71,7 @@ class BBCode extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'BBCode', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/Base.php
+++ b/src/Rules/Base.php
@@ -57,7 +57,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter( 'antispam_bee_rules', [ static::class, 'add_rule' ] );
 	}
 
@@ -68,7 +68,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return array
 	 */
-	public static function add_rule( $rules ) {
+	public static function add_rule( array $rules ): array {
 		$rules[] = static::class;
 
 		return $rules;
@@ -79,7 +79,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return array
 	 */
-	public static function get_supported_types() {
+	public static function get_supported_types(): array {
 		/**
 		 * Filter the reaction types that are supported by the rule.
 		 *
@@ -97,7 +97,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return int Weight factor.
 	 */
-	public static function get_weight() {
+	public static function get_weight(): int {
 		return static::$weight;
 	}
 
@@ -106,7 +106,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return string The slug.
 	 */
-	public static function get_slug() {
+	public static function get_slug(): string {
 		return static::$slug;
 	}
 
@@ -115,7 +115,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return bool
 	 */
-	public static function is_final() {
+	public static function is_final(): bool {
 		return static::$is_final;
 	}
 
@@ -124,7 +124,7 @@ abstract class Base implements Verifiable {
 	 *
 	 * @return bool
 	 */
-	public static function is_invisible() {
+	public static function is_invisible(): bool {
 		return static::$is_invisible;
 	}
 }

--- a/src/Rules/ControllableBase.php
+++ b/src/Rules/ControllableBase.php
@@ -36,7 +36,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( $type ) {
+	public static function is_active( string $type ) {
 		return Settings::get_option( static::get_option_name( 'active' ), $type );
 	}
 
@@ -45,9 +45,9 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * {@inheritDoc} Default: none.
 	 *
-	 * @return mixed
+	 * @return array|null
 	 */
-	public static function get_options() {
+	public static function get_options(): ?array {
 		return null;
 	}
 
@@ -57,7 +57,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return bool
 	 */
-	public static function only_print_custom_options() {
+	public static function only_print_custom_options(): bool {
 		return static::$only_print_custom_options;
 	}
 
@@ -66,7 +66,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 *
 	 * @return string
 	 */
-	public static function get_type() {
+	public static function get_type(): string {
 		return static::$type;
 	}
 
@@ -77,7 +77,7 @@ abstract class ControllableBase extends Base implements Controllable {
 	 * @param string $name Name suffix.
 	 * @return string Corresponding option name
 	 */
-	public static function get_option_name( $name ) {
+	public static function get_option_name( string $name ): string {
 		$type        = static::get_type();
 		$slug        = static::get_slug();
 		$option_name = "{$type}_{$slug}_{$name}";

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -32,7 +32,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		if ( ! isset( $item['comment_author_IP'] ) || empty( $item['comment_author_IP'] ) ) {
 			return 0;
 		}
@@ -137,7 +137,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Country Check', 'antispam-bee' );
 	}
 
@@ -146,7 +146,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Block or allow comments from specific countries', 'antispam-bee' );
 	}
 
@@ -155,7 +155,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		$link1 = sprintf(
 			'<a href="%s" target="_blank" rel="noopener noreferrer">',
 			esc_url(
@@ -185,7 +185,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return array
 	 */
-	public static function get_options() {
+	public static function get_options(): array {
 		$iso_codes_link = 'https://www.iso.org/obp/ui/#search/code/';
 		return [
 			[
@@ -235,7 +235,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 * @param string $value Comma-separated list of potential ISO country codes.
 	 * @return string Comma-separated list if sanitized ISO country codes.
 	 */
-	private static function sanitize_iso_codes_string( $value ) {
+	private static function sanitize_iso_codes_string( string $value ): string {
 		$value  = strtoupper( $value );
 		$values = explode( ',', $value );
 		$values = Sanitize::iso_codes( $values );
@@ -248,7 +248,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return __( 'Country', 'antispam-bee' );
 	}
 }

--- a/src/Rules/DbSpam.php
+++ b/src/Rules/DbSpam.php
@@ -30,7 +30,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$params = [];
 		$filter = [];
 		$url    = wp_unslash( array_shift( DataHelper::get_values_where_key_contains( [ 'url' ], $item ) ) );
@@ -83,7 +83,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Local DB Spam', 'antispam-bee' );
 	}
 
@@ -92,7 +92,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Look in the local spam database', 'antispam-bee' );
 	}
 
@@ -101,7 +101,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'Check for spam data on your own blog', 'antispam-bee' );
 	}
 
@@ -110,7 +110,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return __( 'Local DB', 'antispam-bee' );
 	}
 }

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -30,7 +30,7 @@ class EmptyData extends Base implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$allow_empty_reaction = apply_filters( 'allow_empty_comment', false, $item );
 		$content              = $item['comment_content'] ?? '';
@@ -63,7 +63,7 @@ class EmptyData extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return _x( 'Empty Data', 'spam-reason-form-name', 'antispam-bee' );
 	}
 
@@ -72,7 +72,7 @@ class EmptyData extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Empty Data', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -38,7 +38,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter( 'antispam_bee_rules', [ __CLASS__, 'add_rule' ] );
 
 		add_filter(
@@ -61,7 +61,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['ab_spam__hidden_field'] ) && 1 === $_POST['ab_spam__hidden_field'] ) {
 			return 999;
@@ -75,7 +75,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return void
 	 */
-	public static function precheck() {
+	public static function precheck(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( is_feed() || is_trackback() || empty( $_POST ) ) {
 			return;
@@ -120,7 +120,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return _x( 'Honeypot', 'spam-reason-form-name', 'antispam-bee' );
 	}
 
@@ -129,7 +129,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Inject hidden field', 'antispam-bee' );
 	}
 
@@ -138,7 +138,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'No review of already commented users', 'antispam-bee' );
 	}
 
@@ -147,7 +147,7 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Honeypot', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/InvalidRequest.php
+++ b/src/Rules/InvalidRequest.php
@@ -29,7 +29,7 @@ class InvalidRequest extends Base implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput
 		if ( isset( $_POST['ab_spam__invalid_request'] ) && $_POST['ab_spam__invalid_request'] ) {
 			return 999;
@@ -43,7 +43,7 @@ class InvalidRequest extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return _x( 'Invalid Request', 'spam-reason-form-name', 'antispam-bee' );
 	}
 
@@ -52,7 +52,7 @@ class InvalidRequest extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Invalid Request', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -33,7 +33,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$allowed_languages = array_keys( (array) Settings::get_option( static::get_option_name( 'allowed' ), $item['reaction_type'] ) );
 
 		$comment_content = DataHelper::get_values_where_key_contains( [ 'content' ], $item );
@@ -118,7 +118,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Language', 'antispam-bee' );
 	}
 
@@ -127,7 +127,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Allow reactions only in certain language', 'antispam-bee' );
 	}
 
@@ -136,7 +136,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		$link1 = sprintf(
 			'<a href="%s" target="_blank" rel="noopener noreferrer">',
 			esc_url(
@@ -160,7 +160,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return array
 	 */
-	public static function get_options() {
+	public static function get_options(): array {
 		// @todo: we should enable the user to select all 82 languages we can detect. we use presets: the site language, the site language + english, if more than two langs are installed, use those; and: custom. We could check the preferred languages UI for the custom option. And also for the ISO codes.
 		$languages = [
 			'de' => __( 'German', 'antispam-bee' ),
@@ -199,7 +199,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return __( 'Language', 'antispam-bee' );
 	}
 }

--- a/src/Rules/LinkbackFromMyself.php
+++ b/src/Rules/LinkbackFromMyself.php
@@ -46,7 +46,7 @@ class LinkbackFromMyself extends Base implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$url            = isset( $item['comment_author_url'] ) ? $item['comment_author_url'] : null;
 		$target_post_id = isset( $item['comment_post_ID'] ) ? $item['comment_post_ID'] : null;
 		if ( empty( $url ) || empty( $target_post_id ) ) {
@@ -88,7 +88,7 @@ class LinkbackFromMyself extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Linkback from myself', 'antispam-bee' );
 	}
 
@@ -97,7 +97,7 @@ class LinkbackFromMyself extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Linkback from myself', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/LinkbackFromMyself.php
+++ b/src/Rules/LinkbackFromMyself.php
@@ -47,8 +47,8 @@ class LinkbackFromMyself extends Base implements SpamReason {
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$url            = isset( $item['comment_author_url'] ) ? $item['comment_author_url'] : null;
-		$target_post_id = isset( $item['comment_post_ID'] ) ? $item['comment_post_ID'] : null;
+		$url            = $item['comment_author_url'] ?? null;
+		$target_post_id = $item['comment_post_ID'] ?? null;
 		if ( empty( $url ) || empty( $target_post_id ) ) {
 			return 0;
 		}

--- a/src/Rules/LinkbackPostTitleIsBlogName.php
+++ b/src/Rules/LinkbackPostTitleIsBlogName.php
@@ -38,8 +38,8 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$body      = isset( $item['comment_content'] ) ? $item['comment_content'] : null;
-		$blog_name = isset( $item['comment_author'] ) ? $item['comment_author'] : null;
+		$body      = $item['comment_content'] ?? null;
+		$blog_name = $item['comment_author'] ?? null;
 		preg_match( '/<strong>(.*)<\/strong>\\n\\n/', $body, $matches );
 		if ( ! isset( $matches[1] ) ) {
 			return 0;

--- a/src/Rules/LinkbackPostTitleIsBlogName.php
+++ b/src/Rules/LinkbackPostTitleIsBlogName.php
@@ -37,7 +37,7 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$body      = isset( $item['comment_content'] ) ? $item['comment_content'] : null;
 		$blog_name = isset( $item['comment_author'] ) ? $item['comment_author'] : null;
 		preg_match( '/<strong>(.*)<\/strong>\\n\\n/', $body, $matches );
@@ -53,7 +53,7 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Linkback post title is blog name', 'antispam-bee' );
 	}
 
@@ -62,7 +62,7 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Linkback Post Title', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -32,7 +32,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$fields = [
 			'ip',
 			'host',
@@ -178,7 +178,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Regular Expression', 'antispam-bee' );
 	}
 
@@ -187,7 +187,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Use regular expressions', 'antispam-bee' );
 	}
 
@@ -196,7 +196,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'Predefined and custom patterns by plugin hook', 'antispam-bee' );
 	}
 
@@ -205,7 +205,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'RegExp match', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/TooFastSubmit.php
+++ b/src/Rules/TooFastSubmit.php
@@ -34,7 +34,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public static function init(): void {
 		add_filter( 'antispam_bee_rules', [ __CLASS__, 'add_rule' ] );
 
 		add_filter(
@@ -75,7 +75,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		// Everybody can Post.
 		if ( ! isset( $_POST['ab_init_time'] ) ) {
@@ -100,7 +100,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Comment time', 'antispam-bee' );
 	}
 
@@ -109,7 +109,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Consider the comment time', 'antispam-bee' );
 	}
 
@@ -118,7 +118,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		return __( 'Not recommended when using page caching', 'antispam-bee' );
 	}
 
@@ -127,7 +127,7 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * @return string
 	 */
-	public static function get_reason_text() {
+	public static function get_reason_text(): string {
 		return _x( 'Created too quickly', 'spam-reason-text', 'antispam-bee' );
 	}
 }

--- a/src/Rules/ValidGravatar.php
+++ b/src/Rules/ValidGravatar.php
@@ -37,7 +37,7 @@ class ValidGravatar extends ControllableBase {
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */
-	public static function verify( $item ) {
+	public static function verify( array $item ): int {
 		$email = DataHelper::get_values_where_key_contains( [ 'email' ], $item );
 		if ( empty( $email ) ) {
 			return 0;
@@ -67,7 +67,7 @@ class ValidGravatar extends ControllableBase {
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public static function get_name(): string {
 		return __( 'Valid Gravatar', 'antispam-bee' );
 	}
 
@@ -76,7 +76,7 @@ class ValidGravatar extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_label() {
+	public static function get_label(): ?string {
 		return __( 'Trust commenters with a Gravatar', 'antispam-bee' );
 	}
 
@@ -85,7 +85,7 @@ class ValidGravatar extends ControllableBase {
 	 *
 	 * @return string|null
 	 */
-	public static function get_description() {
+	public static function get_description(): ?string {
 		$link1 = sprintf(
 			'<a href="%s" target="_blank" rel="noopener noreferrer">',
 			esc_url(

--- a/src/load.php
+++ b/src/load.php
@@ -43,7 +43,7 @@ use AntispamBee\Rules\ValidGravatar;
 /**
  * Init function of the plugin
  */
-function init() {
+function init(): void {
 	// Construct all modules to initialize.
 	$modules = [
 		DashboardWidgets::class,


### PR DESCRIPTION
based on #575, #576 and #579 (all merged)

----

* raise required PHP version from 7.0 to 7.2
   We have nullable and void return types, so we can annotate almost every method (some union and mixed types missing, those are PHP 8 features)
* add type hints where possible
* remote redundant type checks in method bodies
* use null coalescing operator (`??`) where applicable

Fixed 2 minor bugs that came up during this refactoring:
* add missing return statement to `Linkback::process()`
* ensure `$implements_interface` is initialized in `ComponentHelper`