### PR TITLE
ci: prevent duplicate workflow runs on PR branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests, Coding Standards
 on:
   push:
+    branches:
+      - master
+      - v3
   pull_request:
 jobs:
   test-unit:


### PR DESCRIPTION
## Context

`.github/workflows/tests.yml` triggers on both `push` and `pull_request` without filters. When pushing to a branch that has an open PR, GitHub fires both events, so every job (`test-unit`, `test-e2e`, `phpstan`, `quality`) runs twice — wasting CI minutes and cluttering the checks list.

## Change

Scope the `push` trigger to the long-lived branches (`master`, `v3`); all other branches are covered by the `pull_request` trigger:

```yaml
on:
  push:
    branches:
      - master
      - v3
  pull_request:
```

Feature branches now run the suite exactly once (via `pull_request`); direct pushes to `master` / `v3` still run via `push`. The deploy workflows are unaffected — they trigger only on tags.

### Trade-off

Pushing to a feature branch **before** opening a PR no longer triggers the suite — checks start once the PR is opened. This is the intended behavior of this pattern.