### PR TITLE
fix: mask IP addresses to a `/24` (IPv4) and `/48` (IPv6) network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
       its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be
       determined at all
+    * Fix: IP addresses are now anonymized by masking the host portion of the address, using the
+      same networks as WordPress itself: a /24 for IPv4, as in Antispam Bee 2.x, and a /64 for
+      IPv6 instead of only its first two groups
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
@@ -20,6 +23,9 @@
       durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
     * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache
       überhaupt nicht bestimmt werden konnte
+    * Fix: IP-Adressen werden nun anonymisiert, indem der Host-Teil der Adresse maskiert wird, und
+      zwar mit denselben Netzen wie in WordPress selbst: ein /24 für IPv4, wie in Antispam Bee 2.x,
+      und ein /64 für IPv6 statt nur der ersten zwei Blöcke
 
 ### 2.11.12 ###
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
       its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be
       determined at all
-    * Fix: IP addresses are now anonymized by masking the host portion of the address, using the
-      same networks as WordPress itself: a /24 for IPv4, as in Antispam Bee 2.x, and a /64 for
-      IPv6 instead of only its first two groups
+    * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for
+      IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6
+      instead of only its first two groups
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
@@ -23,9 +23,9 @@
       durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
     * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache
       überhaupt nicht bestimmt werden konnte
-    * Fix: IP-Adressen werden nun anonymisiert, indem der Host-Teil der Adresse maskiert wird, und
-      zwar mit denselben Netzen wie in WordPress selbst: ein /24 für IPv4, wie in Antispam Bee 2.x,
-      und ein /64 für IPv6 statt nur der ersten zwei Blöcke
+    * Fix: IP-Adressen werden nun anonymisiert, indem der Host-Teil der Adresse maskiert wird: ein
+      /24 für IPv4, dasselbe Netz, das auch WordPress selbst behält, wie in Antispam Bee 2.x, und
+      ein /48 für IPv6 statt nur der ersten zwei Blöcke
 
 ### 2.11.12 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -104,7 +104,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
     * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
-    * Fix: IP addresses are now anonymized by masking the host portion of the address, using the same networks as WordPress itself: a /24 for IPv4, as in Antispam Bee 2.x, and a /64 for IPv6 instead of only its first two groups
+    * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
     * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
