### PR TITLE
Add `ab_spam__invalid_request` logic back to `precheck()` function

### DIFF
--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -94,12 +94,20 @@ class Honeypot extends ControllableBase implements SpamReason {
 		$hidden_field = Settings::get_key( $_POST, 'comment' );
 		$plugin_field = Settings::get_key( $_POST, $plugin_field_name );
 
-		if ( ! empty( $hidden_field ) ) {
-			$_POST['ab_spam__hidden_field'] = 1;
-		} else {
-			$_POST['comment'] = $plugin_field;
-			unset( $_POST[ $plugin_field_name ] );
+		// The secret comment field was not present in $_POST data.
+		if ( is_null( $plugin_field ) ) {
+			$_POST['ab_spam__invalid_request'] = 1;
+			return;
 		}
+
+		// The honeypot field was not present in $_POST data or was filled out.
+		if ( is_null( $hidden_field ) || ! empty( $hidden_field ) ) {
+			$_POST['ab_spam__hidden_field'] = 1;
+			return;
+		}
+
+		$_POST['comment'] = $plugin_field;
+		unset( $_POST[ $plugin_field_name ] );
 	}
 
 	/**

--- a/tests/Unit/Rules/HoneypotTest.php
+++ b/tests/Unit/Rules/HoneypotTest.php
@@ -74,6 +74,9 @@ class HoneypotTest extends AbstractRuleTestCase {
 		// Send all following requests to the correct URL.
 		$_SERVER = [ 'SCRIPT_NAME' => '/wp-comments-post.php' ];
 
+		Honeypot::precheck();
+		self::assertSame( 1, $_POST[ 'ab_spam__invalid_request' ], 'request without missing fields not detected' );
+
 		$_POST = [
 			'd7dcf95a06' => 'S3cr3t',
 			'comment' => 'H1dd3n',

--- a/tests/Unit/Rules/HoneypotTest.php
+++ b/tests/Unit/Rules/HoneypotTest.php
@@ -95,5 +95,12 @@ class HoneypotTest extends AbstractRuleTestCase {
 			'secret was not moved to hidden field'
 		);
 
+		// Honeypot field entirely absent while the secret field is present.
+		$_POST = [
+			'd7dcf95a06' => 'S3cr3t',
+		];
+		Honeypot::precheck();
+		self::assertSame( 1, $_POST['ab_spam__hidden_field'], 'missing hidden field not detected' );
+
 	}
 }


### PR DESCRIPTION
@stklcode thanks for your comment on #655 about a failing test. After fixing the implementation of the Honypot precheck, I've restored the logic from `v2`. In my opinion, the initial implementation of this rule in `v3` added an additional validation step, which might change how spam is detected. I believe it's a good addition, but I'm not sure it we should include it without further testing.

This PR restored that new logic and also adds back the test that was failing in #655, which now works again.