### PR TITLE
feat: single-form tabbed settings page with client-side tab switching

### DIFF
--- a/assets/js/admin-tabs.js
+++ b/assets/js/admin-tabs.js
@@ -1,0 +1,103 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+	const tabs = document.querySelectorAll( '#ab_main .nav-tab-wrapper .nav-tab' );
+	const tabContents = document.querySelectorAll( '#ab_main .nav-tab__content' );
+	const refererInput = document.querySelector( '[name="_wp_http_referer"]' );
+	const TAB_PARAM = 'tab';
+
+	for ( const tab of tabs ) {
+		tab.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+			switchToTab( tab.dataset.tab );
+		} );
+
+		tab.addEventListener( 'keydown', handleKeydown );
+	}
+
+	window.addEventListener( 'popstate', () => {
+		const slug = new URLSearchParams( window.location.search ).get( TAB_PARAM );
+		if ( slug ) {
+			setActiveTab( slug );
+		}
+	} );
+
+	/**
+	 * Handle keyboard navigation between tabs.
+	 *
+	 * @param {KeyboardEvent} event
+	 */
+	function handleKeydown( event ) {
+		const tabList = Array.from( tabs );
+		const idx = tabList.indexOf( event.currentTarget );
+		let newIdx;
+
+		switch ( event.key ) {
+			case 'ArrowLeft':
+				newIdx = ( idx - 1 + tabList.length ) % tabList.length;
+				break;
+			case 'ArrowRight':
+				newIdx = ( idx + 1 ) % tabList.length;
+				break;
+			case 'Home':
+				newIdx = 0;
+				break;
+			case 'End':
+				newIdx = tabList.length - 1;
+				break;
+			default:
+				return;
+		}
+
+		event.preventDefault();
+		tabList[ newIdx ].focus();
+		switchToTab( tabList[ newIdx ].dataset.tab );
+	}
+
+	/**
+	 * Switch to the given tab and update the URL.
+	 *
+	 * @param {string} slug Tab slug to activate.
+	 */
+	function switchToTab( slug ) {
+		setActiveTab( slug );
+		updateUrl( slug );
+	}
+
+	/**
+	 * Activate a tab panel and update ARIA state.
+	 *
+	 * @param {string} slug Tab slug to activate.
+	 */
+	function setActiveTab( slug ) {
+		for ( const tab of tabs ) {
+			const active = tab.dataset.tab === slug;
+			tab.classList.toggle( 'nav-tab-active', active );
+			tab.ariaSelected = String( active );
+			tab.tabIndex = active ? 0 : -1;
+		}
+
+		for ( const content of tabContents ) {
+			content.hidden = content.id !== 'nav-tab__content--' + slug;
+		}
+	}
+
+	/**
+	 * Update the browser URL and WP referer field for the active tab.
+	 *
+	 * @param {string} slug Tab slug.
+	 */
+	function updateUrl( slug ) {
+		const setTab = ( search ) => {
+			const params = new URLSearchParams( search || '' );
+			params.set( TAB_PARAM, slug );
+			return params.toString();
+		};
+
+		const [ path, search ] = window.location.href.split( '?' );
+		history.replaceState( null, null, path + '?' + setTab( search ) );
+
+		if ( refererInput && refererInput.value.includes( '?' ) ) {
+			const [ refPath, refSearch ] = refererInput.value.split( '?' );
+			refererInput.value = refPath + '?' + setTab( refSearch );
+		}
+	}
+} );

