### PR TITLE
docs: clarify that vendor/ is not project code in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 General rules for AI agents contributing to this project.
 
+## What is project code
+
+Project code lives in `src/`, `tests/`, and the root PHP files (e.g. `antispam_bee.php`). Ignore `vendor/` and `node_modules/` when searching, reviewing, or reasoning about the code — both are gitignored, installed locally by `composer install` / `npm install`, and contain only third-party dependencies you must not modify. The plugin ships **no** runtime dependencies; everything in `vendor/` is a `require-dev` code-quality tool (PHPCS, PHPStan, PHPUnit, WP-CLI, WPCS, …), so treating it as project code produces false findings.
+
 ## Code quality — verify before every commit
 
 | Check                   | Command                                      |


### PR DESCRIPTION
## Summary

Agents (including code review) were treating `vendor/` as project code, producing false findings. `vendor/` is gitignored, installed locally by `composer install`, and contains **only** `require-dev` code-quality tools (PHPCS, PHPStan, PHPUnit, WP-CLI, WPCS, …) — the plugin ships no runtime dependencies.

This adds a **"What is project code"** section to `AGENTS.md` that:

- names the actual project code (`src/`, `tests/`, root PHP files such as `antispam_bee.php`)
- tells agents to ignore `vendor/` and `node_modules/` when searching, reviewing, or reasoning about the code
- explains *why* (dev-only, gitignored, must not be modified) so the guidance sticks

Docs-only change; no code or behavior affected.