### PR TITLE
Use `SCRIPT_NAME` instead of `REQUEST_URI` to check path

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1134,7 +1134,7 @@ class Antispam_Bee {
 			return;
 		}
 
-		$request_uri  = self::get_key( $_SERVER, 'REQUEST_URI' );
+		$request_uri  = self::get_key( $_SERVER, 'SCRIPT_NAME' );
 		$request_path = self::parse_url( $request_uri, 'path' );
 
 		if ( strpos( $request_path, 'wp-comments-post.php' ) === false ) {
@@ -1168,7 +1168,7 @@ class Antispam_Bee {
 	public static function handle_incoming_request( $comment ) {
 		$comment['comment_author_IP'] = self::get_client_ip();
 
-		$request_uri  = self::get_key( $_SERVER, 'REQUEST_URI' );
+		$request_uri  = self::get_key( $_SERVER, 'SCRIPT_NAME' );
 		$request_path = self::parse_url( $request_uri, 'path' );
 
 		if ( empty( $request_path ) ) {

--- a/tests/Unit/AntispamBeeTest.php
+++ b/tests/Unit/AntispamBeeTest.php
@@ -68,7 +68,7 @@ class FactoryTest extends TestCase {
 		$_SERVER['REMOTE_ADDR']          = '192.0.2.1';
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '192.0.2.2, 10.0.0.10';
 		$_SERVER['HTTP_X_REAL_IP']       = 'bogus';
-		$_SERVER['REQUEST_URI']          = 'https://domain.com/wp-comments-post.php';
+		$_SERVER['SCRIPT_NAME']          = '/wp-comments-post.php';
 		$_POST['comment']                = $comment;
 
 		$result = Testee::handle_incoming_request( $comment );
@@ -99,7 +99,7 @@ class FactoryTest extends TestCase {
 		$comment = array_merge( $this->get_base_comment(), $comment );
 
 		$_SERVER['REMOTE_ADDR'] = '12.23.34.45';
-		$_SERVER['REQUEST_URI'] = 'https://domain.com/wp-comments-post.php';
+		$_SERVER['SCRIPT_NAME'] = '/wp-comments-post.php';
 		$_POST['comment']       = $comment;
 
 		// This is where we check for the spam reason that was detected.


### PR DESCRIPTION
The script is currently checking if the `REQUEST_URI` is containing `wp-comments-post.php`, the default script to handle the submission of a comment. Some security plugins have options to rename this file to disguise that WordPress is used.

With this fix, the `SCRIPT_NAME` is used instead. Since many security plugins do use rewrite rules, while the `REQUEST_URI` value is changed, the `SCRIPT_NAME` value stays the same. Therefore, the condition would still recognize if a comment was submitted.

Fixes #585