### PR TITLE
fix: use wp_get_word_count_type() if available (WP 6.2+)

### DIFF
--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -63,19 +63,22 @@ class LangSpam extends ControllableBase implements SpamReason {
 
 		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $comment_text ), ' ' );
 
-		/*
-		 * translators: If your word count is based on single characters (e.g. East Asian characters),
-		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-		 * Do not translate into your own language.
-		 */
-		if ( strpos(
+		if ( function_exists( 'wp_get_word_count_type' ) ) {
+			$word_count_type = wp_get_word_count_type();
+		} else {
+			/*
+			 * translators: If your word count is based on single characters (e.g. East Asian characters),
+			 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+			 * Do not translate into your own language.
+			 */
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			_x( 'words', 'Word count type. Do not translate!' ),
-			'characters'
-		) === 0 && preg_match(
+			$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
+		}
+
+		if ( strpos( $word_count_type, 'characters' ) === 0 && preg_match(
 			'/^utf\-?8$/i',
 			get_option( 'blog_charset' )
-		) ) { // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		) ) {
 			preg_match_all( '/./u', $text, $words_array );
 			$word_count = 0;
 			if ( isset( $words_array[0] ) ) {


### PR DESCRIPTION
## Summary

Ports #717 (merged into `master`) to `v3`. That PR fixed #403.

- Use `wp_get_word_count_type()` (introduced in WP 6.2) when available instead of the translatable `_x()` fallback in `LangSpam::verify()`
- Falls back to the existing `_x( 'words', 'Word count type. Do not translate!' )` approach for WP < 6.2

## Changes

**`src/Rules/LangSpam.php`**
- Extract word count type detection into a local variable `$word_count_type`
- Wrap in `function_exists( 'wp_get_word_count_type' )` guard before calling it
- Remove the now-redundant `phpcs:ignore` on the `if` condition line

## Test plan

1. With WP 6.2+: verify `wp_get_word_count_type()` is called and the language spam check still works correctly for CJK locales
2. With WP < 6.2: verify the `_x()` fallback is used and behaviour is unchanged