### PR TITLE
Add the missing type hint for `get_placeholder()`

### DIFF
--- a/src/Admin/Fields/Text.php
+++ b/src/Admin/Fields/Text.php
@@ -26,8 +26,8 @@ class Text extends Field implements RenderElement {
 	 *
 	 * @return string
 	 */
-	public function get_placeholder() {
-		return $this->placeholder;
+	public function get_placeholder(): string {
+		return $this->placeholder ?? '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #628 