### PR TITLE
ci: enable test workflows on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Tests, Coding Standards
-on: push
+on:
+  push:
+  pull_request:
 jobs:
   test-unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `pull_request:` trigger to `.github/workflows/tests.yml` so CI runs on PRs, not only on pushes.

Closes #709

## Test plan

- [ ] Open a draft PR against `v3` and verify the test workflows are triggered