### PR TITLE
Fix validate_file() check to reject all invalid path codes

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2394,7 +2394,7 @@ class Antispam_Bee {
 	 * @return  mixed        FALSE in case of error
 	 */
 	private static function _update_spam_log( $comment ) {
-		if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) || ! ANTISPAM_BEE_LOG_FILE || ! is_writable( ANTISPAM_BEE_LOG_FILE ) || validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0 ) {
+		if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) || ! ANTISPAM_BEE_LOG_FILE || validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0 || ! is_writable( ANTISPAM_BEE_LOG_FILE ) ) {
 			return false;
 		}
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2394,7 +2394,7 @@ class Antispam_Bee {
 	 * @return  mixed        FALSE in case of error
 	 */
 	private static function _update_spam_log( $comment ) {
-		if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) || ! ANTISPAM_BEE_LOG_FILE || ! is_writable( ANTISPAM_BEE_LOG_FILE ) || validate_file( ANTISPAM_BEE_LOG_FILE ) === 1 ) {
+		if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) || ! ANTISPAM_BEE_LOG_FILE || ! is_writable( ANTISPAM_BEE_LOG_FILE ) || validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0 ) {
 			return false;
 		}
 


### PR DESCRIPTION
validate_file() returns four values:
  0 = valid path
  1 = path contains .. (directory traversal)
  2 = Windows absolute path (drive letter)
  3 = path contains Windows directory separator

The previous check (=== 1) only blocked directory traversal. A Windows-style absolute log path like C:\path\malware.log would return 2 and pass the guard, allowing an unintended write target to be used.

Changing to (!== 0) rejects every invalid code consistently, matching the intent of the original check and the documented behavior of validate_file().

Fixes #671.