### PR TITLE
fix: delegate IP anonymization to wp_privacy_anonymize_ip()

### DIFF
--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -61,7 +61,17 @@ class IpHelper {
 	}
 
 	/**
-	 * Anonymize the IP addresses
+	 * Anonymize an IP address.
+	 *
+	 * Only the network portion is kept, the host portion is zeroed out. For
+	 * IPv4 the first three octets are retained (a `/24` network), for IPv6 the
+	 * first three groups are retained (a `/48` network). This keeps enough of
+	 * the address for reliable country-level geolocation while removing the host.
+	 *
+	 * WordPress core's {@see wp_privacy_anonymize_ip()} is used when available;
+	 * it applies the same masks and additionally handles ports, brackets and
+	 * zone identifiers. The bundled masking is only a fallback for environments
+	 * where that function does not exist.
 	 *
 	 * @param string $ip Original IP.
 	 *
@@ -69,12 +79,40 @@ class IpHelper {
 	 * @since   2.5.1
 	 */
 	public static function anonymize_ip( string $ip ): string {
-		preg_match( '/\w+([\.:])\w+/', $ip, $matches );
-		$ip_start = $matches[0];
-		if ( '.' === $matches[1] ) {
-			return $ip_start . '.0.0';
+		if ( function_exists( 'wp_privacy_anonymize_ip' ) ) {
+			return wp_privacy_anonymize_ip( $ip );
 		}
 
-		return $ip_start . '::';
+		return self::mask_ip( $ip );
+	}
+
+	/**
+	 * Fallback anonymization used when {@see wp_privacy_anonymize_ip()} is
+	 * unavailable.
+	 *
+	 * Keeps the first three octets of an IPv4 address (a `/24` network) and the
+	 * first three groups of an IPv6 address (a `/48` network). Invalid input is
+	 * returned unchanged.
+	 *
+	 * @param string $ip Original IP.
+	 *
+	 * @return string Anonymous IP.
+	 */
+	private static function mask_ip( string $ip ): string {
+		$packed = filter_var( $ip, FILTER_VALIDATE_IP ) ? inet_pton( $ip ) : false;
+
+		if ( false === $packed ) {
+			return $ip;
+		}
+
+		if ( 4 === strlen( $packed ) ) {
+			// IPv4: keep the first three octets (a /24 network).
+			$mask = (string) inet_pton( '255.255.255.0' );
+		} else {
+			// IPv6: keep the first three groups (a /48 network).
+			$mask = (string) inet_pton( 'ffff:ffff:ffff::' );
+		}
+
+		return (string) inet_ntop( $packed & $mask );
 	}
 }

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -42,28 +42,53 @@ class IpHelperTest extends TestCase {
 	}
 
 	/**
-	 * Anonymizing an IP should keep only its first two parts.
+	 * The bundled fallback masking should keep only the network portion: the
+	 * first three octets for IPv4 (a /24) and the first three groups for IPv6
+	 * (a /48). `wp_privacy_anonymize_ip()` is undefined in the unit test
+	 * environment, so this exercises the fallback path.
 	 *
 	 * @dataProvider provide_ips_to_anonymize
 	 *
 	 * @param string $ip       The original IP.
 	 * @param string $expected The expected anonymized IP.
 	 */
