### PR TITLE
Escape action link URL and replace strip_tags() with wp_strip_all_tags() (Refs #534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog ##
 
+### 2.11.13 ###
+* **English**
+  * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
+  * Fix: Replace deprecated `strip_tags()` with `wp_strip_all_tags()` in spam notification email body (Refs #534) (Thanks @thisismyurl!)
+
+* **Deutsch**
+  * Fix: Einstellungs-Link-URL mit `esc_url()` maskieren (Refs #534) (Danke @thisismyurl!)
+  * Fix: Veraltetes `strip_tags()` durch `wp_strip_all_tags()` im Spam-Benachrichtigungs-E-Mail-Body ersetzen (Refs #534) (Danke @thisismyurl!)
+
+
 ### 2.11.12 ###
 * **English**
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ### 2.11.13 ###
 * **English**
   * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
-  * Fix: Replace deprecated `strip_tags()` with `wp_strip_all_tags()` in spam notification email body (Refs #534) (Thanks @thisismyurl!)
+  * Fix: Replace `strip_tags()` with `wp_strip_all_tags()` for WordPress-consistent tag stripping in spam notification email body (Refs #534) (Thanks @thisismyurl!)
 
 * **Deutsch**
   * Fix: Einstellungs-Link-URL mit `esc_url()` maskieren (Refs #534) (Danke @thisismyurl!)
-  * Fix: Veraltetes `strip_tags()` durch `wp_strip_all_tags()` im Spam-Benachrichtigungs-E-Mail-Body ersetzen (Refs #534) (Danke @thisismyurl!)
+  * Fix: `strip_tags()` durch `wp_strip_all_tags()` für WordPress-konformes Entfernen von Tags im Spam-Benachrichtigungs-E-Mail-Body ersetzen (Refs #534) (Danke @thisismyurl!)
 
 
 ### 2.11.12 ###

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -586,11 +586,13 @@ class Antispam_Bee {
 			array(
 				sprintf(
 					'<a href="%s">%s</a>',
-					add_query_arg(
-						array(
-							'page' => 'antispam_bee',
-						),
-						admin_url( 'options-general.php' )
+					esc_url(
+						add_query_arg(
+							array(
+								'page' => 'antispam_bee',
+							),
+							admin_url( 'options-general.php' )
+						)
 					),
 					esc_attr__( 'Settings', 'antispam-bee' )
 				),
@@ -2579,7 +2581,7 @@ class Antispam_Bee {
 		);
 
 		// Content.
-		$content = strip_tags( stripslashes( $comment['comment_content'] ) );
+		$content = wp_strip_all_tags( stripslashes( $comment['comment_content'] ) );
 		if ( ! $content ) {
 			$content = sprintf(
 				'-- %s --',
@@ -2600,11 +2602,11 @@ class Antispam_Bee {
 		$body = sprintf(
 			"%s \"%s\"\r\n\r\n",
 			esc_html__( 'New spam comment on your post', 'antispam-bee' ),
-			strip_tags( $post->post_title )
+			wp_strip_all_tags( $post->post_title )
 		) . sprintf(
 			"%s: %s\r\n",
 			esc_html__( 'Author', 'antispam-bee' ),
-			( empty( $comment['comment_author'] ) ? '' : strip_tags( $comment['comment_author'] ) )
+			( empty( $comment['comment_author'] ) ? '' : wp_strip_all_tags( $comment['comment_author'] ) )
 		) . sprintf(
 			"URL: %s\r\n",
 			// empty check exists.

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -2396,7 +2396,12 @@ class Antispam_Bee {
 	 * @return  mixed        FALSE in case of error
 	 */
 	private static function _update_spam_log( $comment ) {
-		if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) || ! ANTISPAM_BEE_LOG_FILE || validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0 || ! is_writable( ANTISPAM_BEE_LOG_FILE ) ) {
+		if (
+			! defined( 'ANTISPAM_BEE_LOG_FILE' ) ||
+			! ANTISPAM_BEE_LOG_FILE ||
+			validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0 ||
+			! is_writable( ANTISPAM_BEE_LOG_FILE )
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
Hey folks,

Two Plugin Check findings from issue #534 that are ready to fix now.

**Settings action link URL not escaped**

`init_action_links()` passes the `add_query_arg()` return value directly into the `href` attribute of the settings link. `add_query_arg()` output should always go through `esc_url()` before it lands in HTML. This fixes the `WordPress.Security.EscapeOutput.OutputNotEscaped` finding.

**`strip_tags()` replaced with `wp_strip_all_tags()` in the notification email**

The spam notification email body uses `strip_tags()` in three places — on `post_title`, `comment_author`, and `comment_content`. `wp_strip_all_tags()` is the WordPress equivalent and handles edge cases (`<script>` and `<style>` content) more completely. The function is available across the supported version range and the output is plain text in all three cases, so the substitution is a safe drop-in.

I left the `file_put_contents` / WP_Filesystem item and the nonce-verification items for a separate PR — those need more context about the surrounding logic to get right.

No unit test added: these are output-escaping and function-preference changes with no behavioral delta, and neither `init_action_links` nor `send_mail_notification` have existing test coverage in the suite.

To verify: activate the plugin on a test site, visit the Plugins page, and confirm the Settings link still resolves correctly. For the `wp_strip_all_tags` change, trigger a spam notification and confirm the email body renders as expected.

(full disclosure: AI helped me identify the issue and verify my work)