### PR TITLE
feat: add filter for post processor supported reaction types

### DIFF
--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -73,7 +73,15 @@ abstract class Base implements PostProcessor {
 	 * @return string[]
 	 */
 	public static function get_supported_types(): array {
-		return static::$supported_types;
+		/**
+		 * Filter the reaction types that are supported by the post processor.
+		 *
+		 * @param array $supported_types The supported types.
+		 * @param string $slug The post processor’s slug.
+		 *
+		 * @return array Array of supported types.
+		 */
+		return apply_filters( 'antispam_bee_post_processor_supported_types', static::$supported_types, static::$slug );
 	}
 
 	/**


### PR DESCRIPTION
## What

Adds the `antispam_bee_post_processor_supported_types` filter to `PostProcessors\Base::get_supported_types()`, mirroring the existing `antispam_bee_rule_supported_types` filter on `Rules\Base`.

## Why

`Rules` already let third parties adjust which reaction types a component supports via a filter, but `PostProcessors` returned the static property directly. This brings the post processor extension API in line with rules so extenders get consistent behavior across both component families.

The filter passes the same arguments as the rules equivalent: the `$supported_types` array and the component `$slug`.

Closes #741