### PR TITLE
fix: wrap settings tab navigation in nav element for accessibility

### DIFF
--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -198,20 +198,22 @@ class SettingsPage {
 		<div class="wrap" id="ab_main">
 			<h1><?php esc_html_e( 'Antispam Bee', 'antispam-bee' ); ?></h1>
 
-			<ul class="nav-tab-wrapper">
-				<style>.nav-tab-wrapper li { margin-bottom: 0; }</style>
-				<?php foreach ( $this->tabs as $tab ) : ?>
-				<li>
-					<?php if ( $tab->get_slug() === $this->active_tab ) : ?>
-						<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
-							class="nav-tab nav-tab-active"><?php echo esc_html( $tab->get_title() ); ?></a>
-					<?php else : ?>
-						<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
-							class="nav-tab"><?php echo esc_html( $tab->get_title() ); ?></a>
-					<?php endif; ?>
-				</li>
-				<?php endforeach; ?>
-			</ul>
+			<nav aria-label="<?php esc_attr_e( 'Settings sections', 'antispam-bee' ); ?>">
+				<ul class="nav-tab-wrapper">
+					<style>.nav-tab-wrapper li { margin-bottom: 0; }</style>
+					<?php foreach ( $this->tabs as $tab ) : ?>
+					<li>
+						<?php if ( $tab->get_slug() === $this->active_tab ) : ?>
+							<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
+								class="nav-tab nav-tab-active" aria-current="page"><?php echo esc_html( $tab->get_title() ); ?></a>
+						<?php else : ?>
+							<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
+								class="nav-tab"><?php echo esc_html( $tab->get_title() ); ?></a>
+						<?php endif; ?>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</nav>
 
 			<form
 				action="<?php echo esc_url( add_query_arg( 'tab', $this->active_tab, admin_url( 'options.php' ) ) ); ?>"


### PR DESCRIPTION
## Summary

- Wraps the settings tab list in a `<nav aria-label="Settings sections">` so screen readers can identify and navigate to it
- Adds `aria-current="page"` to the active tab link

ARIA `role="tablist"` / `role="tab"` are intentionally not used: those roles imply a JavaScript-driven widget with arrow-key navigation and in-place panel switching. Here each tab triggers a full page reload, so the correct semantic is a landmark navigation region.