### PR TITLE
fix: return bool from _is_mobile() instead of raw strpos result

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2271,7 +2271,7 @@ class Antispam_Bee {
 	 * @return  boolean  TRUE if "wptouch" is active
 	 */
 	private static function _is_mobile() {
-		return strpos( get_template_directory(), 'wptouch' );
+		return false !== strpos( get_template_directory(), 'wptouch' );
 	}
 
 	/**


### PR DESCRIPTION
`strpos()` returns `int|false`, so `_is_mobile()` was returning an integer position when wptouch was found rather than the `bool` its PHPDoc promises. This just adds `false !==` to make the return type correct.

Fixes #670.

Built and tested with AI assistance.