### PR TITLE
refactor: disambiguate component_type vs reaction_type naming

### DIFF
--- a/src/Admin/CommentsColumns.php
+++ b/src/Admin/CommentsColumns.php
@@ -31,8 +31,8 @@ class CommentsColumns {
 
 		$supported_types = SaveReason::get_supported_types();
 		$show_column     = false;
-		foreach ( $supported_types as $type ) {
-			$show_column = Settings::get_option( SaveReason::get_option_name( 'active' ), $type );
+		foreach ( $supported_types as $reaction_type ) {
+			$show_column = Settings::get_option( SaveReason::get_option_name( 'active' ), $reaction_type );
 			if ( $show_column ) {
 				break;
 			}

--- a/src/Admin/Fields/CheckboxGroup.php
+++ b/src/Admin/Fields/CheckboxGroup.php
@@ -50,7 +50,7 @@ class CheckboxGroup extends Field implements RenderElement {
 	 * @return mixed Value stored in database.
 	 */
 	protected function get_custom_value( string $key ) {
-		$options = Settings::get_option( "{$this->controllable_option_name}", $this->type );
+		$options = Settings::get_option( "{$this->controllable_option_name}", $this->reaction_type );
 
 		return $options[ $key ] ?? null;
 	}

--- a/src/Admin/Fields/Field.php
+++ b/src/Admin/Fields/Field.php
@@ -15,11 +15,11 @@ use AntispamBee\Interfaces\Controllable;
  */
 abstract class Field {
 	/**
-	 * Item type.
+	 * Reaction type.
 	 *
 	 * @var string
 	 */
-	protected $type;
+	protected $reaction_type;
 
 	/**
 	 * Field options.
@@ -38,12 +38,12 @@ abstract class Field {
 	/**
 	 * Initializing field
 	 *
-	 * @param string $type         Item type.
-	 * @param array  $option       Field options.
-	 * @param string $controllable The related controllable (class name).
+	 * @param string $reaction_type Reaction type.
+	 * @param array  $option        Field options.
+	 * @param string $controllable  The related controllable (class name).
 	 */
-	public function __construct( string $type, array $option, string $controllable ) {
-		$this->type                     = $type;
+	public function __construct( string $reaction_type, array $option, string $controllable ) {
+		$this->reaction_type            = $reaction_type;
 		$this->option                   = $option;
 		$this->controllable_option_name = $controllable::get_option_name( $this->option['option_name'] );
 	}
@@ -55,7 +55,7 @@ abstract class Field {
 	 */
 	public function get_name(): string {
 		$option_name = Settings::OPTION_NAME;
-		$name        = "{$option_name}[{$this->type}][{$this->controllable_option_name}]";
+		$name        = "{$option_name}[{$this->reaction_type}][{$this->controllable_option_name}]";
 
 		return str_replace( '-', '_', $name );
 	}
@@ -98,7 +98,7 @@ abstract class Field {
 	 * @return mixed Value stored in database.
 	 */
 	protected function get_value() {
-		return Settings::get_option( $this->controllable_option_name, $this->type );
+		return Settings::get_option( $this->controllable_option_name, $this->reaction_type );
 	}
 
 	/**

--- a/src/Admin/Section.php
+++ b/src/Admin/Section.php
@@ -49,11 +49,11 @@ class Section {
 	private $rows = [];
 
 	/**
-	 * Item type.
+	 * Reaction type.
 	 *
 	 * @var string
 	 */
-	private $type;
+	private $reaction_type;
 
 
 	/**
@@ -62,13 +62,13 @@ class Section {
 	 * @param string      $slug Slug of the tab.
 	 * @param string      $title Title for tab.
 	 * @param string      $description Description of the tab.
-	 * @param string|null $type Item type (e.g. comment, trackback).
+	 * @param string|null $reaction_type Reaction type (e.g. comment, trackback).
 	 */
-	public function __construct( string $slug, string $title, string $description = '', ?string $type = null ) {
-		$this->slug        = $slug;
-		$this->title       = $title;
-		$this->description = $description;
-		$this->type        = $type;
+	public function __construct( string $slug, string $title, string $description = '', ?string $reaction_type = null ) {
+		$this->slug          = $slug;
+		$this->title         = $title;
+		$this->description   = $description;
+		$this->reaction_type = $reaction_type;
 	}
 
 	/**
@@ -110,7 +110,7 @@ class Section {
 			if ( ! empty( $options ) ) {
 				foreach ( $options as $option ) {
 					$valid_for = $option['valid_for'] ?? null;
-					if ( null !== $valid_for && $this->type !== $valid_for ) {
+					if ( null !== $valid_for && $this->reaction_type !== $valid_for ) {
 						continue;
 					}
 					$fields[] = $this->generate_field( $option, $controllable );
@@ -134,17 +134,17 @@ class Section {
 	private function generate_field( array $option, string $controllable ): ?Field {
 		switch ( $option['type'] ) {
 			case 'input':
-				return new Text( $this->type, $option, $controllable );
+				return new Text( $this->reaction_type, $option, $controllable );
 			case 'select':
-				return new Select( $this->type, $option, $controllable );
+				return new Select( $this->reaction_type, $option, $controllable );
 			case 'textarea':
-				return new Textarea( $this->type, $option, $controllable );
+				return new Textarea( $this->reaction_type, $option, $controllable );
 			case 'checkbox':
-				return new Checkbox( $this->type, $option, $controllable );
+				return new Checkbox( $this->reaction_type, $option, $controllable );
 			case 'checkbox-group':
-				return new CheckboxGroup( $this->type, $option, $controllable );
+				return new CheckboxGroup( $this->reaction_type, $option, $controllable );
 			case 'inline':
-				return new Inline( $this->type, $option, $controllable );
+				return new Inline( $this->reaction_type, $option, $controllable );
 		}
 
 		error_log( 'Missing or invalid `type` for field' );
@@ -203,7 +203,7 @@ class Section {
 	 * Renders the settings section.
 	 */
 	public function render(): void {
-		$page = SettingsPage::SETTINGS_PAGE_SLUG . '_' . $this->type;
+		$page = SettingsPage::SETTINGS_PAGE_SLUG . '_' . $this->reaction_type;
 
 		add_settings_section(
 			$this->get_slug(),

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -105,8 +105,6 @@ class SettingsPage {
 	 * Setup tabs content.
 	 */
 	public function setup_settings(): void {
-		// Todo: Fix the confusing naming. We have a lot of type e.g. (Nice-to-have).
-
 		$tabs['general'] = new Tab(
 			'general',
 			__( 'General', 'antispam-bee' )
@@ -114,19 +112,19 @@ class SettingsPage {
 
 		$this->rules           = Rules::get_controllables();
 		$this->post_processors = PostProcessors::get_controllables();
-		$types                 = [];
+		$reaction_types        = [];
 		foreach ( $this->rules as $rule ) {
-			$types = array_merge( $types, $rule::get_supported_types() );
+			$reaction_types = array_merge( $reaction_types, $rule::get_supported_types() );
 		}
 		foreach ( $this->post_processors as $post_processor ) {
-			$types = array_merge( $types, $post_processor::get_supported_types() );
+			$reaction_types = array_merge( $reaction_types, $post_processor::get_supported_types() );
 		}
-		$types = array_unique( $types );
+		$reaction_types = array_unique( $reaction_types );
 
-		foreach ( $types as $type ) {
-			$tabs[ $type ] = new Tab(
-				$type,
-				ContentTypeHelper::get_type_name( $type )
+		foreach ( $reaction_types as $reaction_type ) {
+			$tabs[ $reaction_type ] = new Tab(
+				$reaction_type,
+				ContentTypeHelper::get_type_name( $reaction_type )
 			);
 		}
 		$this->tabs = $tabs;
@@ -156,14 +154,14 @@ class SettingsPage {
 	 */
 	protected function populate_tabs(): void {
 		foreach ( $this->tabs as $tab ) {
-			$type = $tab->get_slug();
-			$data = [];
+			$reaction_type = $tab->get_slug();
+			$data          = [];
 
-			if ( 'general' === $type ) {
+			if ( 'general' === $reaction_type ) {
 				$data['general'] = [
 					'title'         => ContentTypeHelper::get_type_name( 'general' ),
 					'description'   => __( 'Setup global plugin spam settings.', 'antispam-bee' ),
-					'controllables' => ComponentsHelper::filter( GeneralOptions::get_controllables(), [ 'reaction_type' => $type ] ),
+					'controllables' => ComponentsHelper::filter( GeneralOptions::get_controllables(), [ 'reaction_type' => $reaction_type ] ),
 				];
 			}
 
@@ -173,12 +171,12 @@ class SettingsPage {
 					'rules'           => [
 						'title'         => __( 'Rules', 'antispam-bee' ),
 						'description'   => __( 'Setup rules.', 'antispam-bee' ),
-						'controllables' => ComponentsHelper::filter( $this->rules, [ 'reaction_type' => $type ] ),
+						'controllables' => ComponentsHelper::filter( $this->rules, [ 'reaction_type' => $reaction_type ] ),
 					],
 					'post_processors' => [
 						'title'         => __( 'Post Processors', 'antispam-bee' ),
 						'description'   => __( 'Setup post processors.', 'antispam-bee' ),
-						'controllables' => ComponentsHelper::filter( $this->post_processors, [ 'reaction_type' => $type ] ),
+						'controllables' => ComponentsHelper::filter( $this->post_processors, [ 'reaction_type' => $reaction_type ] ),
 					],
 				]
 			);
@@ -192,10 +190,10 @@ class SettingsPage {
 					$key,
 					$value['title'],
 					$value['description'],
-					$type
+					$reaction_type
 				);
 				$section->add_controllables( $value['controllables'] );
-				$this->tabs[ $type ]->add_section( $section );
+				$this->tabs[ $reaction_type ]->add_section( $section );
 			}
 		}
 	}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -124,7 +124,7 @@ class SettingsPage {
 		foreach ( $reaction_types as $reaction_type ) {
 			$tabs[ $reaction_type ] = new Tab(
 				$reaction_type,
-				ContentTypeHelper::get_type_name( $reaction_type )
+				ContentTypeHelper::get_reaction_type_name( $reaction_type )
 			);
 		}
 		$this->tabs = $tabs;
@@ -159,7 +159,7 @@ class SettingsPage {
 
 			if ( 'general' === $reaction_type ) {
 				$data['general'] = [
-					'title'         => ContentTypeHelper::get_type_name( 'general' ),
+					'title'         => ContentTypeHelper::get_reaction_type_name( 'general' ),
 					'description'   => __( 'Setup global plugin spam settings.', 'antispam-bee' ),
 					'controllables' => ComponentsHelper::filter( GeneralOptions::get_controllables(), [ 'reaction_type' => $reaction_type ] ),
 				];

--- a/src/GeneralOptions/Base.php
+++ b/src/GeneralOptions/Base.php
@@ -17,11 +17,11 @@ use AntispamBee\Interfaces\Controllable;
 abstract class Base implements Controllable {
 
 	/**
-	 * Option type.
+	 * Component type.
 	 *
 	 * @var string
 	 */
-	protected static $type = 'general';
+	protected static $component_type = 'general';
 
 	/**
 	 * Option slug.
@@ -84,12 +84,12 @@ abstract class Base implements Controllable {
 	/**
 	 * Returns activation state for this option.
 	 *
-	 * @param string $type One of the types defined in AntispamBee\Helpers\ItemTypeHelper::get_types().
+	 * @param string $reaction_type One of the supported reaction types (comment, linkback, general).
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( string $type = 'general' ) {
-		return Settings::get_option( static::get_option_name( 'active' ), $type );
+	public static function is_active( string $reaction_type = 'general' ) {
+		return Settings::get_option( static::get_option_name( 'active' ), $reaction_type );
 	}
 
 	/**
@@ -112,12 +112,12 @@ abstract class Base implements Controllable {
 	}
 
 	/**
-	 * Get type of the option.
+	 * Get the component type (rule, post_processor or general).
 	 *
 	 * @return string
 	 */
-	public static function get_type(): string {
-		return static::$type;
+	public static function get_component_type(): string {
+		return static::$component_type;
 	}
 
 	/**
@@ -128,9 +128,9 @@ abstract class Base implements Controllable {
 	 * @return string Corresponding option name
 	 */
 	public static function get_option_name( string $name ): string {
-		$type        = static::get_type();
-		$slug        = static::get_slug();
-		$option_name = "{$type}_{$slug}_{$name}";
+		$component_type = static::get_component_type();
+		$slug           = static::get_slug();
+		$option_name    = "{$component_type}_{$slug}_{$name}";
 
 		return str_replace( '-', '_', $option_name );
 	}

--- a/src/Handlers/GeneralOptions.php
+++ b/src/Handlers/GeneralOptions.php
@@ -13,29 +13,29 @@ namespace AntispamBee\Handlers;
 class GeneralOptions {
 
 	/**
-	 * Options type.
+	 * Reaction type.
 	 *
 	 * @var string
 	 */
-	protected $type;
+	protected $reaction_type;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param string $type Option type.
+	 * @param string $reaction_type Reaction type.
 	 */
-	public function __construct( string $type ) {
-		$this->type = $type;
+	public function __construct( string $reaction_type ) {
+		$this->reaction_type = $reaction_type;
 	}
 
 	/**
 	 * Get controllable items for this option.
 	 *
-	 * @param string $type Option type.
+	 * @param string $reaction_type Reaction type.
 	 * @return array List of controllable items.
 	 */
-	public static function get_controllables( string $type = 'general' ): array {
-		if ( 'general' !== $type ) {
+	public static function get_controllables( string $reaction_type = 'general' ): array {
+		if ( 'general' !== $reaction_type ) {
 			return [];
 		}
 

--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -21,7 +21,7 @@ class Linkback extends Reaction {
 	 *
 	 * @var string
 	 */
-	protected static $type = 'linkback';
+	protected static $reaction_type = 'linkback';
 
 	/**
 	 * Process a linkback.

--- a/src/Handlers/Reaction.php
+++ b/src/Handlers/Reaction.php
@@ -19,7 +19,7 @@ abstract class Reaction {
 	 *
 	 * @var string
 	 */
-	protected static $type = 'comment';
+	protected static $reaction_type = 'comment';
 
 	/**
 	 * Initialize the handler.
@@ -60,7 +60,7 @@ abstract class Reaction {
 	 */
 	public static function process( array $reaction ): array {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
-		$rules   = new Rules( static::$type );
+		$rules   = new Rules( static::$reaction_type );
 		$is_spam = $rules->apply( $reaction );
 
 		if ( $is_spam ) {
@@ -78,7 +78,7 @@ abstract class Reaction {
 	 * @return array|never-return Handled reaction (or die, if item was deleted)
 	 */
 	protected static function handle_spam( array $reaction, Rules $rules ) {
-		$item = PostProcessors::apply( static::$type, $reaction, $rules->get_spam_reasons() );
+		$item = PostProcessors::apply( static::$reaction_type, $reaction, $rules->get_spam_reasons() );
 		if ( ! isset( $item['asb_marked_as_delete'] ) ) {
 			add_filter(
 				'pre_comment_approved',

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -19,11 +19,11 @@ use AntispamBee\Interfaces\Verifiable;
 class Rules {
 
 	/**
-	 * Rule type.
+	 * Reaction type.
 	 *
 	 * @var string
 	 */
-	protected $type;
+	protected $reaction_type;
 
 	/**
 	 * List of spam reasons.
@@ -42,10 +42,10 @@ class Rules {
 	/**
 	 * Ruleset constructor.
 	 *
-	 * @param string $type Item type.
+	 * @param string $reaction_type Reaction type.
 	 */
-	public function __construct( string $type ) {
-		$this->type = $type;
+	public function __construct( string $reaction_type ) {
+		$this->reaction_type = $reaction_type;
 	}
 
 	/**
@@ -55,8 +55,8 @@ class Rules {
 	 * @return bool Item identified as spam.
 	 */
 	public function apply( array $item ): bool {
-		$item['reaction_type'] = $this->type;
-		$rules                 = self::get( $this->type, true );
+		$item['reaction_type'] = $this->reaction_type;
+		$rules                 = self::get( $this->reaction_type, true );
 
 		$no_spam_threshold = (float) apply_filters( 'antispam_bee_no_spam_threshold', 0.0 );
 		$spam_threshold    = (float) apply_filters( 'antispam_bee_spam_threshold', 0.0 );
@@ -104,14 +104,14 @@ class Rules {
 	/**
 	 * Get applicable rules.
 	 *
-	 * @param string|null $type        Reaction type.
-	 * @param bool        $only_active Get only active rules.
+	 * @param string|null $reaction_type Reaction type.
+	 * @param bool        $only_active   Get only active rules.
 	 * @return array List of applicable rules.
 	 */
-	public static function get( ?string $type = null, bool $only_active = false ): array {
+	public static function get( ?string $reaction_type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
-				'reaction_type' => $type,
+				'reaction_type' => $reaction_type,
 				'only_active'   => $only_active,
 				'implements'    => Verifiable::class,
 			]
@@ -121,14 +121,14 @@ class Rules {
 	/**
 	 * Get controllable items.
 	 *
-	 * @param string|null $type        Reaction type.
-	 * @param bool        $only_active Get only active items.
+	 * @param string|null $reaction_type Reaction type.
+	 * @param bool        $only_active   Get only active items.
 	 * @return array List of suitable controllables.
 	 */
-	public static function get_controllables( ?string $type = null, bool $only_active = false ): array {
+	public static function get_controllables( ?string $reaction_type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
-				'reaction_type' => $type,
+				'reaction_type' => $reaction_type,
 				'only_active'   => $only_active,
 				'implements'    => [ Verifiable::class, Controllable::class ],
 			]
@@ -136,16 +136,16 @@ class Rules {
 	}
 
 	/**
-	 * Todo: Try to find a better suited method name.
+	 * Get rules that provide a spam reason (implement the SpamReason interface).
 	 *
-	 * @param string|null $type        Reaction type.
-	 * @param bool        $only_active Get only active rules.
-	 * @return array List of applicable rules.
+	 * @param string|null $reaction_type Reaction type.
+	 * @param bool        $only_active   Get only active rules.
+	 * @return array List of rules that provide a spam reason.
 	 */
-	public static function get_spam_rules( ?string $type = null, bool $only_active = false ): array {
+	public static function get_spam_reason_rules( ?string $reaction_type = null, bool $only_active = false ): array {
 		return self::filter(
 			[
-				'reaction_type' => $type,
+				'reaction_type' => $reaction_type,
 				'only_active'   => $only_active,
 				'implements'    => [ Verifiable::class, SpamReason::class ],
 			]

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -17,19 +17,19 @@ class ContentTypeHelper {
 	const LINKBACK_TYPE = 'linkback';
 
 	/**
-	 * Get human-readable item type name.
+	 * Get human-readable reaction type name.
 	 *
 	 * @param string $reaction_type Reaction type.
-	 * @return string Readable type name.
+	 * @return string Readable reaction type name.
 	 */
-	public static function get_type_name( string $reaction_type ): string {
+	public static function get_reaction_type_name( string $reaction_type ): string {
 		$type_names = [
 			self::GENERAL_TYPE  => __( 'General', 'antispam-bee' ),
 			self::COMMENT_TYPE  => __( 'Comment', 'antispam-bee' ),
 			self::LINKBACK_TYPE => __( 'Linkback', 'antispam-bee' ),
 		];
 
-		$type_names = array_merge( apply_filters( 'antispam_bee_item_types', [] ), $type_names );
+		$type_names = array_merge( apply_filters( 'antispam_bee_reaction_types', [] ), $type_names );
 
 		return $type_names[ $reaction_type ] ?? $reaction_type;
 	}

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -19,10 +19,10 @@ class ContentTypeHelper {
 	/**
 	 * Get human-readable item type name.
 	 *
-	 * @param string $item_type Type name.
+	 * @param string $reaction_type Reaction type.
 	 * @return string Readable type name.
 	 */
-	public static function get_type_name( string $item_type ): string {
+	public static function get_type_name( string $reaction_type ): string {
 		$type_names = [
 			self::GENERAL_TYPE  => __( 'General', 'antispam-bee' ),
 			self::COMMENT_TYPE  => __( 'Comment', 'antispam-bee' ),
@@ -31,7 +31,7 @@ class ContentTypeHelper {
 
 		$type_names = array_merge( apply_filters( 'antispam_bee_item_types', [] ), $type_names );
 
-		return $type_names[ $item_type ] ?? $item_type;
+		return $type_names[ $reaction_type ] ?? $reaction_type;
 	}
 
 	/**

--- a/src/Helpers/Sanitize.php
+++ b/src/Helpers/Sanitize.php
@@ -109,8 +109,8 @@ class Sanitize {
 		$tabs = [ 'general' ];
 
 		foreach ( array_merge( Rules::get_controllables(), PostProcessors::get_controllables() ) as $controllable ) {
-			foreach ( $controllable::get_supported_types() as $type ) {
-				$tabs[] = $type;
+			foreach ( $controllable::get_supported_types() as $reaction_type ) {
+				$tabs[] = $reaction_type;
 			}
 		}
 

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -87,17 +87,17 @@ class Settings {
 	/**
 	 * Get single option field
 	 *
-	 * @param string $option_name Option name.
-	 * @param string $type The type.
+	 * @param string $option_name   Option name.
+	 * @param string $reaction_type The reaction type.
 	 *
 	 * @return mixed Field value.
 	 */
-	public static function get_option( string $option_name, string $type = 'general' ) {
+	public static function get_option( string $option_name, string $reaction_type = 'general' ) {
 		$options = self::get_options();
 
 		$value_path = "$option_name";
-		if ( ! empty( $type ) ) {
-			$value_path = "$type.$option_name";
+		if ( ! empty( $reaction_type ) ) {
+			$value_path = "$reaction_type.$option_name";
 		}
 		$value_path = str_replace( '-', '_', $value_path );
 

--- a/src/Helpers/SpamReasonTextHelper.php
+++ b/src/Helpers/SpamReasonTextHelper.php
@@ -37,7 +37,7 @@ class SpamReasonTextHelper {
 	 * @return void
 	 */
 	public static function populate(): void {
-		$rules                 = Rules::get_spam_rules();
+		$rules                 = Rules::get_spam_reason_rules();
 		self::$slug_text_array = [];
 		foreach ( $rules as $rule ) {
 			self::$slug_text_array[ $rule::get_slug() ] = $rule::get_reason_text();

--- a/src/Interfaces/Controllable.php
+++ b/src/Interfaces/Controllable.php
@@ -62,11 +62,11 @@ interface Controllable {
 	/**
 	 * Returns activation state for this element.
 	 *
-	 * @param string $type One of the types defined in AntispamBee\Helpers\ItemTypeHelper::get_types().
+	 * @param string $reaction_type One of the supported reaction types (comment, linkback, general).
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( string $type );
+	public static function is_active( string $reaction_type );
 
 	/**
 	 * Only print custom options?
@@ -84,11 +84,11 @@ interface Controllable {
 	public static function get_supported_types(): array;
 
 	/**
-	 * Get type of the controllable.
+	 * Get the component type (rule, post_processor or general).
 	 *
 	 * @return string
 	 */
-	public static function get_type(): string;
+	public static function get_component_type(): string;
 
 	/**
 	 * Get controllable slug.
@@ -99,7 +99,7 @@ interface Controllable {
 
 	/**
 	 * Get option name.
-	 * This will typically add type and slug prefixes to the short name.
+	 * This will typically add the component type and slug prefixes to the short name.
 	 *
 	 * @param string $name Name suffix.
 	 * @return string Corresponding option name

--- a/src/PostProcessors/ControllableBase.php
+++ b/src/PostProcessors/ControllableBase.php
@@ -15,11 +15,11 @@ use AntispamBee\Interfaces\Controllable;
  */
 abstract class ControllableBase extends Base implements Controllable {
 	/**
-	 * Controllable type.
+	 * Component type.
 	 *
 	 * @var string
 	 */
-	protected static $type = 'post_processor';
+	protected static $component_type = 'post_processor';
 
 	/**
 	 * Only print custom options?
@@ -31,12 +31,12 @@ abstract class ControllableBase extends Base implements Controllable {
 	/**
 	 * Returns activation state for post processor.
 	 *
-	 * @param string $type One of the types defined in AntispamBee\Helpers\ItemTypeHelper::get_types().
+	 * @param string $reaction_type One of the supported reaction types (comment, linkback, general).
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( string $type ) {
-		return Settings::get_option( static::get_option_name( 'active' ), $type );
+	public static function is_active( string $reaction_type ) {
+		return Settings::get_option( static::get_option_name( 'active' ), $reaction_type );
 	}
 
 	/**
@@ -61,12 +61,12 @@ abstract class ControllableBase extends Base implements Controllable {
 	}
 
 	/**
-	 * Get type of the controllable.
+	 * Get the component type (rule, post_processor or general).
 	 *
 	 * @return string
 	 */
-	public static function get_type(): string {
-		return static::$type;
+	public static function get_component_type(): string {
+		return static::$component_type;
 	}
 
 	/**
@@ -77,9 +77,9 @@ abstract class ControllableBase extends Base implements Controllable {
 	 * @return string Corresponding option name
 	 */
 	public static function get_option_name( string $name ): string {
-		$type        = static::get_type();
-		$slug        = static::get_slug();
-		$option_name = "{$type}_{$slug}_{$name}";
+		$component_type = static::get_component_type();
+		$slug           = static::get_slug();
+		$option_name    = "{$component_type}_{$slug}_{$name}";
 
 		return str_replace( '-', '_', $option_name );
 	}

--- a/src/PostProcessors/DeleteForReasons.php
+++ b/src/PostProcessors/DeleteForReasons.php
@@ -90,8 +90,8 @@ class DeleteForReasons extends ControllableBase {
 	 */
 	public static function get_options(): array {
 		$options = [];
-		foreach ( self::get_supported_types() as $type ) {
-			$filtered_rules   = Rules::get_spam_rules( $type );
+		foreach ( self::get_supported_types() as $reaction_type ) {
+			$filtered_rules   = Rules::get_spam_reason_rules( $reaction_type );
 			$checkbox_options = [];
 
 			foreach ( $filtered_rules as $rule ) {
@@ -102,7 +102,7 @@ class DeleteForReasons extends ControllableBase {
 			}
 
 			$options[] = [
-				'valid_for'   => $type,
+				'valid_for'   => $reaction_type,
 				'label'       => __( 'Reasons', 'antispam-bee' ),
 				'type'        => 'checkbox-group',
 				'options'     => $checkbox_options,

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -211,7 +211,7 @@ EOF;
 		$template_content = self::get_body_template();
 
 		$content       = self::get_content( $comment );
-		$reaction_type = ContentTypeHelper::get_type_name( $item['reaction_type'] );
+		$reaction_type = ContentTypeHelper::get_reaction_type_name( $item['reaction_type'] );
 
 		$spam_reasons = SpamReasonTextHelper::get_texts_by_slugs( $item['asb_reasons'] );
 

--- a/src/Rules/ControllableBase.php
+++ b/src/Rules/ControllableBase.php
@@ -23,21 +23,21 @@ abstract class ControllableBase extends Base implements Controllable {
 	protected static $only_print_custom_options = false;
 
 	/**
-	 * Type of the controllable item.
+	 * Component type.
 	 *
 	 * @var string
 	 */
-	protected static $type = 'rule';
+	protected static $component_type = 'rule';
 
 	/**
 	 * Returns activation state of this rule.
 	 *
-	 * @param string $type One of the types defined in AntispamBee\Helpers\ItemTypeHelper::get_types().
+	 * @param string $reaction_type One of the supported reaction types (comment, linkback, general).
 	 *
 	 * @return mixed|null
 	 */
-	public static function is_active( string $type ) {
-		return Settings::get_option( static::get_option_name( 'active' ), $type );
+	public static function is_active( string $reaction_type ) {
+		return Settings::get_option( static::get_option_name( 'active' ), $reaction_type );
 	}
 
 	/**
@@ -62,12 +62,12 @@ abstract class ControllableBase extends Base implements Controllable {
 	}
 
 	/**
-	 * Get type of the controllable.
+	 * Get the component type (rule, post_processor or general).
 	 *
 	 * @return string
 	 */
-	public static function get_type(): string {
-		return static::$type;
+	public static function get_component_type(): string {
+		return static::$component_type;
 	}
 
 	/**
@@ -78,9 +78,9 @@ abstract class ControllableBase extends Base implements Controllable {
 	 * @return string Corresponding option name
 	 */
 	public static function get_option_name( string $name ): string {
-		$type        = static::get_type();
-		$slug        = static::get_slug();
-		$option_name = "{$type}_{$slug}_{$name}";
+		$component_type = static::get_component_type();
+		$slug           = static::get_slug();
+		$option_name    = "{$component_type}_{$slug}_{$name}";
 
 		return str_replace( '-', '_', $option_name );
 	}


### PR DESCRIPTION
## What & why

Two distinct concepts shared the name **\`type\`** across the v3 component system, which was explicitly flagged by TODOs in \`SettingsPage\` and \`Handlers/Rules\`. This PR splits them into two clearly named axes:

- **Component kind** (`rule` / `post_processor` / `general`): `Controllable::get_type()` and the `$type` property → **`get_component_type()`** / **`$component_type`** (interface + Rules/PostProcessors `ControllableBase` + `GeneralOptions/Base`). Used to build option-name prefixes like `rule_asb_regexp_active`.
- **Reaction / content type** (`comment` / `linkback` / `general`): standardised on **`$reaction_type`** everywhere — `is_active()`, `Settings::get_option()`, the `Rules`/`PostProcessors` getter parameters, the `Reaction`/`Linkback`/`GeneralOptions` handlers, `Admin/Section`, `Admin/Fields/Field` (+ the `CheckboxGroup` subclass), `CommentsColumns`, `Sanitize`, and `ContentTypeHelper`.

Additionally, `Rules::get_spam_rules()` → **`Rules::get_spam_reason_rules()`** — it returns rules implementing the `SpamReason` interface (rules that *provide a spam reason*), not "the spam rules". Its parameter is renamed to `$reaction_type`. The two naming TODOs this resolves are removed.

## No data migration

Stored option keys and DB values are **unchanged** — this is a code-level identifier rename only. The string values (`'rule'`, `'comment'`, …) are untouched.

## Verification

- ✅ PHPStan: no errors
- ✅ PHPCS (`phpcs.xml`): no new errors
- ✅ Unit tests: 17 passed, 50 assertions