### PR TITLE
test(e2e): assert honeypot lets a genuine comment through

### DIFF
--- a/tests/e2e/specs/filter.spec.ts
+++ b/tests/e2e/specs/filter.spec.ts
@@ -75,6 +75,28 @@ test.describe( 'Spam filter mechanisms', () => {
 		await expect( page.locator( 'body' ) ).not.toContainText( 'Mr. Burns' );
 	} );
 
+	test( 'honeypot lets a genuine comment through when the trap is empty', async ( {
+		page,
+	} ) => {
+		// Genuine visitor: fills the visible comment field but leaves the
+		// hidden honeypot trap empty (fillHoneypot omitted).
+		await fillComment( page, {
+			comment: 'Thanks for the great article, very helpful!',
+			author: 'Lisa Simpson',
+			email: 'lisa.simpson@springfield-elementary.edu',
+		} );
+
+		await adminLogin( page );
+		await page.goto( '/wp-admin/edit-comments.php?comment_status=spam' );
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			'Lisa Simpson'
+		);
+		await page.goto(
+			'/wp-admin/edit-comments.php?comment_status=moderated'
+		);
+		await expect( page.locator( 'body' ) ).toContainText( 'Lisa Simpson' );
+	} );
+
 	test( 'local spam DB flags comment from same IP', async ( {
 		page,
 		cli,


### PR DESCRIPTION
## What

Adds an end-to-end test covering the honeypot **ham** path: a genuine visitor who fills the visible comment field but leaves the hidden honeypot trap empty.

## Why

Every existing honeypot e2e test in `tests/e2e/specs/filter.spec.ts` fills the hidden trap to force a **spam** verdict; none asserted that a legitimate comment is let through. This test closes that gap by asserting the comment is **absent from the spam list** and **present in the moderation queue**.

## Notes

This behaviour is identical on `v3` and the `feature/honeypot-extended-validation` branch (PR #656), so beyond closing the coverage gap it also acts as a stable regression guard: it stays green after #656 is rebased onto `v3`.

Reuses the existing `fillComment` helper (which already defaults `fillHoneypot` to `false`); no plugin code or options changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)