### PR TITLE
fix: raise comment_form_field_comment filter priority to 99

### DIFF
--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -49,7 +49,8 @@ class Honeypot extends ControllableBase implements SpamReason {
 				}
 
 				return HoneypotField::inject( $field_markup, [ 'field_id' => 'comment' ] );
-			}
+			},
+			99
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Raises the priority of the `comment_form_field_comment` filter from the default 10 to 99 in `Rules/Honeypot::init()`.
- This prevents conflicts with themes that also hook into `comment_form_field_comment` at the default priority and overwrite the honeypot field.

Closes #705

## Test plan

- [ ] Run `composer test:unit` — all tests pass
- [ ] Verify the honeypot field is injected correctly even when a theme uses `comment_form_field_comment` at priority 10