### PR TITLE
Fix upgrade_notice(): wrong hook tag (absolute path vs. plugin basename) and trailing space in array key

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1095,7 +1095,7 @@ class Antispam_Bee {
 			printf(
 				'<div class="update-message">%s</div>',
 				wp_kses(
-					wpautop( $data['upgrade_notice '] ),
+					wpautop( $data['upgrade_notice'] ),
 					array(
 						'p'     => array(),
 						'a'     => array( 'href', 'title' ),
@@ -3032,7 +3032,7 @@ register_uninstall_hook(
 
 // Upgrade notice.
 add_action(
-	'in_plugin_update_message-' . __FILE__,
+	'in_plugin_update_message-' . plugin_basename( __FILE__ ),
 	array(
 		'Antispam_Bee',
 		'upgrade_notice',


### PR DESCRIPTION
Fixes #669.

Two bugs in `upgrade_notice()` that together mean this feature has never worked for any Antispam Bee release.

**Bug 1 — Wrong hook tag:** `add_action( 'in_plugin_update_message-' . __FILE__, ... )` — `__FILE__` resolves to the absolute server path. WordPress registers the hook under the plugin basename (`antispam-bee/antispam_bee.php`), so the action was never matched and `upgrade_notice()` was never called. Fix: `plugin_basename( __FILE__ )`.

**Bug 2 — Trailing space in array key:** `$data['upgrade_notice ']` — the key has a trailing space. Even if the hook had fired, `isset()` would always fail because WordPress passes `'upgrade_notice'` (no space). Fix: remove the trailing space.

To verify: trigger the in_plugin_update_message action with a test `upgrade_notice` value — the `<div class="update-message">` should now render.

(full disclosure: AI helped me identify the issue and verify my work)
