### PR TITLE
fix: make quotes optional in Honeypot inject() regex; add tests

### DIFF
--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -81,17 +81,17 @@ class Honeypot {
 						<textarea                                        (?# the opening of the textarea and some optional attributes )
 						(                                                (?# match a id attribute followed by some optional ones and the name attribute )
 							(?P<before1>[^>]*)
-							(?P<id1>id=["\']{{HONEYPOT_ID}}["\'])
+							(?P<id1>id=["\']?{{HONEYPOT_ID}}["\']?)
 							(?P<between1>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							|                                            (?# match same as before, but with the name attribute before the id attribute )
 							(?P<before2>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							(?P<between2>[^>]*)
-							(?P<id2>id=["\']{{HONEYPOT_ID}}["\'])
+							(?P<id2>id=["\']?{{HONEYPOT_ID}}["\']?)
 							|                                            (?# match same as before, but with no id attribute )
 							(?P<before3>[^>]*)
-							name=["\']{{HONEYPOT_NAME}}["\']
+							name=["\']?{{HONEYPOT_NAME}}["\']?
 							(?P<between3>[^>]*)
 						)
 						(?P<after>[^>]*)                                 (?# match any additional optional attributes )

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Honeypot;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'NONCE_SALT' ) ) {
+	define( 'NONCE_SALT', 'test-nonce-salt' );
+}
+
+/**
+ * Unit tests for {@see Honeypot} (helper).
+ */
+class HoneypotHelperTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+		when( 'esc_attr' )->returnArg();
+		when( 'esc_js' )->returnArg();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_inject_returns_empty_when_field_not_found(): void {
+		$result = Honeypot::inject(
+			'<textarea id="other" name="other"></textarea>',
+			[ 'field_id' => 'comment' ]
+		);
+
+		self::assertSame( '', $result, 'inject() should return empty string when field id is not found' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_inject_with_quoted_attributes(): void {
+		$name   = Honeypot::get_secret_name_for_post();
+		$markup = '<textarea id="comment" name="comment" class="my-class">My Content</textarea>';
+
+		$result = Honeypot::inject( $markup, [ 'field_id' => 'comment' ] );
+
+		self::assertNotEmpty( $result, 'inject() should return non-empty markup for a valid field' );
+		self::assertStringContainsString( 'name="' . $name . '"', $result, 'Secret name should be in the output' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_inject_with_unquoted_attributes(): void {
+		$name   = Honeypot::get_secret_name_for_post();
+		$markup = '<textarea id=comment name=comment class="my-class">My Content</textarea>';
+
+		$result = Honeypot::inject( $markup, [ 'field_id' => 'comment' ] );
+
+		self::assertNotEmpty( $result, 'inject() should handle textarea with unquoted attributes' );
+		self::assertStringContainsString( 'name="' . $name . '"', $result, 'Secret name should be in the output for unquoted markup' );
+	}
+}


### PR DESCRIPTION
## Summary

- Makes attribute quotes optional in the `Helpers/Honeypot::inject()` regex patterns (e.g. `id=["\']?comment["\']?`), so it handles HTML with unquoted attributes.
- Adds a new `tests/Unit/Helpers/HoneypotHelperTest.php` covering:
  - `inject()` returns `''` when the target field id is not found
  - `inject()` works with quoted `name`/`id` attributes (baseline)
  - `inject()` works with unquoted `name`/`id` attributes

The code fix was supposed to land via #676 but the regex in `src/Helpers/Honeypot.php` was still requiring quotes.

Closes #713

## Test plan

- [ ] Run `composer test:unit` — all 15 tests pass including the 3 new Honeypot helper tests
- [ ] Manually verify a comment form with unquoted textarea attributes is handled correctly