### PR TITLE
Add shorturl.fm spam pattern

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1655,6 +1655,9 @@ class Antispam_Bee {
 				'body'  => 'dating|sex|lotto|pharmacy',
 				'email' => '@mail\.ru|@yandex\.',
 			),
+			array(
+				'body' => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
+			),
 		);
 
 		$quoted_author = preg_quote( $comment['author'], '/' );

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1657,6 +1657,8 @@ class Antispam_Bee {
 			),
 			array(
 				'body' => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
+				'email' => '@gmail\.com',
+				'author' => '^[A-Z][a-z]+\d{3,4}$',
 			),
 		);
 


### PR DESCRIPTION
Closes #685 

Adds a body pattern to block spam comments consisting solely of a shorturl.fm URL with a 5-character alphanumeric slug.