-	public function test_anonymize_ip_keeps_only_first_two_parts( string $ip, string $expected ): void {
-		self::assertSame( $expected, IpHelper::anonymize_ip( $ip ), 'Only the first two parts of the IP should remain' );
+	public function test_anonymize_ip_fallback_keeps_only_the_network_portion( string $ip, string $expected ): void {
+		self::assertFalse( function_exists( 'wp_privacy_anonymize_ip' ), 'This test must run against the fallback masking' );
+		self::assertSame( $expected, IpHelper::anonymize_ip( $ip ), 'Only the network portion of the IP should remain' );
 	}
 
 	/**
-	 * Data provider for {@see test_anonymize_ip_keeps_only_first_two_parts}.
+	 * When WordPress core's `wp_privacy_anonymize_ip()` is available, it should
+	 * be used instead of the bundled fallback.
+	 *
+	 * Runs in a separate process so the stubbed function definition does not
+	 * leak into the fallback tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_anonymize_ip_delegates_to_wordpress_core(): void {
+		when( 'wp_privacy_anonymize_ip' )->justReturn( '203.0.113.0' );
+
+		self::assertSame(
+			'203.0.113.0',
+			IpHelper::anonymize_ip( '203.0.113.42' ),
+			'anonymize_ip should delegate to wp_privacy_anonymize_ip when it exists'
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_anonymize_ip_fallback_keeps_only_the_network_portion}.
 	 *
 	 * @return array<string, array{string, string}>
 	 */
 	public static function provide_ips_to_anonymize(): array {
 		return array(
-			'IPv4 normal'     => array( '192.168.1.1', '192.168.0.0' ),
+			'IPv4 normal'     => array( '192.168.1.1', '192.168.1.0' ),
 			'IPv4 short'      => array( '10.0.0.1', '10.0.0.0' ),
-			'IPv6 full'       => array( '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8::' ),
+			'IPv6 full'       => array( '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3::' ),
 			'IPv6 compressed' => array( '2001:db8::1', '2001:db8::' ),
+			'invalid input'   => array( 'not-an-ip', 'not-an-ip' ),
 		);
 	}
 }


### PR DESCRIPTION
## Description

The IPv4 branch of `\AntispamBee\Helpers\IpHelper::anonymize_ip` kept only the first two octets (a `/16`) and the IPv6 branch only the first two groups (a `/32`). A `/16` can span country borders and geolocation databases key country on `/24`, so the previous masking could **degrade the country lookup** in `CountrySpam`, which sends the anonymized IP to iplocate.io (see `src/Rules/CountrySpam.php`).

This delegates to WordPress core's `wp_privacy_anonymize_ip()` when it is available:

- IPv4 → `/24` (first 3 octets), IPv6 → `/48` (first 3 groups) — enough for reliable country-level geolocation while removing the host.
- Core additionally handles ports, brackets and zone identifiers.

A bundled `inet_pton`/`inet_ntop` masking with the **same** `/24` and `/48` masks is kept as a `function_exists()` fallback for environments where the core function does not exist.

## Comparison across versions

`anonymize_ip` has changed masks between versions. This PR **restores the v2 IPv4 behaviour** (`/24`), while making IPv6 more private than v2 but coarse enough to keep country geolocation:

| Version | IPv4 mask | IPv6 mask |
|---|---|---|
| v2 (released) | `/24` (3 octets) | `/16` (1 group) |
| v3 (current) | `/16` (2 octets) | `/32` (2 groups) |
| **This PR** | **`/24` (3 octets)** | **`/48` (3 groups)** |

Worked examples:

| Input | v2 | v3 (current) | This PR |
|---|---|---|---|
| `192.168.1.1` | `192.168.1.0` | `192.168.0.0` | `192.168.1.0` |
| `203.0.113.42` | `203.0.113.0` | `203.0.0.0` | `203.0.113.0` |
| `2001:db8:85a3:8d3:1319:8a2e:370:7348` | `2001::` | `2001:db8::` | `2001:db8:85a3::` |

➡️ **IPv4 anonymization is identical to v2** (`/24`); IPv6 keeps two more groups than v2, restoring reliable country lookups without exposing the host.

## Testing

- Data-provider test covering IPv4/IPv6 (full + compressed) and invalid input, asserting the fallback masking (`wp_privacy_anonymize_ip()` is undefined in the unit env).
- Separate-process test verifying delegation to core when the function exists.

`composer test:unit` — all pass. `phpcs` and `phpstan` clean.

> **Note:** stacked on #761 (the unit-test PR). Base is `test/anonymize-ip-unit-test`; GitHub will auto-retarget to `v3` once #761 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)