### PR TITLE
chore: pre-beta cleanup (PHP guard, spelling, TODO removal)

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -34,7 +34,7 @@ pre_init();
  */
 function pre_init(): void {
 	// Check if the min. required PHP version is available and if not, show an admin notice.
-	if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
+	if ( version_compare( PHP_VERSION, '7.2', '<' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\min_php_version_error' );
 
 		// Stop the further processing of the plugin.

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -28,10 +28,12 @@ define( __NAMESPACE__ . '\PLUGIN_PATH', plugin_dir_path( MAIN_PLUGIN_FILE ) );
 pre_init();
 
 /**
- * Pre init function to check the plugins compatibility.
+ * Pre init function to check the plugins' compatibility.
+ *
+ * @return void
  */
 function pre_init(): void {
-	// Check, if the min. required PHP version is available and if not, show an admin notice.
+	// Check if the min. required PHP version is available and if not, show an admin notice.
 	if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\min_php_version_error' );
 
@@ -39,7 +41,7 @@ function pre_init(): void {
 		return;
 	}
 
-	// Check, if the DOMDocument class exists.
+	// Check if the `DOMDocument` class exists.
 	if ( ! class_exists( 'DOMDocument' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\domdocument_class_error' );
 
@@ -65,7 +67,9 @@ function pre_init(): void {
 }
 
 /**
- * Show a admin notice error message, if the PHP version is too low
+ * Show an admin notice error message if the PHP version is too low
+ *
+ * @return void
  */
 function min_php_version_error(): void {
 	echo '<div class="error"><p>';
@@ -74,7 +78,9 @@ function min_php_version_error(): void {
 }
 
 /**
- * Show a admin notice error message, if the PHP version is too low
+ * Show an admin notice error message if the `DOMDocument` class is missing
+ *
+ * @return void
  */
 function domdocument_class_error(): void {
 	echo '<div class="error"><p>';
@@ -83,7 +89,9 @@ function domdocument_class_error(): void {
 }
 
 /**
- * Show a admin notice error message, if the PHP version is too low
+ * Show an admin notice error message if the Composer autoloader is missing
+ *
+ * @return void
  */
 function autoloader_missing(): void {
 	echo '<div class="error"><p>';

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "wp-coding-standards/wpcs": "^3.0.1",
     "wp-cli/wp-cli-bundle": "@stable",
     "wp-coding-standards/wpcs": "^3.1",
     "yoast/wp-test-utils": "^1.2.0",

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -106,15 +106,6 @@ class SettingsPage {
 	 * Setup tabs content.
 	 */
 	public function setup_settings(): void {
-		// Todo: Add a way to build rows and fields with a fluent interface? (Nice-to-have).
-
-		/*
-		 * Todo: Instead of using an array to pass options to a function, one could introduce a class that contains
-		 *   these options as class attributes. You instantiate an object of this class and pass it to the
-		 *   Components::filter() method. For frequently used options, one could also use blueprints for options.
-		 *   This would make refactoring easier, but would slightly increase the complexity. (nice-to-have).
-		 */
-
 		// Todo: Fix the confusing naming. We have a lot of type e.g. (Nice-to-have).
 
 		$tabs['general'] = new Tab(

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -16,7 +16,7 @@ use AntispamBee\Helpers\Sanitize;
 use AntispamBee\Helpers\Settings;
 use const AntispamBee\MAIN_PLUGIN_FILE;
 
-// @todo: add `ids` to the `h2` section headlines. After first analyzation, that seems only to be possible via JS
+// @todo: add `ids` to the `h2` section headlines. After first analysis, that seems only to be possible via JS
 /**
  * Antispam Bee Settings Page
  */

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -16,7 +16,6 @@ use AntispamBee\Helpers\Sanitize;
 use AntispamBee\Helpers\Settings;
 use const AntispamBee\MAIN_PLUGIN_FILE;
 
-// @todo: add `ids` to the `h2` section headlines. After first analysis, that seems only to be possible via JS
 /**
  * Antispam Bee Settings Page
  */

--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -73,12 +73,12 @@ class PluginStateChangeHandler {
 
 		delete_option( Settings::OPTION_NAME );
 		delete_option( 'antispambee_db_version' );
-		// @todo: do that when out of beta.
+		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 		// delete_option( 'antispam_bee' );
 
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		// @todo: do that when out of beta.
+		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 		// $wpdb->query( 'DELETE FROM `' . $wpdb->commentmeta . '`WHERE `meta_key` IN ("antispam_bee_iphash", "antispam_bee_reason")' );
 	}
 

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -159,7 +159,6 @@ class Rules {
 	 * @return array List of filtered elements.
 	 */
 	private static function filter( array $options ): array {
-		// Todo: discuss if our rules should be filterable or not.
 		return ComponentsHelper::filter( apply_filters( 'antispam_bee_rules', [] ), $options );
 	}
 

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -29,7 +29,6 @@ class ContentTypeHelper {
 			self::LINKBACK_TYPE => __( 'Linkback', 'antispam-bee' ),
 		];
 
-		// Todo: Write a doc how to add custom types.
 		$type_names = array_merge( apply_filters( 'antispam_bee_item_types', [] ), $type_names );
 
 		return $type_names[ $item_type ] ?? $item_type;

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -17,7 +17,7 @@ class ContentTypeHelper {
 	const LINKBACK_TYPE = 'linkback';
 
 	/**
-	 * Get huam-readable item type name.
+	 * Get human-readable item type name.
 	 *
 	 * @param string $item_type Type name.
 	 * @return string Readable type name.

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -132,7 +132,6 @@ class Honeypot {
 					$markup
 				);
 				break;
-			// Todo: Add the possibility to use an input instead a textarea (for next version).
 			default:
 				break;
 		}

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -39,7 +39,6 @@ class Settings {
 		],
 	];
 
-	// @todo: check if code is PHP 7 compatible
 	const OPTION_NAME = 'antispam_bee_options';
 
 	/**

--- a/src/Interfaces/PostProcessor.php
+++ b/src/Interfaces/PostProcessor.php
@@ -32,7 +32,7 @@ interface PostProcessor {
 	public static function get_supported_types(): array;
 
 	/**
-	 * Does this processor mark am element as deleted?
+	 * Does this processor mark an element as deleted?
 	 *
 	 * @return bool
 	 */

--- a/src/Interfaces/Verifiable.php
+++ b/src/Interfaces/Verifiable.php
@@ -22,7 +22,7 @@ interface Verifiable {
 
 	/**
 	 * Get rule weight.
-	 * This value can be used to tweak the overall results. Will be user as a multiplier of the verification result.
+	 * This value can be used to tweak the overall results. Will be used as a multiplier of the verification result.
 	 *
 	 * @return int Weight factor.
 	 */
@@ -43,7 +43,7 @@ interface Verifiable {
 	public static function get_supported_types(): array;
 
 	/**
-	 * It this rule final?
+	 * Is this rule final?
 	 *
 	 * @return bool
 	 */

--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -78,7 +78,7 @@ abstract class Base implements PostProcessor {
 	}
 
 	/**
-	 * Does this processor mark am element as deleted?
+	 * Does this processor mark an element as deleted?
 	 *
 	 * @return bool
 	 */

--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -73,7 +73,6 @@ abstract class Base implements PostProcessor {
 	 * @return string[]
 	 */
 	public static function get_supported_types(): array {
-		// @todo: add filter
 		return static::$supported_types;
 	}
 

--- a/src/PostProcessors/DeleteForReasons.php
+++ b/src/PostProcessors/DeleteForReasons.php
@@ -91,7 +91,6 @@ class DeleteForReasons extends ControllableBase {
 	public static function get_options(): array {
 		$options = [];
 		foreach ( self::get_supported_types() as $type ) {
-			// @todo: disable the reasons checkboxes if the rule is not active.
 			$filtered_rules   = Rules::get_spam_rules( $type );
 			$checkbox_options = [];
 

--- a/src/Rules/ApprovedEmail.php
+++ b/src/Rules/ApprovedEmail.php
@@ -32,8 +32,6 @@ class ApprovedEmail extends ControllableBase {
 	/**
 	 * Verify an item.
 	 *
-	 * Todo: Discuss if this (and gravatar) should be final rules, and also surpass the Honeypot.
-	 *
 	 * @param array $item Item to verify.
 	 * @return int Numeric result.
 	 */

--- a/src/Rules/Base.php
+++ b/src/Rules/Base.php
@@ -93,7 +93,7 @@ abstract class Base implements Verifiable {
 
 	/**
 	 * Get rule weight.
-	 * This value can be used to tweak the overall results. Will be user as a multiplier of the verification result.
+	 * This value can be used to tweak the overall results. Will be used as a multiplier of the verification result.
 	 *
 	 * @return int Weight factor.
 	 */
@@ -111,7 +111,7 @@ abstract class Base implements Verifiable {
 	}
 
 	/**
-	 * It this rule final?
+	 * Is this rule final?
 	 *
 	 * @return bool
 	 */
@@ -120,7 +120,7 @@ abstract class Base implements Verifiable {
 	}
 
 	/**
-	 * It this rule invisible?
+	 * Is this rule invisible?
 	 *
 	 * @return bool
 	 */

--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -176,7 +176,6 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 * @return array
 	 */
 	public static function get_options(): array {
-		// @todo: we should enable the user to select all 82 languages we can detect. we use presets: the site language, the site language + english, if more than two langs are installed, use those; and: custom. We could check the preferred languages UI for the custom option. And also for the ISO codes.
 		$languages = [
 			'de' => __( 'German', 'antispam-bee' ),
 			'en' => __( 'English', 'antispam-bee' ),
@@ -185,7 +184,6 @@ class LangSpam extends ControllableBase implements SpamReason {
 			'es' => __( 'Spanish', 'antispam-bee' ),
 		];
 
-		// Todo: Deprecate old filters.
 		/**
 		 * Filter the possible languages for the language spam test
 		 *

--- a/src/Rules/LinkbackFromMyself.php
+++ b/src/Rules/LinkbackFromMyself.php
@@ -12,8 +12,6 @@ use AntispamBee\Interfaces\SpamReason;
 
 /**
  * Rule that is responsible for checking if the linkback is from myself.
- *
- * @todo: check on remote server.
  */
 class LinkbackFromMyself extends Base implements SpamReason {
 


### PR DESCRIPTION
Pre-beta tidy-up of the v3 codebase. Five small, self-contained commits:

1. **`docs:` spelling & grammar** — fixes typos and grammar in comments, docblocks and public interfaces (e.g. `huam`→`human`, `It this`→`Is this`, `user as a multiplier`→`used`, `am element`→`an element`, `analyzation`→`analysis`, and the copy-pasted admin-notice docblocks in the bootstrap).
2. **`fix:` PHP version guard** — the bootstrap guard checked for PHP `5.6`, but `composer.json`, `readme.txt` and the admin notice itself all state **7.2**. Sites on PHP 7.0/7.1 passed the guard and then hit code requiring 7.2.
3. **`chore:` remove TODO comments now tracked as issues** — removes the feature/refactor TODOs that were moved to GitHub issues #737–#743, deletes a stale "PHP 7 compatible" TODO, and replaces the two "out of beta" markers in the uninstall routine with a reference to #744 (the commented-out cleanup code is kept).
4. **`chore:` remove remaining feature/doc TODOs** — moves the last actionable TODOs to issues #745–#747 and removes them.
5. **`chore:` deduplicate WPCS dev dependency in `composer.json`**.

### Intentionally left in place
The two **naming-related** TODOs (`SettingsPage` "confusing naming" and `Handlers/Rules` "better method name") were kept out of this PR on purpose — they are addressed separately in #748 (component_type vs reaction_type rename).

### Notes
- No behavioural changes; comments/docblocks/bootstrap-guard only (plus the composer dedup).
- Related issues: #737–#747.