### PR TITLE
fix: pass integer to _n() in dashboard spam counter

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -752,13 +752,15 @@ class Antispam_Bee {
 
 		echo '<style>#dashboard_right_now .ab-count:before {content: "\f117"}</style>';
 
+		$spam_count = intval( self::get_option( 'spam_count' ) );
+
 		$items[] = '<span class="ab-count">' . esc_html(
 			sprintf(
 				// translators: The number of spam comments Antispam Bee blocked so far.
 				_n(
 					'%s Blocked',
 					'%s Blocked',
-					self::_get_spam_count(),
+					$spam_count,
 					'antispam-bee'
 				),
 				self::_get_spam_count()


### PR DESCRIPTION
## Summary

Fixes a PHP fatal `TypeError` on the WordPress Dashboard when the dashboard spam counter option is enabled on sites with a strictly typed `ngettext` filter (reported with Divi 5.6 / `D4DomainBridge`).

`add_dashboard_count()` passed `self::_get_spam_count()` as the third argument to `_n()`. That method returns a locale-formatted string (`number_format()` / `number_format_i18n()`), but `_n()` expects a numeric value for singular/plural selection only. The formatted value should be used only for display in `sprintf()`.

## Changes

- Pass `intval( self::get_option( 'spam_count' ) )` to `_n()`
- Continue using `self::_get_spam_count()` for the formatted count in `sprintf()`

## How to test

1. Enable **Display spam counter on dashboard** in Antispam Bee settings.
2. Ensure the spam count is greater than 0.
3. Open **Dashboard** as an administrator.
4. Confirm the blocked count displays and no PHP fatal appears in `debug.log`.

Recommended: test on PHP 8+ with Divi 5.6 if available (environment that previously reproduced the error).

## Related

- https://wordpress.org/support/topic/dashboard-fatal-_n-given-formatted-string-instead-of-integer/
- Fixes https://github.com/pluginkollektiv/antispam-bee/issues/691