### PR TITLE
feat: add support links next to Save button on General tab

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -23,6 +23,7 @@ namespace AntispamBee;
 
 define( __NAMESPACE__ . '\MAIN_PLUGIN_FILE', __FILE__ );
 define( __NAMESPACE__ . '\PLUGIN_PATH', plugin_dir_path( MAIN_PLUGIN_FILE ) );
+define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-alpha.15' );
 
 // The pre_init functions check the compatibility of the plugin and calls the init function, if check were successful.
 pre_init();

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -2,6 +2,10 @@
 	margin-bottom: 0;
 }
 
+.nav-tab-wrapper button {
+	cursor: pointer;
+}
+
 .ab-action-row {
 	display: flex;
 	flex-wrap: wrap;

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -12,3 +12,4 @@ namespace AntispamBee;
 
 define( __NAMESPACE__ . '\MAIN_PLUGIN_FILE', __DIR__ . '/antispam_bee.php' );
 define( __NAMESPACE__ . '\PLUGIN_PATH', __DIR__ . '/' );
+define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-alpha.15' );

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -82,7 +82,7 @@ class SettingsPage {
 
 		wp_enqueue_style(
 			'antispam-bee-admin',
-			plugin_dir_url( MAIN_PLUGIN_FILE ) . 'src/Admin/assets/admin.css',
+			plugin_dir_url( MAIN_PLUGIN_FILE ) . 'assets/css/admin.css',
 			[],
 			PLUGIN_VERSION
 		);

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -62,7 +62,6 @@ class SettingsPage {
 	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'setup_settings' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( MAIN_PLUGIN_FILE ), [ $this, 'add_action_links' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'add_row_meta' ], 10, 2 );
@@ -87,6 +86,14 @@ class SettingsPage {
 			[],
 			PLUGIN_VERSION
 		);
+
+		wp_enqueue_script(
+			'antispam-bee-admin-tabs',
+			plugin_dir_url( MAIN_PLUGIN_FILE ) . 'assets/js/admin-tabs.js',
+			[],
+			PLUGIN_VERSION,
+			true
+		);
 	}
 
 	/**
@@ -99,25 +106,6 @@ class SettingsPage {
 			'manage_options',
 			self::SETTINGS_PAGE_SLUG,
 			[ $this, 'options_page' ]
-		);
-	}
-
-	/**
-	 * Enqueue admin assets for the settings page.
-	 *
-	 * @param string $hook_suffix Current admin page hook suffix.
-	 */
-	public function enqueue_assets( string $hook_suffix ): void {
-		if ( 'settings_page_antispam_bee' !== $hook_suffix ) {
-			return;
-		}
-
-		wp_enqueue_script(
-			'antispam-bee-admin-tabs',
-			plugins_url( 'assets/js/admin-tabs.js', dirname( dirname( __DIR__ ) ) . '/antispam_bee.php' ),
-			[],
-			'3.0.0',
-			true
 		);
 	}
 

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -240,7 +240,26 @@ class SettingsPage {
 					<?php echo $is_active ? '' : 'hidden'; ?>
 				>
 					<?php do_settings_sections( self::SETTINGS_PAGE_SLUG . '_' . $tab->get_slug() ); ?>
-					<?php submit_button(); ?>
+
+					<?php if ( 'general' === $this->active_tab ) : ?>
+						<style>
+							.ab-form-footer { display: flex; align-items: center; }
+							.ab-support-links { display: flex; gap: 1em; margin-left: 1.5em; padding-left: 1.5em; border-left: 1px solid #c3c4c7; font-size: 0.85em; }
+							.ab-support-links a { color: #646970; text-decoration: none; }
+							.ab-support-links a:hover { color: #135e96; text-decoration: underline; }
+						</style>
+						<p class="submit ab-form-footer">
+							<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Save Changes' ); ?>">
+							<span class="ab-support-links">
+							<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'antispam-bee' ); ?></a>
+							<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/antispam-bee/#faq', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'antispam-bee' ); ?></a>
+							<a href="<?php echo esc_url( __( 'https://antispambee.pluginkollektiv.org/documentation', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'antispam-bee' ); ?></a>
+							<a href="https://wordpress.org/support/plugin/antispam-bee/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'antispam-bee' ); ?></a>
+						</span>
+						</p>
+					<?php else : ?>
+						<?php submit_button(); ?>
+					<?php endif; ?>
 				</div>
 				<?php endforeach; ?>
 			</form>

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -261,19 +261,20 @@ class SettingsPage {
 				>
 					<?php do_settings_sections( self::SETTINGS_PAGE_SLUG . '_' . $tab->get_slug() ); ?>
 
-					<?php if ( 'general' === $this->active_tab ) : ?>
-						<p class="submit ab-form-footer">
-						<?php echo get_submit_button( null, 'primary', 'submit', false ); ?>
-							<span class="ab-support-links">
-							<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'antispam-bee' ); ?></a>
-							<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/antispam-bee/#faq', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'antispam-bee' ); ?></a>
-							<a href="<?php echo esc_url( __( 'https://antispambee.pluginkollektiv.org/documentation', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'antispam-bee' ); ?></a>
-							<a href="https://wordpress.org/support/plugin/antispam-bee/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'antispam-bee' ); ?></a>
-						</span>
-						</p>
-					<?php else : ?>
+					<div class="ab-action-row">
 						<?php submit_button(); ?>
-					<?php endif; ?>
+
+						<?php if ( 'general' === $this->active_tab ) : ?>
+							<nav class="ab-help-links" aria-label="<?php echo esc_attr__( 'Plugin resources', 'antispam-bee' ); ?>">
+								<ul>
+									<li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'antispam-bee' ); ?></a></li>
+									<li><a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/antispam-bee/#faq', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'antispam-bee' ); ?></a></li>
+									<li><a href="<?php echo esc_url( __( 'https://antispambee.pluginkollektiv.org/documentation', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Manual', 'antispam-bee' ); ?></a></li>
+									<li><a href="https://wordpress.org/support/plugin/antispam-bee/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Support', 'antispam-bee' ); ?></a></li>
+								</ul>
+							</nav>
+						<?php endif; ?>
+					</div>
 				</div>
 				<?php endforeach; ?>
 			</form>

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -15,6 +15,7 @@ use AntispamBee\Helpers\ContentTypeHelper;
 use AntispamBee\Helpers\Sanitize;
 use AntispamBee\Helpers\Settings;
 use const AntispamBee\MAIN_PLUGIN_FILE;
+use const AntispamBee\PLUGIN_VERSION;
 
 /**
  * Antispam Bee Settings Page
@@ -62,11 +63,30 @@ class SettingsPage {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'setup_settings' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( MAIN_PLUGIN_FILE ), [ $this, 'add_action_links' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'add_row_meta' ], 10, 2 );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'general';
+	}
+
+	/**
+	 * Enqueue admin stylesheet on the settings page.
+	 *
+	 * @param string $hook_suffix Current admin page hook suffix.
+	 */
+	public function enqueue_scripts( string $hook_suffix ): void {
+		if ( 'settings_page_' . self::SETTINGS_PAGE_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'antispam-bee-admin',
+			plugin_dir_url( MAIN_PLUGIN_FILE ) . 'src/Admin/assets/admin.css',
+			[],
+			PLUGIN_VERSION
+		);
 	}
 
 	/**
@@ -242,14 +262,8 @@ class SettingsPage {
 					<?php do_settings_sections( self::SETTINGS_PAGE_SLUG . '_' . $tab->get_slug() ); ?>
 
 					<?php if ( 'general' === $this->active_tab ) : ?>
-						<style>
-							.ab-form-footer { display: flex; align-items: center; }
-							.ab-support-links { display: flex; gap: 1em; margin-left: 1.5em; padding-left: 1.5em; border-left: 1px solid #c3c4c7; font-size: 0.85em; }
-							.ab-support-links a { color: #646970; text-decoration: none; }
-							.ab-support-links a:hover { color: #135e96; text-decoration: underline; }
-						</style>
 						<p class="submit ab-form-footer">
-							<input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Save Changes' ); ?>">
+						<?php echo get_submit_button( null, 'primary', 'submit', false ); ?>
 							<span class="ab-support-links">
 							<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Donate', 'antispam-bee' ); ?></a>
 							<a href="<?php echo esc_url( __( 'https://wordpress.org/plugins/antispam-bee/#faq', 'antispam-bee' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'FAQ', 'antispam-bee' ); ?></a>

--- a/src/Admin/assets/admin.css
+++ b/src/Admin/assets/admin.css
@@ -1,0 +1,27 @@
+.nav-tab-wrapper li {
+	margin-bottom: 0;
+}
+
+.ab-form-footer {
+	display: flex;
+	align-items: center;
+}
+
+.ab-support-links {
+	display: flex;
+	gap: 1em;
+	margin-left: 1.5em;
+	padding-left: 1.5em;
+	border-left: 1px solid #c3c4c7;
+	font-size: 0.85em;
+}
+
+.ab-support-links a {
+	color: #646970;
+	text-decoration: none;
+}
+
+.ab-support-links a:hover {
+	color: #135e96;
+	text-decoration: underline;
+}

--- a/src/Admin/assets/admin.css
+++ b/src/Admin/assets/admin.css
@@ -2,26 +2,90 @@
 	margin-bottom: 0;
 }
 
-.ab-form-footer {
+.ab-action-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 16px;
+}
+
+.ab-action-row .submit {
+	margin: 0;
+	flex-shrink: 0;
+}
+
+.ab-help-links {
+	flex: 1;
+	min-width: 320px;
+}
+
+.ab-help-links ul {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.ab-help-links li {
+	margin: 0;
 	display: flex;
 	align-items: center;
 }
 
-.ab-support-links {
-	display: flex;
-	gap: 1em;
-	margin-left: 1.5em;
-	padding-left: 1.5em;
-	border-left: 1px solid #c3c4c7;
-	font-size: 0.85em;
+.ab-help-links li + li::before {
+	content: "•";
+	display: inline-block;
+	margin: 0 .75em;
+	color: #8c8f94;
+	font-size: .75em;
+	vertical-align: middle;
 }
 
-.ab-support-links a {
-	color: #646970;
+.ab-help-links a {
 	text-decoration: none;
 }
 
-.ab-support-links a:hover {
-	color: #135e96;
-	text-decoration: underline;
+/* Wide screens: grid keeps links truly centered on the row, button stays left */
+@media (min-width: 961px) {
+	.ab-action-row {
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		align-items: center;
+	}
+
+	.ab-action-row .submit {
+		grid-column: 1;
+		justify-self: start;
+	}
+
+	.ab-help-links {
+		grid-column: 2;
+		flex: none;
+	}
+}
+
+/* Medium screens: links right-aligned, still beside the button */
+@media (max-width: 960px) {
+	.ab-help-links ul {
+		justify-content: flex-end;
+		align-items: flex-end;
+	}
+}
+
+/* Small screens: stack below button, left-aligned, with top border */
+@media (max-width: 782px) {
+	.ab-help-links {
+		flex-basis: 100%;
+	}
+
+	.ab-help-links ul {
+		justify-content: flex-start;
+		align-items: center;
+		width: fit-content;
+		border-top: 1px solid #c3c4c7;
+		padding-top: 16px;
+	}
 }


### PR DESCRIPTION
## Summary

Restores the Donate, FAQ, Manual and Support links from v2, placed on the General tab next to the Save Changes button.

- The four links appear to the right of the Save button, separated from it by a vertical rule
- Links open in a new tab
- Only shown on the General tab; other tabs retain the standard `submit_button()` output
- Adds `src/Admin/assets/admin.css` for admin styles, enqueued via `wp_enqueue_style()` on the settings page only (replaces the previous inline `<style>` tags)
- Adds a `PLUGIN_VERSION` constant for stylesheet cache busting

Closes #707