### PR TITLE
fix: delete antispambee_db_version option on plugin uninstall

### DIFF
--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -72,6 +72,7 @@ class PluginStateChangeHandler {
 		}
 
 		delete_option( Settings::OPTION_NAME );
+		delete_option( 'antispambee_db_version' );
 		// @todo: do that when out of beta.
 		// delete_option( 'antispam_bee' );
 


### PR DESCRIPTION
## Summary

- Adds `delete_option('antispambee_db_version')` to `PluginStateChangeHandler::maybe_remove_antispam_bee_data()`.
- The `antispambee_db_version` option (managed by `PluginUpdate`) was left behind in the database when the plugin was deleted.

Closes #710

## Test plan

- [ ] Install the plugin, then delete it with "Delete data on uninstall" enabled
- [ ] Confirm `antispambee_db_version` is no longer present in `wp_options`