+    * Fix: IP addresses are now anonymized by masking the host portion of the address, using the same networks as WordPress itself: a /24 for IPv4, as in Antispam Bee 2.x, and a /64 for IPv6 instead of only its first two groups
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -70,11 +70,18 @@ class IpHelper {
 	 * Anonymize an IP address.
 	 *
 	 * Only the network portion is kept, the host portion is zeroed out: the
-	 * first three octets of an IPv4 address (a `/24` network) and the first four
-	 * groups of an IPv6 address (a `/64` network). These are the same masks that
-	 * WordPress core applies in `wp_privacy_anonymize_ip()`, coarse enough to
-	 * drop the host and fine enough for a reliable country lookup. An
-	 * IPv4-mapped IPv6 address is masked like the IPv4 address it carries.
+	 * first three octets of an IPv4 address (a `/24` network) and the first three
+	 * groups of an IPv6 address (a `/48` network). Both are coarse enough to drop
+	 * the host and fine enough for a reliable country lookup. An IPv4-mapped IPv6
+	 * address is masked like the IPv4 address it carries.
+	 *
+	 * The IPv4 mask is the one WordPress core applies in
+	 * `wp_privacy_anonymize_ip()`. For IPv6 core keeps a `/64`, one step finer than
+	 * this. A `/64` is a single subscriber LAN, while country data is never keyed
+	 * below `/48`: across 1388 addresses taken from real comments, no announced BGP
+	 * prefix was longer than `/48`, and the country IPLocate reports was identical
+	 * at `/64`, `/56` and `/48` for every one of them. The first mask that changes
+	 * the answer is `/40`. See #761 for the measurements.
 	 *
 	 * Addresses that cannot be parsed result in an empty string.
 	 *
@@ -96,7 +103,7 @@ class IpHelper {
 			// An IPv4-mapped IPv6 address carries an IPv4 address, mask that one.
 			$netmask = '::ffff:255.255.255.0';
 		} else {
-			$netmask = 'ffff:ffff:ffff:ffff::';
+			$netmask = 'ffff:ffff:ffff::';
 		}
 
 		$anonymized = inet_ntop( $packed & (string) inet_pton( $netmask ) );

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -78,10 +78,8 @@ class IpHelper {
 	 * The IPv4 mask is the one WordPress core applies in
 	 * `wp_privacy_anonymize_ip()`. For IPv6 core keeps a `/64`, one step finer than
 	 * this. A `/64` is a single subscriber LAN, while country data is never keyed
-	 * below `/48`: across 1388 addresses taken from real comments, no announced BGP
-	 * prefix was longer than `/48`, and the country IPLocate reports was identical
-	 * at `/64`, `/56` and `/48` for every one of them. The first mask that changes
-	 * the answer is `/40`. See #761 for the measurements.
+	 * below `/48`, so the extra group would identify the visitor without improving
+	 * the lookup.
 	 *
 	 * Addresses that cannot be parsed result in an empty string.
 	 *

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -69,20 +69,38 @@ class IpHelper {
 	/**
 	 * Anonymize an IP address.
 	 *
+	 * Only the network portion is kept, the host portion is zeroed out: the
+	 * first three octets of an IPv4 address (a `/24` network) and the first four
+	 * groups of an IPv6 address (a `/64` network). These are the same masks that
+	 * WordPress core applies in `wp_privacy_anonymize_ip()`, coarse enough to
+	 * drop the host and fine enough for a reliable country lookup. An
+	 * IPv4-mapped IPv6 address is masked like the IPv4 address it carries.
+	 *
+	 * Addresses that cannot be parsed result in an empty string.
+	 *
 	 * @param string $ip Original IP.
 	 *
 	 * @return  string Anonymous IP.
 	 */
 	public static function anonymize_ip( string $ip ): string {
-		if ( ! preg_match( '/\w+([\.:])\w+/', $ip, $matches ) ) {
+		$packed = inet_pton( $ip );
+
+		if ( false === $packed ) {
 			return '';
 		}
 
-		$ip_start = $matches[0];
-		if ( '.' === $matches[1] ) {
-			return $ip_start . '.0.0';
+		// IPv4 addresses pack into four bytes, IPv6 addresses into sixteen.
+		if ( 4 === strlen( $packed ) ) {
+			$netmask = '255.255.255.0';
+		} elseif ( 0 === strncmp( $packed, str_repeat( "\0", 10 ) . "\xff\xff", 12 ) ) {
+			// An IPv4-mapped IPv6 address carries an IPv4 address, mask that one.
+			$netmask = '::ffff:255.255.255.0';
+		} else {
+			$netmask = 'ffff:ffff:ffff:ffff::';
 		}
 
-		return $ip_start . '::';
+		$anonymized = inet_ntop( $packed & (string) inet_pton( $netmask ) );
+
+		return false === $anonymized ? '' : $anonymized;
 	}
 }

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -55,8 +55,9 @@ class IpHelperTest extends TestCase {
 		return [
 			[ '198.51.100.42', '198.51.100.0', 'IPv4 address should be truncated to a /24 network' ],
 			[ '10.11.12.13', '10.11.12.0', 'IPv4 host bits should be zeroed out' ],
-			[ '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3:8d3::', 'IPv6 address should be truncated to a /64 network' ],
-			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8:85a3::', 'compressed IPv6 address should be truncated to a /64 network' ],
+			[ '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3::', 'IPv6 address should be truncated to a /48 network' ],
+			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8:85a3::', 'compressed IPv6 address should be truncated to a /48 network' ],
+			[ '2a02:8109:aa00:1234::5', '2a02:8109:aa00::', 'the fourth group should be dropped whole, not truncated to a /56' ],
 			[ '2001:db8::1', '2001:db8::', 'IPv6 address shorter than the mask should only lose its host bits' ],
 			[ '::1', '::', 'the IPv6 loopback address should be masked, not rejected' ],
 			[ '0:0:0:0:0:0:0:1', '::', 'the result should not depend on the notation of the address' ],

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -57,7 +57,7 @@ class IpHelperTest extends TestCase {
 			[ '10.11.12.13', '10.11.12.0', 'IPv4 host bits should be zeroed out' ],
 			[ '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3::', 'IPv6 address should be truncated to a /48 network' ],
 			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8:85a3::', 'compressed IPv6 address should be truncated to a /48 network' ],
-			[ '2a02:8109:aa00:1234::5', '2a02:8109:aa00::', 'the fourth group should be dropped whole, not truncated to a /56' ],
+			[ 'fd02:8109:aa00:1234::5', 'fd02:8109:aa00::', 'the fourth group should be dropped whole, not truncated to a /56' ],
 			[ '2001:db8::1', '2001:db8::', 'IPv6 address shorter than the mask should only lose its host bits' ],
 			[ '::1', '::', 'the IPv6 loopback address should be masked, not rejected' ],
 			[ '0:0:0:0:0:0:0:1', '::', 'the result should not depend on the notation of the address' ],

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -53,10 +53,16 @@ class IpHelperTest extends TestCase {
 
 	public function anonymize_ip_provider(): array {
 		return [
-			[ '192.0.2.123', '192.0.0.0', 'IPv4 address should be truncated' ],
-			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8::', 'IPv6 address should be truncated' ],
+			[ '198.51.100.42', '198.51.100.0', 'IPv4 address should be truncated to a /24 network' ],
+			[ '10.11.12.13', '10.11.12.0', 'IPv4 host bits should be zeroed out' ],
+			[ '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3:8d3::', 'IPv6 address should be truncated to a /64 network' ],
+			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8:85a3::', 'compressed IPv6 address should be truncated to a /64 network' ],
+			[ '2001:db8::1', '2001:db8::', 'IPv6 address shorter than the mask should only lose its host bits' ],
+			[ '::1', '::', 'the IPv6 loopback address should be masked, not rejected' ],
+			[ '0:0:0:0:0:0:0:1', '::', 'the result should not depend on the notation of the address' ],
+			[ 'fe80::1', 'fe80::', 'a link-local IPv6 address should be masked, not rejected' ],
+			[ '::ffff:192.0.2.123', '::ffff:192.0.2.0', 'an IPv4-mapped IPv6 address should be masked like an IPv4 address' ],
 			[ '', '', 'empty input should result in an empty string' ],
-			[ '::1', '', 'unmatchable input should result in an empty string' ],
 			[ 'no-ip-at-all', '', 'non-IP input should result in an empty string' ],
 		];
 	}


### PR DESCRIPTION
## Description

`\AntispamBee\Helpers\IpHelper::anonymize_ip` slices an IP address with the pattern `\w+([\.:])\w+` and keeps what it matched: the first two octets of an IPv4 address (a `/16`) and the first two groups of an IPv6 address (a `/32`).

This masks the address instead, with a **`/24`** for IPv4 — the mask WordPress core uses in `wp_privacy_anonymize_ip()` — and a **`/48`** for IPv6:

```php
public static function anonymize_ip( string $ip ): string {
	$packed = inet_pton( $ip );

	if ( false === $packed ) {
		return '';
	}

	// IPv4 addresses pack into four bytes, IPv6 addresses into sixteen.
	if ( 4 === strlen( $packed ) ) {
		$netmask = '255.255.255.0';
	} elseif ( 0 === strncmp( $packed, str_repeat( "\0", 10 ) . "\xff\xff", 12 ) ) {
		// An IPv4-mapped IPv6 address carries an IPv4 address, mask that one.
		$netmask = '::ffff:255.255.255.0';
	} else {
		$netmask = 'ffff:ffff:ffff::';
	}

	$anonymized = inet_ntop( $packed & (string) inet_pton( $netmask ) );

	return false === $anonymized ? '' : $anonymized;
}
```

Input that cannot be parsed as an IP address results in an empty string, so `CountrySpam` never sends anything but an address to the geolocation service. `inet_pton` returns `false` for such input without emitting a warning, so it doubles as the validation guard.

## Behaviour

| Input | Before | After | WP core |
|---|---|---|---|
| `198.51.100.42` | `198.51.0.0` | `198.51.100.0` | `198.51.100.0` |
| `10.11.12.13` | `10.11.0.0` | `10.11.12.0` | `10.11.12.0` |
| `2001:db8:85a3:8d3:1319:8a2e:370:7348` | `2001:db8::` | `2001:db8:85a3::` | `2001:db8:85a3:8d3::` |
| `2001:db8:85a3::8a2e:370:7334` | `2001:db8::` | `2001:db8:85a3::` | `2001:db8:85a3::` |
| `2a02:8109:aa00:1234::5` | `2a02:8109::` | `2a02:8109:aa00::` | `2a02:8109:aa00:1234::` |
| `2001:db8::1` | `2001:db8::` | `2001:db8::` | `2001:db8::` |
| `::1` | `''` | `::` | `::` |
| `0:0:0:0:0:0:0:1` | `0:0::` | `::` | `::` |
| `fe80::1` | `''` | `fe80::` | `fe80::` |
| `::ffff:192.0.2.123` | `ffff:192::` | `::ffff:192.0.2.0` | `::ffff:192.0.2.0` |
| `''` | `''` | `''` | `0.0.0.0` |
| `no-ip-at-all` | `''` | `''` | `0.0.0.0` |

➡️ IPv4 is now identical to core's. IPv6 is deliberately one step **coarser** than core, and the result deliberately differs for input that cannot be parsed: core answers `0.0.0.0`, which would be looked up as if it were a real address, so an empty string is kept instead.

Besides the masks, this fixes three defects of the pattern:

- A valid address it could not match was **rejected outright** — `::1` and `fe80::1` came back as an empty string.
- The result depended on the **notation** rather than the address: `::1` was rejected, while the very same address written `0:0:0:0:0:0:0:1` became `0:0::`.
- An **IPv4-mapped IPv6 address** produced an unrelated prefix, turning `::ffff:192.0.2.123` into `ffff:192::`. Such an address can show up in `REMOTE_ADDR` on a dual-stack host, and `filter_var( …, FILTER_VALIDATE_IP )` in `get_client_ip()` accepts it, so it does reach this method. It is now masked like the IPv4 address it carries, as core does.

## Why `/24` for IPv4

Geolocation databases key the country on `/24`, and a single `/16` can span country borders, so the previous mask could resolve to the wrong country or to no country at all. Neither failure is visible to the site owner:

- `CountrySpam::verify` returns `0` when the response carries no `country_code`, so an unresolvable network address silently means "not spam".
- In allow-list mode, a neighbouring country that is not on the list turns a **legitimate** comment into spam.

A `/24` is also the boundary core and the common data-protection guidance have settled on, and it is what Antispam Bee 2.x shipped.

## Why `/48` for IPv6

2.x kept only the **first group** of an IPv6 address. That looks like a stronger privacy guarantee, but a `/16` cannot identify a country at all, so what it really did was disable the rule for IPv6 visitors: RIPE sub-allocates `2a00::/12` in `/29`–`/32` chunks, so three different countries collapsed onto one identical query and anything starting with `2001:` collapsed onto the Teredo prefix.

The mask has to be coarse enough to drop the host and fine enough to resolve a country. `/48` is the coarsest mask that satisfies both, and this was measured rather than assumed — see [the detailed comment below](https://github.com/pluginkollektiv/antispam-bee/pull/761#issuecomment-5251105039). Against 1592 IPv6 addresses taken from real comments:

- **No announced BGP prefix is longer than `/48`** — 0 of 1388 addresses with a route. Every `/64` inside a `/48` therefore falls in the same announced prefix, so a `/48` mask cannot change which block a lookup matches. Of the 125 `/48` groups holding more than one distinct `/64`, none has a conflicting country.
- Sampling 225 networks against IPLocate at four widths, the country was **identical at `/64`, `/56` and `/48` for all 225**. `/40` is the first mask that changes the answer, flipping 13 of them — tunnel brokers and hosters where the geo layer localises below the announced `/32`, so the lookup returns the provider's country instead of the visitor's.

A `/64` — what core uses — is a single subscriber LAN: ISPs delegate one per VLAN, and cellular links and hosted servers commonly get exactly one. `/48` is the site allocation, so it drops the subscriber without costing a single country lookup. Bit symmetry with IPv4 is not a useful yardstick either: an IPv4 `/16` is up to 65,536 addresses across many organisations, while an IPv6 `/64` is one LAN.

Worth stating plainly: `/48` sits **exactly** on the boundary, with 66 of the measured networks announced at precisely `/48`. That is an argument for recording the measurement, not for backing off — anything a vendor keys finer than `/48` would be city-level data, which this rule does not use.

## Why not call `wp_privacy_anonymize_ip()` directly

It requires WordPress 4.9.6, while we still declare `Requires at least: 4.7`. Delegating to it with a bundled fallback was explored in #762, where the two code paths ended up applying different masks. It would also fix the IPv6 mask at core's `/64` and answer `0.0.0.0` for unparseable input. Core's extra handling of ports, brackets and zone identifiers is not needed here, because `get_client_ip()` has already put the address through `filter_var( …, FILTER_VALIDATE_IP )`.

Core's function also exists for a different purpose — storing a visitor's IP safely *inside* the site — whereas this value is sent to a third party on every reaction, which is what justifies going one step coarser.

## Testing

Extends the existing `anonymize_ip_provider` in `IpHelperTest` to cover every row of the table above. The IPv4 rows deliberately use addresses whose second and third octets are non-zero, and `2a02:8109:aa00:1234::5` is there so that an implementation keeping a `/56` — the fourth group truncated rather than dropped — would fail. Every expectation was cross-checked against an independent implementation.

`composer test:unit` — 69 tests pass. `phpcs` and `phpstan` (level 8) clean.

## Out of scope

`CountrySpam` sends the anonymized IP to iplocate.io for every reaction, including loopback and private addresses, and interpolates the result into the URL without checking for an empty string. Worth a separate issue.
