### PR TITLE
fix: pin PHP version in deployment pipeline (#682)

### DIFF
--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -8,10 +8,15 @@ jobs:
     name: Push to master
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: php-actions/composer@v6
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        args: --ignore-platform-reqs
+        php-version: '8.3'
+        tools: composer
+    - name: Build
+      run: composer install --ignore-platform-reqs
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -9,10 +9,15 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: php-actions/composer@v6
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        args: --ignore-platform-reqs
+        php-version: '8.3'
+        tools: composer
+    - name: Build
+      run: composer install --ignore-platform-reqs
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog ##
 
+### 2.11.10 ###
+* **English**
+  * Fix: remove build-tool warnings from minified Javascript and CSS resources
+
+* **Deutsch**
+  * Fix: Build-Tool-Warnungen aus minifizierten Javascript und CSS Ressourcen entfernt
+
 ### 2.11.9 ###
 * **English**
   * Tweak: Improved compatibility with unquoted HTML attributes in comment forms

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -9,7 +9,7 @@
  * Domain Path: /lang
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.11.9
+ * Version:     2.11.10
  *
  * @package Antispam Bee
  **/

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 4.6
 * Tested up to:      7.0
 * Requires PHP:      5.2
-* Stable tag:        2.11.9
+* Stable tag:        2.11.10
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,6 +97,9 @@ A complete documentation is available on [pluginkollektiv.org](https://antispamb
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)
 
 ## Changelog ##
+
+### 2.11.10 ###
+  * Fix: remove build-tool warnings from minified Javascript and CSS resources
 
 ### 2.11.9 ###
   * Tweak: Improved compatibility with unquoted HTML attributes in comment forms


### PR DESCRIPTION
Running the Composer scripts with PHP 8.4 or later generates deprecation warnings which are printed on top of the minified JS and CSS resources.

Refactor the build pipeline and pin the PHP version to 8.3 to resolve this issue.

----

Immediate version bump, so we can release this hotfix without other changes.

resolves #682

----

**All good with PHP 8.3**

```
$ podman run --rm -it -v "$(pwd)":/ws:Z -w /ws --entrypoint /bin/bash php:8.3 -c "php composer.phar minify" && head js/raphael.helper.min.js

> minifycss css/dashboard.css > css/dashboard.min.css
> minifycss css/styles.css > css/styles.min.css
> minifyjs js/dashboard.js > js/dashboard.min.js
> minifyjs js/raphael.helper.js > js/raphael.helper.min.js
> minifyjs js/scripts.js > js/scripts.min.js

var tokenRegex=/\{([^\}]+)\}/g,objNotationRegex=...
```

**Broken output with 8.4 or later**

```
$ podman run --rm -it -v "$(pwd)":/ws:Z -w /ws --entrypoint /bin/bash php:8.4 -c "php composer.phar minify" && head js/raphael.helper.min.js

Deprecation Notice: Constant E_STRICT is deprecated in phar:///ws/composer.phar/src/Composer/Util/Silencer.php:36
Deprecation Notice: Composer\Pcre\Preg::replace(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in phar:///ws/composer.phar/vendor/composer/pcre/src/Preg.php:150
...
> minifycss css/dashboard.css > css/dashboard.min.css
> minifycss css/styles.css > css/styles.min.css
> minifyjs js/dashboard.js > js/dashboard.min.js
> minifyjs js/raphael.helper.js > js/raphael.helper.min.js
> minifyjs js/scripts.js > js/scripts.min.js

Deprecated: GuzzleHttp\Promise\queue(): Implicitly marking parameter $assign as nullable is deprecated, the explicit nullable type must be used instead in /ws/vendor/guzzlehttp/promises/src/functions.php on line 24

Deprecated: GuzzleHttp\Promise\each(): Implicitly marking parameter $onFulfilled as nullable is deprecated, the explicit nullable type must be used instead in /ws/vendor/guzzlehttp/promises/src/functions.php on line 260
...