### PR TITLE
[v3] Use looser regex for non-quoted attributes (#657)

### DIFF
--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -65,17 +65,17 @@ class Honeypot {
 						<textarea                                        (?# the opening of the textarea and some optional attributes )
 						(                                                (?# match a id attribute followed by some optional ones and the name attribute )
 							(?P<before1>[^>]*)
-							(?P<id1>id=["\']{{HONEYPOT_ID}}["\'])
+							(?P<id1>id=["\']?{{HONEYPOT_ID}}["\']?)
 							(?P<between1>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							|                                            (?# match same as before, but with the name attribute before the id attribute )
 							(?P<before2>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							(?P<between2>[^>]*)
-							(?P<id2>id=["\']{{HONEYPOT_ID}}["\'])
+							(?P<id2>id=["\']?{{HONEYPOT_ID}}["\']?)
 							|                                            (?# match same as before, but with no id attribute )
 							(?P<before3>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							(?P<between3>[^>]*)
 						)
 						(?P<after>[^>]*)                                 (?# match any additional optional attributes )


### PR DESCRIPTION
Markup preparation for textarea elements with unquoted "name" attribute are not properly detected and are not augmented by Antispam Bee.

Loosen the expression to also match unquoted attributes which are valid HTML and should be processed equally.

Adapted to v3 from: 4e36755df73cba0942df28d761d7ee447f12b9d3 (#658)