--- a/src/Admin/Section.php
+++ b/src/Admin/Section.php
@@ -203,6 +203,8 @@ class Section {
 	 * Renders the settings section.
 	 */
 	public function render(): void {
+		$page = SettingsPage::SETTINGS_PAGE_SLUG . '_' . $this->type;
+
 		add_settings_section(
 			$this->get_slug(),
 			$this->get_title(),
@@ -210,7 +212,7 @@ class Section {
 				$this,
 				'get_callback',
 			],
-			SettingsPage::SETTINGS_PAGE_SLUG
+			$page
 		);
 
 		foreach ( $this->get_rows() as $row ) {
@@ -220,7 +222,7 @@ class Section {
 				function () use ( $row ) {
 					$this->render_row_fields( $row );
 				},
-				SettingsPage::SETTINGS_PAGE_SLUG,
+				$page,
 				$this->get_slug()
 			);
 		}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -219,7 +219,8 @@ class SettingsPage {
 			<h1><?php esc_html_e( 'Antispam Bee', 'antispam-bee' ); ?></h1>
 
 			<div class="nav-tab-wrapper" role="tablist">
-				<?php foreach ( $this->tabs as $tab ) :
+				<?php
+				foreach ( $this->tabs as $tab ) :
 					$is_active = $tab->get_slug() === $this->active_tab;
 					?>
 					<button
@@ -237,9 +238,10 @@ class SettingsPage {
 			<form action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>" method="post">
 				<?php settings_fields( self::SETTINGS_PAGE_SLUG ); ?>
 
-				<?php foreach ( $this->tabs as $tab ) :
+				<?php
+				foreach ( $this->tabs as $tab ) :
 					$is_active = $tab->get_slug() === $this->active_tab;
-				?>
+					?>
 				<div
 					id="nav-tab__content--<?php echo esc_attr( $tab->get_slug() ); ?>"
 					class="nav-tab__content"

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -62,6 +62,7 @@ class SettingsPage {
 	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'setup_settings' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( MAIN_PLUGIN_FILE ), [ $this, 'add_action_links' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'add_row_meta' ], 10, 2 );
 
@@ -79,6 +80,25 @@ class SettingsPage {
 			'manage_options',
 			self::SETTINGS_PAGE_SLUG,
 			[ $this, 'options_page' ]
+		);
+	}
+
+	/**
+	 * Enqueue admin assets for the settings page.
+	 *
+	 * @param string $hook_suffix Current admin page hook suffix.
+	 */
+	public function enqueue_assets( string $hook_suffix ): void {
+		if ( 'settings_page_antispam_bee' !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'antispam-bee-admin-tabs',
+			plugins_url( 'assets/js/admin-tabs.js', dirname( dirname( __DIR__ ) ) . '/antispam_bee.php' ),
+			[],
+			'3.0.0',
+			true
 		);
 	}
 
@@ -123,13 +143,9 @@ class SettingsPage {
 
 		$this->populate_tabs();
 
-		// Register option setting.
+		// Register sections for all tabs.
 		foreach ( $this->tabs as $tab ) {
 			foreach ( $tab->get_sections() as $section ) {
-				if ( $tab->get_slug() !== $this->active_tab ) {
-					continue;
-				}
-
 				$section->render();
 			}
 		}
@@ -149,47 +165,48 @@ class SettingsPage {
 	 * @return void
 	 */
 	protected function populate_tabs(): void {
-		$type = $this->active_tab;
+		foreach ( $this->tabs as $tab ) {
+			$type = $tab->get_slug();
+			$data = [];
 
-		$data = [];
-
-		if ( 'general' === $type ) {
-			$data['general'] = [
-				'title'         => ContentTypeHelper::get_type_name( 'general' ),
-				'description'   => __( 'Setup global plugin spam settings.', 'antispam-bee' ),
-				'controllables' => ComponentsHelper::filter( GeneralOptions::get_controllables(), [ 'reaction_type' => $type ] ),
-			];
-		}
-
-		$data = array_merge(
-			$data,
-			[
-				'rules'           => [
-					'title'         => __( 'Rules', 'antispam-bee' ),
-					'description'   => __( 'Setup rules.', 'antispam-bee' ),
-					'controllables' => ComponentsHelper::filter( $this->rules, [ 'reaction_type' => $type ] ),
-				],
-				'post_processors' => [
-					'title'         => __( 'Post Processors', 'antispam-bee' ),
-					'description'   => __( 'Setup post processors.', 'antispam-bee' ),
-					'controllables' => ComponentsHelper::filter( $this->post_processors, [ 'reaction_type' => $type ] ),
-				],
-			]
-		);
-
-		foreach ( $data as $key => $value ) {
-			if ( empty( $value['controllables'] ) ) {
-				continue;
+			if ( 'general' === $type ) {
+				$data['general'] = [
+					'title'         => ContentTypeHelper::get_type_name( 'general' ),
+					'description'   => __( 'Setup global plugin spam settings.', 'antispam-bee' ),
+					'controllables' => ComponentsHelper::filter( GeneralOptions::get_controllables(), [ 'reaction_type' => $type ] ),
+				];
 			}
 
-			$section = new Section(
-				$key,
-				$value['title'],
-				$value['description'],
-				$type
+			$data = array_merge(
+				$data,
+				[
+					'rules'           => [
+						'title'         => __( 'Rules', 'antispam-bee' ),
+						'description'   => __( 'Setup rules.', 'antispam-bee' ),
+						'controllables' => ComponentsHelper::filter( $this->rules, [ 'reaction_type' => $type ] ),
+					],
+					'post_processors' => [
+						'title'         => __( 'Post Processors', 'antispam-bee' ),
+						'description'   => __( 'Setup post processors.', 'antispam-bee' ),
+						'controllables' => ComponentsHelper::filter( $this->post_processors, [ 'reaction_type' => $type ] ),
+					],
+				]
 			);
-			$section->add_controllables( $value['controllables'] );
-			$this->tabs[ $type ]->add_section( $section );
+
+			foreach ( $data as $key => $value ) {
+				if ( empty( $value['controllables'] ) ) {
+					continue;
+				}
+
+				$section = new Section(
+					$key,
+					$value['title'],
+					$value['description'],
+					$type
+				);
+				$section->add_controllables( $value['controllables'] );
+				$this->tabs[ $type ]->add_section( $section );
+			}
 		}
 	}
 
@@ -201,32 +218,39 @@ class SettingsPage {
 		<div class="wrap" id="ab_main">
 			<h1><?php esc_html_e( 'Antispam Bee', 'antispam-bee' ); ?></h1>
 
-			<nav aria-label="<?php esc_attr_e( 'Settings sections', 'antispam-bee' ); ?>">
-				<ul class="nav-tab-wrapper">
-					<style>.nav-tab-wrapper li { margin-bottom: 0; }</style>
-					<?php foreach ( $this->tabs as $tab ) : ?>
-					<li>
-						<?php if ( $tab->get_slug() === $this->active_tab ) : ?>
-							<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
-								class="nav-tab nav-tab-active" aria-current="page"><?php echo esc_html( $tab->get_title() ); ?></a>
-						<?php else : ?>
-							<a href="?page=antispam_bee&tab=<?php echo esc_attr( $tab->get_slug() ); ?>"
-								class="nav-tab"><?php echo esc_html( $tab->get_title() ); ?></a>
-						<?php endif; ?>
-					</li>
-					<?php endforeach; ?>
-				</ul>
-			</nav>
+			<div class="nav-tab-wrapper" role="tablist">
+				<?php foreach ( $this->tabs as $tab ) :
+					$is_active = $tab->get_slug() === $this->active_tab;
+					?>
+					<button
+							type="button"
+							id="tab-<?php echo esc_attr( $tab->get_slug() ); ?>"
+							class="nav-tab<?php echo $is_active ? ' nav-tab-active' : ''; ?>"
+							data-tab="<?php echo esc_attr( $tab->get_slug() ); ?>"
+							role="tab"
+							aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>"
+							tabindex="<?php echo $is_active ? '0' : '-1'; ?>"
+					><?php echo esc_html( $tab->get_title() ); ?></button>
+				<?php endforeach; ?>
+			</div>
 
-			<form
-				action="<?php echo esc_url( add_query_arg( 'tab', $this->active_tab, admin_url( 'options.php' ) ) ); ?>"
-				method="post">
-				<input type="hidden" name="action" value="ab_save_changes"/>
-
+			<form action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>" method="post">
 				<?php settings_fields( self::SETTINGS_PAGE_SLUG ); ?>
-				<?php do_settings_sections( self::SETTINGS_PAGE_SLUG ); ?>
 
-				<?php submit_button(); ?>
+				<?php foreach ( $this->tabs as $tab ) :
+					$is_active = $tab->get_slug() === $this->active_tab;
+				?>
+				<div
+					id="nav-tab__content--<?php echo esc_attr( $tab->get_slug() ); ?>"
+					class="nav-tab__content"
+					role="tabpanel"
+					aria-labelledby="tab-<?php echo esc_attr( $tab->get_slug() ); ?>"
+					<?php echo $is_active ? '' : 'hidden'; ?>
+				>
+					<?php do_settings_sections( self::SETTINGS_PAGE_SLUG . '_' . $tab->get_slug() ); ?>
+					<?php submit_button(); ?>
+				</div>
+				<?php endforeach; ?>
 			</form>
 		</div>
 		<?php

--- a/src/Helpers/Sanitize.php
+++ b/src/Helpers/Sanitize.php
@@ -85,19 +85,36 @@ class Sanitize {
 	 */
 	public static function sanitize_options( array $options ): array {
 		$current_options = Settings::get_options();
+		$options         = ! empty( $options ) ? $options : [];
 
-		if ( empty( $_GET['tab'] ) ) {
-			$tab = 'general';
-		} else {
-			$tab = sanitize_key( wp_unslash( $_GET['tab'] ) );
+		$tabs = self::get_tab_slugs();
+
+		foreach ( $tabs as $tab ) {
+			if ( ! isset( $options[ $tab ] ) ) {
+				$options[ $tab ] = [];
+			}
+			$sanitized_options       = self::sanitize_controllables( $options, $tab );
+			$current_options[ $tab ] = $sanitized_options[ $tab ] ?? [];
 		}
 
-		$options = ! empty( $options ) ? $options : [ $tab => [] ];
-
-		$sanitized_options       = self::sanitize_controllables( $options, $tab );
-		$current_options[ $tab ] = $sanitized_options[ $tab ];
-
 		return $current_options;
+	}
+
+	/**
+	 * Return all valid settings tab slugs derived from registered controllables.
+	 *
+	 * @return string[]
+	 */
+	private static function get_tab_slugs(): array {
+		$tabs = [ 'general' ];
+
+		foreach ( array_merge( Rules::get_controllables(), PostProcessors::get_controllables() ) as $controllable ) {
+			foreach ( $controllable::get_supported_types() as $type ) {
+				$tabs[] = $type;
+			}
+		}
+
+		return array_unique( $tabs );
 	}
 
 	/**

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -111,8 +111,8 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 				'email' => '@mail\.ru|@yandex\.',
 			],
 			[
-				'body' => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
-				'email' => '@gmail\.com',
+				'body'   => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
+				'email'  => '@gmail\.com',
 				'author' => '^[A-Z][a-z]+\d{3,4}$',
 			],
 			[


### PR DESCRIPTION
## Summary

- Renders all tab panels inside a single `<form>` so unsaved changes on one tab are not lost when switching to another
- Replaces full-page-reload tab links with `<button>` elements driven by a new `assets/js/admin-tabs.js` (tab show/hide, ARIA state, URL sync via `history.replaceState`, keyboard navigation)
- Sanitizer now processes all tabs on every save instead of only the active tab, removing the `$_GET['tab']` dependency
- Each settings section registers under a per-tab page slug (`antispam_bee_{type}`) so `do_settings_sections()` can target individual panels

## Test plan

- [ ] Settings page loads without PHP errors on all tabs
- [ ] Clicking a tab switches content without a page reload
- [ ] URL updates to `?page=antispam_bee&tab={slug}` on tab switch
- [ ] Changing a setting on one tab, switching to another, then saving — the first tab's change persists
- [ ] Keyboard navigation: Arrow Left/Right, Home, End move between tabs
- [ ] Save Changes button works from any tab
- [ ] After save, page redirects back to the correct tab