### PR TITLE
Remove `add_reasons_to_defaults()` from general initialization

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -151,11 +151,6 @@ class Antispam_Bee {
 
 		self::_init_internal_vars();
 
-		if ( self::_current_page( 'dashboard' ) || self::_current_page( 'plugins' ) || self::_current_page( 'options' ) || self::_current_page( 'edit-comments' ) || self::_current_page( 'admin-post' ) ) {
-			self::load_plugin_lang();
-			self::add_reasons_to_defaults();
-		}
-
 		if ( defined( 'DOING_CRON' ) ) {
 			add_action(
 				'antispam_bee_daily_cronjob',

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -151,6 +151,13 @@ class Antispam_Bee {
 
 		self::_init_internal_vars();
 
+		add_action(
+			'init', array(
+				__CLASS__,
+				'add_reasons_to_defaults'
+			)
+		);
+
 		if ( defined( 'DOING_CRON' ) ) {
 			add_action(
 				'antispam_bee_daily_cronjob',
@@ -473,7 +480,7 @@ class Antispam_Bee {
 	 *
 	 * @since 2.11.2
 	 */
-	private static function add_reasons_to_defaults() {
+	public static function add_reasons_to_defaults() {
 		self::$defaults['reasons'] = array(
 			'css'           => esc_attr__( 'Honeypot', 'antispam-bee' ),
 			'time'          => esc_attr__( 'Comment time', 'antispam-bee' ),
@@ -2534,8 +2541,6 @@ class Antispam_Bee {
 		if ( ! $post ) {
 			return $id;
 		}
-
-		self::add_reasons_to_defaults();
 
 		$subject = sprintf(
 			'[%s] %s',

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -561,19 +561,6 @@ class Antispam_Bee {
 
 
 	/**
-	 * Integration of the localization file
-	 *
-	 * @since  0.1
-	 * @since  2.4
-	 */
-	public static function load_plugin_lang() {
-		load_plugin_textdomain(
-			'antispam-bee'
-		);
-	}
-
-
-	/**
 	 * Add the link to the settings
 	 *
 	 * @since  1.1
@@ -2548,7 +2535,6 @@ class Antispam_Bee {
 			return $id;
 		}
 
-		self::load_plugin_lang();
 		self::add_reasons_to_defaults();
 
 		$subject = sprintf(

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -152,9 +152,10 @@ class Antispam_Bee {
 		self::_init_internal_vars();
 
 		add_action(
-			'init', array(
+			'init',
+			array(
 				__CLASS__,
-				'add_reasons_to_defaults'
+				'add_reasons_to_defaults',
 			)
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv, websupporter, schlessera, zodiac1978, swissspidy, krafit, kau-boy, florianbrinkmann, pfefferle
 * Tags:              anti-spam, antispam, block spam, comment, comments, comment spam, pingback, spam, spam filter, trackback, GDPR
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 4.5
+* Requires at least: 4.6
 * Tested up to:      6.5
 * Requires PHP:      5.2
 * Stable tag:        2.11.6
@@ -65,7 +65,7 @@ Antispam Bee works best with default WordPress comments. It does not help to pro
 Antispam Bee works best with default WordPress comments. It is not compatible with Jetpack, wpDiscuz or Disqus Comments as those plugins load a new comment form within an iframe. Thus Antispam Bee can not access the comment form directly.
 
 ### Does Antispam Bee work with AJAX comment plugins or similar theme features?
-Whether Antispam Bee works with a comment form submitted via AJAX depends on how the AJAX request is made. If the request goes to the file that usually also receives the comments, Antispam Bee could work with it out of the box (the [WP Ajaxify Comments](https://wordpress.org/plugins/wp-ajaxify-comments/) plugin does this, for example). 
+Whether Antispam Bee works with a comment form submitted via AJAX depends on how the AJAX request is made. If the request goes to the file that usually also receives the comments, Antispam Bee could work with it out of the box (the [WP Ajaxify Comments](https://wordpress.org/plugins/wp-ajaxify-comments/) plugin does this, for example).
 
 If the comments are sent to the `admin-ajax.php`, the `antispam_bee_disallow_ajax_calls` filter must be used to run ASB for requests to that file as well. If the script does not send all form data to the file, but only some selected ones, further customization is probably necessary, as [exemplified in this post by Torsten Landsiedel](https://torstenlandsiedel.de/2020/10/04/ajaxifizierte-kommentare-und-antispam-bee/) (in German).
 


### PR DESCRIPTION
The `add_reasons_to_defaults()` adds the translatable strings to the `$default`. Those `reasons` are only needed inside the `send_mail_notification()` method, which also calls the `add_reasons_to_defaults()` function. Therefore, the function call can be removed from the general `init()` function.

Fixes #625