### PR TITLE
Get hidden and plugin field correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "wp-cli/wp-cli-bundle": "@stable",
-    "wp-coding-standards/wpcs": "^3.1",
+    "wp-coding-standards/wpcs": "^3.2.0",
     "yoast/wp-test-utils": "^1.2.0",
     "phpstan/phpstan": "^2.2",
     "szepeviktor/phpstan-wordpress": "^2.0"

--- a/src/Rules/DbSpam.php
+++ b/src/Rules/DbSpam.php
@@ -33,7 +33,8 @@ class DbSpam extends ControllableBase implements SpamReason {
 	public static function verify( array $item ): int {
 		$params = [];
 		$filter = [];
-		$url    = wp_unslash( array_shift( DataHelper::get_values_where_key_contains( [ 'url' ], $item ) ) );
+		$values = DataHelper::get_values_where_key_contains( [ 'url' ], $item );
+		$url    = wp_unslash( array_shift( $values ) );
 
 		if ( ! empty( $url ) ) {
 			$filter[] = '`comment_author_url` = %s';

--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -88,32 +88,18 @@ class Honeypot extends ControllableBase implements SpamReason {
 		if ( strpos( $request_path, 'wp-comments-post.php' ) === false ) {
 			return;
 		}
-		$fields = [];
-		foreach ( $_POST as $key => $value ) {
-			if ( isset( $fields['plugin_field'] ) ) {
-				$fields['hidden_field'] = $key;
-				break;
-			}
-			if ( HoneypotField::get_secret_name_for_post() === $key ) {
-				$fields['plugin_field'] = $key;
-			}
-		}
 
-		if ( ! isset( $fields['plugin_field'] ) ) {
-			// Honeypot field was not present in $_POST data.
-			$_POST['ab_spam__invalid_request'] = 1;
-			return;
-		}
+		$plugin_field_name = HoneypotField::get_secret_name_for_post();
 
-		if ( ! empty( $_POST[ $fields['hidden_field'] ] ) ) {
+		$hidden_field = Settings::get_key( $_POST, 'comment' );
+		$plugin_field = Settings::get_key( $_POST, $plugin_field_name );
+
+		if ( ! empty( $hidden_field ) ) {
 			$_POST['ab_spam__hidden_field'] = 1;
-			return;
+		} else {
+			$_POST['comment'] = $plugin_field;
+			unset( $_POST[ $plugin_field_name ] );
 		}
-
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$_POST[ $fields['hidden_field'] ] = $_POST[ $fields['plugin_field'] ];
-		unset( $_POST[ HoneypotField::get_secret_name_for_post() ] );
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
 	/**


### PR DESCRIPTION
The new code is using a `foreach` to get the two fields, but requires them to be in the correct order.

This change uses a code similar to v2 which would get the parameters, independent of the order.

Fixes: https://github.com/pluginkollektiv/antispam-bee/pull/506#pullrequestreview-1837201864