### PR TITLE
fix: address code review findings from 3.0.0-beta.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ treating it as project code produces false findings.
 
 Fix code style violations automatically with `composer csfix`.
 
-Target PHP 7.2+. Avoid syntax introduced in PHP 7.4 or later: typed properties, arrow functions (
-`fn =>`), `match` expressions, null-coalescing assignment (`??=`). The `phpcs.xml` ruleset enforces
-this via PHPCompatibilityWP.
+Target PHP 7.4+. Avoid syntax introduced in PHP 8.0 or later: `match` expressions, constructor
+property promotion, named arguments, nullsafe operator (`?->`), union types. The `phpcs.xml` ruleset
+enforces this via PHPCompatibilityWP.
 
 ## WordPress & security conventions
 

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -35,7 +35,7 @@ pre_init();
  */
 function pre_init(): void {
 	// Check if the min. required PHP version is available and if not, show an admin notice.
-	if ( version_compare( PHP_VERSION, '7.2', '<' ) ) {
+	if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\min_php_version_error' );
 
 		// Stop the further processing of the plugin.
@@ -90,7 +90,7 @@ function pre_init(): void {
  */
 function min_php_version_error(): void {
 	echo '<div class="error"><p>';
-	esc_html_e( 'Antispam Bee requires PHP version 7.2 or higher to function properly. Please upgrade PHP or deactivate Antispam Bee.', 'antispam-bee' );
+	esc_html_e( 'Antispam Bee requires PHP version 7.4 or higher to function properly. Please upgrade PHP or deactivate Antispam Bee.', 'antispam-bee' );
 	echo '</p></div>';
 }
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-v2",
 	"require": {
-		"php": ">=7.2",
+		"php": ">=7.4",
 		"ext-libxml": "*",
 		"ext-dom": "*",
 		"ext-json": "*"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -94,7 +94,7 @@
 	-->
 
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.6
 * Tested up to:      7.0
-* Requires PHP:      7.2
+* Requires PHP:      7.4
 * Stable tag:        3.0.0-beta.1
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -50,7 +50,7 @@ Say Goodbye to comment spam on your WordPress blog or website. *Antispam Bee* bl
 * If you don’t know how to install a plugin for WordPress, [here’s how](https://wordpress.org/documentation/article/manage-plugins/#automatic-plugin-installation-1).
 
 ### Requirements ###
-* PHP 7.2 or greater
+* PHP 7.4 or greater
 * WordPress 4.6 or greater
 
 ### Settings ###

--- a/src/Admin/Fields/Select.php
+++ b/src/Admin/Fields/Select.php
@@ -18,13 +18,24 @@ class Select extends Field implements RenderElement {
 	 * Get the HTML.
 	 */
 	public function render(): void {
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		$value    = $this->get_value();
+		$multiple = isset( $this->option['multiple'] ) && $this->option['multiple'];
 
-		$name     = $this->get_name();
-		$multiple = isset( $this->option['multiple'] ) && $this->option['multiple'] ? 'multiple' : '';
-		echo "<select name='$name' $multiple>";
-		foreach ( $this->option['options'] as $key => $value ) {
-			echo "<option value='{$key}'>$value</option>";
+		printf(
+			'<select name="%s"%s>',
+			esc_attr( $this->get_name() . ( $multiple ? '[]' : '' ) ),
+			$multiple ? ' multiple' : ''
+		);
+		foreach ( $this->option['options'] as $key => $label ) {
+			$is_selected = is_array( $value )
+				? in_array( (string) $key, array_map( 'strval', $value ), true )
+				: (string) $key === (string) $value;
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $key ),
+				selected( $is_selected, true, false ),
+				esc_html( $label )
+			);
 		}
 		echo '</select>';
 		$this->maybe_show_description();

--- a/src/Admin/Fields/Text.php
+++ b/src/Admin/Fields/Text.php
@@ -72,13 +72,4 @@ class Text extends Field implements RenderElement, InjectableField {
 
 		return 'regular-text';
 	}
-
-	/**
-	 * Get the placeholder.
-	 *
-	 * @return string The placeholder of the field.
-	 */
-	public function get_placeholder(): string {
-		return $this->placeholder ?? '';
-	}
 }

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -36,9 +36,24 @@ class DebugMode {
 		$date        = date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$time        = date( 'H-i-s' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		$content_dir = WP_CONTENT_DIR;
+		$suffix      = self::get_log_file_suffix();
 
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug use.
-		error_log( "[{$date} {$time}] {$message}\n", 3, "{$content_dir}/asb-debug.{$date}.log" );
+		error_log( "[{$date} {$time}] {$message}\n", 3, "{$content_dir}/asb-debug.{$date}.{$suffix}.log" );
+	}
+
+	/**
+	 * Get the salted log file suffix.
+	 *
+	 * The log contains comment data and `WP_CONTENT_DIR` is usually served
+	 * publicly, so the file name must not be guessable.
+	 *
+	 * @return string
+	 */
+	private static function get_log_file_suffix(): string {
+		$salt = defined( 'NONCE_SALT' ) ? \NONCE_SALT : \ABSPATH;
+
+		return substr( sha1( 'asb-debug' . $salt ), 0, 12 );
 	}
 
 	/**

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -33,19 +33,24 @@ class Honeypot {
 	 */
 	public static function inject( string $markup, array $options ): string {
 		$dom = new DOMDocument();
+		// Malformed or HTML5-only markup must not bubble up as PHP warnings.
+		$use_internal_errors = libxml_use_internal_errors( true );
 		$dom->loadHTML( $markup, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $use_internal_errors );
+
 		$xpath     = new DOMXPath( $dom );
 		$node_list = $xpath->query( '//*[@id="' . $options['field_id'] . '"]' );
 		$input     = $node_list ? $node_list->item( 0 ) : null;
 		if ( ! $input instanceof DOMElement ) {
-			return '';
+			return $markup;
 		}
 
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$id_attr   = $input->attributes->getNamedItem( 'id' );
 		$name_attr = $input->attributes->getNamedItem( 'name' );
 		if ( null === $id_attr || null === $name_attr ) {
-			return '';
+			return $markup;
 		}
 
 		$input_type    = $input->nodeName;

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -75,8 +75,9 @@ class IpHelper {
 	 */
 	public static function anonymize_ip( string $ip ): string {
 		if ( ! preg_match( '/\w+([\.:])\w+/', $ip, $matches ) ) {
-			return $ip;
+			return '';
 		}
+
 		$ip_start = $matches[0];
 		if ( '.' === $matches[1] ) {
 			return $ip_start . '.0.0';

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -19,13 +19,37 @@ class HoneypotHelperTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_inject_returns_empty_when_field_not_found(): void {
-		$result = Honeypot::inject(
-			'<textarea id="other" name="other"></textarea>',
-			[ 'field_id' => 'comment' ]
-		);
+	public function test_inject_returns_markup_unchanged_when_field_not_found(): void {
+		$markup = '<textarea id="other" name="other"></textarea>';
 
-		self::assertSame( '', $result, 'inject() should return empty string when field id is not found' );
+		$result = Honeypot::inject( $markup, [ 'field_id' => 'comment' ] );
+
+		self::assertSame( $markup, $result, 'inject() should return the markup unchanged when field id is not found' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_inject_returns_markup_unchanged_when_name_attribute_is_missing(): void {
+		$markup = '<textarea id="comment"></textarea>';
+
+		$result = Honeypot::inject( $markup, [ 'field_id' => 'comment' ] );
+
+		self::assertSame( $markup, $result, 'inject() should return the markup unchanged when the field has no name attribute' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_inject_does_not_emit_warnings_for_html5_markup(): void {
+		$markup = '<article><textarea id="comment" name="comment" required>My Content</textarea></article>';
+
+		$result = Honeypot::inject( $markup, [ 'field_id' => 'comment' ] );
+
+		self::assertNotEmpty( $result, 'inject() should handle HTML5 markup' );
+		self::assertEmpty( libxml_get_errors(), 'inject() should not leave libxml errors behind' );
 	}
 
 	/**

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -43,4 +43,21 @@ class IpHelperTest extends TestCase {
 
 		self::assertSame( '192.0.2.2', IpHelper::get_client_ip(), 'pre_comment_user_ip filter should override the IP' );
 	}
+
+	/**
+	 * @dataProvider anonymize_ip_provider
+	 */
+	public function test_anonymize_ip( string $ip, string $expected, string $message ): void {
+		self::assertSame( $expected, IpHelper::anonymize_ip( $ip ), $message );
+	}
+
+	public function anonymize_ip_provider(): array {
+		return [
+			[ '192.0.2.123', '192.0.0.0', 'IPv4 address should be truncated' ],
+			[ '2001:db8:85a3::8a2e:370:7334', '2001:db8::', 'IPv6 address should be truncated' ],
+			[ '', '', 'empty input should result in an empty string' ],
+			[ '::1', '', 'unmatchable input should result in an empty string' ],
+			[ 'no-ip-at-all', '', 'non-IP input should result in an empty string' ],
+		];
+	}
 }


### PR DESCRIPTION
## Summary

This PR fixes the confirmed functional bugs found in a full code review of `3.0.0-beta.1`, one fix per commit:

- **`LinkbackFromMyself` never fired**: `$url[0]` / `$target_post_id[0]` indexed the first *character* of the scalar values from `preprocess_comment`, so the `home_url()` comparison could never match and legitimate self-linkbacks never received their `-100` trust score. (+ new unit tests)
- **Fatal on PHP 7.2**: `Settings` uses `array_key_last()` (PHP 7.3+) while the plugin advertised a PHP 7.2 floor. Since CI only tests PHP 7.4+, the minimum version is now 7.4 across `composer.json`, `phpcs.xml`, the runtime guard in `antispam_bee.php`, `readme.txt` and `AGENTS.md`.
- **`Honeypot::inject()` fails safe now**: it returned an empty string when the comment field markup had no element with the configured `field_id` — themes without `id="comment"` lost their comment textarea entirely. It also fataled on fields without a `name` attribute and emitted libxml warnings on HTML5 markup. All three cases now return the original markup unchanged / stay silent. `get_secret_id_for_post()`/`get_secret_name_for_post()` share one implementation now (output unchanged). (+ new unit tests)
- **`IpHelper::anonymize_ip()`**: empty or unmatchable input (e.g. `::1`) caused undefined-index warnings and a garbage return value; it returns an empty string now. (+ new unit tests)
- **`Select` admin field**: output was completely unescaped and the stored value was never marked as `selected`, so the setting did not survive a settings-page round-trip; multi-selects also submitted only one value (missing `[]` in the name). Latent — no bundled component uses `select` yet — but a landmine for extenders. The dead `Text::get_placeholder()` override (always-unset property shadowing the working parent method) is removed as well.
- **`DataHelper::get_values_where_key_contains()`**: truthy `strpos()` check missed matches at position 0.
- **Debug log disclosure**: the opt-in debug log was written to `wp-content/asb-debug.{date}.log` — a predictable, usually web-accessible path — and contains comment content. The file name now includes a salted hash suffix.

## Test steps

1. `composer test:unit` — 29 tests pass (10 of them new).
2. Honeypot regression: activate a theme whose comment form textarea has no `id="comment"` → the comment field must still render (previously it disappeared).
3. Self-linkback: enable pingbacks, publish post B linking post A, verify the pingback on A is not treated as spam by other rules more aggressively than before (rule now contributes its `-100` trust score).
4. Debug mode: define `ANTISPAM_BEE_DEBUG_MODE_ENABLED`, submit a comment, and verify the log file in `wp-content/` now carries a hash suffix.
5. On a PHP < 7.4 host the plugin deactivates gracefully with the admin notice instead of fataling in `Settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
