### PR TITLE
fix: only determine client IP from REMOTE_ADDR via pre_comment_user_ip filter

### DIFF
--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -13,38 +13,25 @@ namespace AntispamBee\Helpers;
 class IpHelper {
 
 	/**
-	 * Return real client IP
+	 * Return real client IP.
+	 *
+	 * By default, only `REMOTE_ADDR` is evaluated. Use the `pre_comment_user_ip`
+	 * filter to supply an IP from a trusted proxy header instead.
+	 *
+	 * @hook    string  pre_comment_user_ip  The client IP, defaults to REMOTE_ADDR.
 	 *
 	 * @return string Client IP
 	 */
 	public static function get_client_ip(): string {
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		// Sanitization of $ip takes place further down.
-		$ip = '';
-
-		if ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-			$ip = wp_unslash( $_SERVER['HTTP_CLIENT_IP'] );
-		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-			$ip = wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] );
-		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED'] ) ) {
-			$ip = wp_unslash( $_SERVER['HTTP_X_FORWARDED'] );
-		} elseif ( isset( $_SERVER['HTTP_FORWARDED_FOR'] ) ) {
-			$ip = wp_unslash( $_SERVER['HTTP_FORWARDED_FOR'] );
-		} elseif ( isset( $_SERVER['HTTP_FORWARDED'] ) ) {
-			$ip = wp_unslash( $_SERVER['HTTP_FORWARDED'] );
-		}
-
-		$ip = self::sanitize_ip( $ip );
-		if ( $ip ) {
-			return $ip;
-		}
-
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
-			return self::sanitize_ip( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
-		}
-
-		return '';
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		return self::sanitize_ip(
+			(string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) )
+		);
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 	}
 
 	/**

--- a/tests/Unit/Handlers/CommentTest.php
+++ b/tests/Unit/Handlers/CommentTest.php
@@ -19,8 +19,8 @@ class CommentTest extends TestCase {
 
 		$_POST   = null;
 		$_SERVER = [
-			'HTTP_CLIENT_IP' => '192.0.2.100',
-			'SCRIPT_NAME'    => '/index.php'
+			'REMOTE_ADDR' => '192.0.2.100',
+			'SCRIPT_NAME' => '/index.php',
 		];
 
 		stubs(

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\IpHelper;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Functions\when;
+use function Brain\Monkey\Filters\expectApplied;
+
+/**
+ * Unit tests for {@see IpHelper}.
+ *
+ * @backupGlobals enabled
+ */
+class IpHelperTest extends TestCase {
+
+	public function test_get_client_ip_uses_remote_addr(): void {
+		global $_SERVER;
+
+		when( 'wp_unslash' )->returnArg();
+
+		$_SERVER['REMOTE_ADDR']          = '192.0.2.1';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1';
+
+		self::assertSame( '192.0.2.1', IpHelper::get_client_ip(), 'REMOTE_ADDR should be the default IP source' );
+	}
+
+	public function test_get_client_ip_filter_can_override(): void {
+		global $_SERVER;
+
+		when( 'wp_unslash' )->returnArg();
+
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.1';
+
+		expectApplied( 'pre_comment_user_ip' )
+			->once()
+			->with( '192.0.2.1' )
+			->andReturn( '192.0.2.2' );
+
+		self::assertSame( '192.0.2.2', IpHelper::get_client_ip(), 'pre_comment_user_ip filter should override the IP' );
+	}
+}


### PR DESCRIPTION
## Summary

- Refactors `IpHelper::get_client_ip()` to use only `REMOTE_ADDR` by default instead of checking multiple proxy headers (which are trivially spoofable).
- Proxy/forwarded headers can be used by hooking the standard WordPress `pre_comment_user_ip` filter.
- Updates `CommentTest` to use `REMOTE_ADDR` instead of `HTTP_CLIENT_IP`.
- Adds a new `tests/Unit/Helpers/IpHelperTest.php` with tests for default behaviour and filter override.

Closes #708

## Test plan

- [ ] Run `composer test:unit` — all tests pass
- [ ] Verify client IP is read from `REMOTE_ADDR` by default
- [ ] Verify a `pre_comment_user_ip` filter hook can supply an IP from a trusted proxy header