### PR TITLE
feat: wire up `is_final()` so definitive rules short-circuit the spam check

### DIFF
--- a/docs/adding-rules.md
+++ b/docs/adding-rules.md
@@ -5,3 +5,14 @@ ASB 3 makes it possible for third-party plugins to add custom rules.
 Each Rule is a class that extends the `ControllableBase` (if your rule has options, like for
 disabling/enabling) or `Base` (if your rule works invisible in the background) class and implements
 the `SpamReason` interface.
+
+A rule's `verify()` method returns a positive score if the item looks like spam, a negative score if
+the rule found a trust signal, or `0` if the result is neutral. The score is multiplied with the
+rule's `$weight` and added to the overall score; an item is treated as spam if the overall score is
+positive.
+
+A rule can set the `$is_final` property to `true` if a positive result is definitive (like a filled
+honeypot field). Final rules are checked before all other rules, and a positive result marks the
+item as spam immediately, without evaluating the remaining rules. The finals-first ordering can be
+disabled with the `antispam_bee_sort_final_rules_first` filter (return `false`), in which case all
+rules are checked in their registered order.

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -115,6 +115,10 @@ class Rules {
 	/**
 	 * Apply rules.
 	 *
+	 * Final rules are checked before all other rules. A positive result of a
+	 * final rule is definitive: the item is marked as spam without evaluating
+	 * the remaining (potentially expensive) rules.
+	 *
 	 * @param array<string, mixed> $item Normalized payload to apply rules to.
 	 *
 	 * @return bool Whether the item was identified as spam.
@@ -162,7 +166,7 @@ class Rules {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		DebugMode::log( 'Looping through spam rules for reaction with the following data: ' . print_r( $log_item, true ) );
 
-		foreach ( $rules as $rule ) {
+		foreach ( $this->sort_rules( $rules ) as $rule ) {
 			DebugMode::log( "Checking »{$rule::get_name()}« rule" );
 
 			$rule_score = $rule::verify( $item ) * $rule::get_weight();
@@ -171,6 +175,12 @@ class Rules {
 
 			if ( $rule_score > 0.0 ) {
 				$this->spam_reasons[] = $rule::get_slug();
+
+				if ( $rule::is_final() ) {
+					DebugMode::log( "»{$rule::get_name()}« is a final rule with a positive score — marking as spam without checking the remaining rules" );
+
+					return true;
+				}
 			} else {
 				$this->no_spam_reasons[] = $rule::get_slug();
 			}
@@ -191,6 +201,44 @@ class Rules {
 		}
 
 		return $score > 0.0;
+	}
+
+	/**
+	 * Sort the rules so that final rules are checked first.
+	 *
+	 * The sorting can be disabled with the `antispam_bee_sort_final_rules_first`
+	 * filter, in which case the rules are checked in their registered order.
+	 *
+	 * @param array<class-string> $rules Rules to sort.
+	 *
+	 * @return array<class-string> Sorted rules.
+	 */
+	private function sort_rules( array $rules ): array {
+		/**
+		 * Filter whether final rules should be checked before all other rules.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool   $sort_final_first Whether to check final rules first. Default true.
+		 * @param string $reaction_type    The reaction type (e.g. "comment").
+		 */
+		$sort_final_first = (bool) apply_filters( 'antispam_bee_sort_final_rules_first', true, $this->reaction_type );
+
+		if ( ! $sort_final_first ) {
+			return $rules;
+		}
+
+		$final_rules     = [];
+		$non_final_rules = [];
+		foreach ( $rules as $rule ) {
+			if ( $rule::is_final() ) {
+				$final_rules[] = $rule;
+			} else {
+				$non_final_rules[] = $rule;
+			}
+		}
+
+		return array_merge( $final_rules, $non_final_rules );
 	}
 
 	/**

--- a/src/Interfaces/Verifiable.php
+++ b/src/Interfaces/Verifiable.php
@@ -51,6 +51,10 @@ interface Verifiable {
 	/**
 	 * Is this rule final?
 	 *
+	 * Final rules are checked before all other rules. If a final rule returns
+	 * a positive result, the item is marked as spam right away and the
+	 * remaining rules are not evaluated.
+	 *
 	 * @return bool Whether this rule is final.
 	 */
 	public static function is_final(): bool;

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -23,6 +23,13 @@ class EmptyData extends Base implements SpamReason {
 	protected static $slug = 'asb-empty';
 
 	/**
+	 * Missing required data is a definitive spam signal.
+	 *
+	 * @var bool
+	 */
+	protected static $is_final = true;
+
+	/**
 	 * Verify an item.
 	 *
 	 * Check for empty content or author.

--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -26,6 +26,13 @@ class Honeypot extends ControllableBase implements SpamReason {
 	protected static $slug = 'asb-honeypot';
 
 	/**
+	 * A filled honeypot is a definitive spam signal.
+	 *
+	 * @var bool
+	 */
+	protected static $is_final = true;
+
+	/**
 	 * Only comments are supported.
 	 *
 	 * @var string[]

--- a/src/Rules/InvalidRequest.php
+++ b/src/Rules/InvalidRequest.php
@@ -22,6 +22,13 @@ class InvalidRequest extends Base implements SpamReason {
 	protected static $slug = 'asb-invalid-request';
 
 	/**
+	 * An invalid request is a definitive spam signal.
+	 *
+	 * @var bool
+	 */
+	protected static $is_final = true;
+
+	/**
 	 * Verify an item.
 	 *
 	 * Check for invalid request content in POST data.

--- a/src/Rules/LinkbackPostTitleIsBlogName.php
+++ b/src/Rules/LinkbackPostTitleIsBlogName.php
@@ -23,6 +23,13 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	protected static $slug = 'asb-linkback-post-title-is-blogname';
 
 	/**
+	 * A linkback titled like the blog name is a definitive spam signal.
+	 *
+	 * @var bool
+	 */
+	protected static $is_final = true;
+
+	/**
 	 * Only linkbacks are supported.
 	 *
 	 * @var string[]

--- a/tests/Unit/Handlers/RulesTest.php
+++ b/tests/Unit/Handlers/RulesTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\Handlers\Rules;
+use AntispamBee\Helpers\ContentTypeHelper;
+use AntispamBee\Rules\Base;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Filters\expectApplied;
+
+if ( ! defined( 'AntispamBee\PLUGIN_PATH' ) ) {
+	define( 'AntispamBee\PLUGIN_PATH', dirname( __DIR__, 3 ) . DIRECTORY_SEPARATOR );
+}
+
+/**
+ * Non-final test rule with a configurable score that counts its calls.
+ */
+class RulesTestNonFinalRule extends Base {
+	protected static $slug = 'test-non-final';
+
+	public static $verify_calls = 0;
+	public static $score        = 0;
+
+	public static function verify( array $item ): int {
+		++self::$verify_calls;
+
+		return self::$score;
+	}
+
+	public static function get_name(): string {
+		return 'Non-final test rule';
+	}
+}
+
+/**
+ * Final test rule with a configurable score that counts its calls.
+ */
+class RulesTestFinalRule extends Base {
+	protected static $slug     = 'test-final';
+	protected static $is_final = true;
+
+	public static $verify_calls = 0;
+	public static $score        = 0;
+
+	public static function verify( array $item ): int {
+		++self::$verify_calls;
+
+		return self::$score;
+	}
+
+	public static function get_name(): string {
+		return 'Final test rule';
+	}
+}
+
+/**
+ * Unit tests for {@see Rules::apply()}.
+ */
+class RulesTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+
+		RulesTestNonFinalRule::$verify_calls = 0;
+		RulesTestNonFinalRule::$score        = 0;
+		RulesTestFinalRule::$verify_calls    = 0;
+		RulesTestFinalRule::$score           = 0;
+	}
+
+	/**
+	 * Register the two test rules, non-final first, to prove that final
+	 * rules are checked before the others regardless of registration order.
+	 */
+	private function register_test_rules(): void {
+		expectApplied( 'antispam_bee_rules' )
+			->andReturn( [ RulesTestNonFinalRule::class, RulesTestFinalRule::class ] );
+	}
+
+	public function test_final_rule_hit_marks_spam_without_checking_remaining_rules() {
+		$this->register_test_rules();
+		RulesTestFinalRule::$score    = 999;
+		RulesTestNonFinalRule::$score = -1;
+
+		$rules = new Rules( ContentTypeHelper::COMMENT_TYPE );
+
+		self::assertTrue( $rules->apply( [] ), 'positive final rule should mark the item as spam' );
+		self::assertSame( 1, RulesTestFinalRule::$verify_calls, 'final rule should have been checked' );
+		self::assertSame( 0, RulesTestNonFinalRule::$verify_calls, 'non-final rule should not run after a final hit' );
+		self::assertSame( [ 'test-final' ], $rules->get_spam_reasons(), 'only the final rule should be recorded as reason' );
+	}
+
+	public function test_final_rule_without_hit_does_not_short_circuit() {
+		$this->register_test_rules();
+		RulesTestFinalRule::$score    = 0;
+		RulesTestNonFinalRule::$score = 1;
+
+		$rules = new Rules( ContentTypeHelper::COMMENT_TYPE );
+
+		self::assertTrue( $rules->apply( [] ), 'positive overall score should mark the item as spam' );
+		self::assertSame( 1, RulesTestFinalRule::$verify_calls, 'final rule should have been checked' );
+		self::assertSame( 1, RulesTestNonFinalRule::$verify_calls, 'non-final rule should run when no final rule hits' );
+		self::assertSame( [ 'test-non-final' ], $rules->get_spam_reasons(), 'unexpected spam reasons' );
+		self::assertSame( [ 'test-final' ], $rules->get_no_spam_reasons(), 'unexpected no-spam reasons' );
+	}
+
+	public function test_sorting_can_be_disabled_via_filter() {
+		$this->register_test_rules();
+		RulesTestFinalRule::$score    = 999;
+		RulesTestNonFinalRule::$score = 0;
+
+		expectApplied( 'antispam_bee_sort_final_rules_first' )
+			->once()
+			->andReturn( false );
+
+		$rules = new Rules( ContentTypeHelper::COMMENT_TYPE );
+
+		self::assertTrue( $rules->apply( [] ), 'positive final rule should still mark the item as spam' );
+		self::assertSame( 1, RulesTestNonFinalRule::$verify_calls, 'non-final rule should run first when sorting is disabled' );
+		self::assertSame( 1, RulesTestFinalRule::$verify_calls, 'final rule should still be checked' );
+	}
+
+	public function test_negative_overall_score_is_not_spam() {
+		$this->register_test_rules();
+		RulesTestFinalRule::$score    = 0;
+		RulesTestNonFinalRule::$score = -1;
+
+		$rules = new Rules( ContentTypeHelper::COMMENT_TYPE );
+
+		self::assertFalse( $rules->apply( [] ), 'negative overall score should not mark the item as spam' );
+		self::assertSame( 1, RulesTestFinalRule::$verify_calls, 'final rule should have been checked' );
+		self::assertSame( 1, RulesTestNonFinalRule::$verify_calls, 'non-final rule should have been checked' );
+	}
+}


### PR DESCRIPTION
## What

The `Verifiable::is_final()` contract existed but `Rules::apply()` never consulted it: every rule ran for every reaction — including the rules that make blocking remote requests (`ValidGravatar`, `LangSpam`, `CountrySpam`) — even after a definitive hit like a filled honeypot.

## Changes

- `Rules::apply()` now short-circuits: a positive weighted score from a rule with `is_final()` marks the item as spam immediately and skips the remaining rules.
- Final rules are checked before all other rules via `Rules::sort_rules()`. The ordering can be disabled with the new `antispam_bee_sort_final_rules_first` filter, in which case rules run in their registered order.
- The four definitive 999-scoring rules — `Honeypot`, `EmptyData`, `InvalidRequest` and `LinkbackPostTitleIsBlogName` — are marked `$is_final`.
- Adds the first unit tests for `Rules::apply()` (short-circuiting, finals-first ordering, the ordering opt-out filter, reason bucketing, negative overall score).
- Documents the scoring and `is_final` semantics in `docs/adding-rules.md`.

## Why

Performance and reliability: once a definitive rule has flagged spam, running further (potentially remote-HTTP) rules only adds latency and external dependencies to every spam submission. It also makes the `is_final` API surface real before the 3.0 contract freezes.

## Verification

- `composer test:unit` — 21 tests, 67 assertions, all passing
- `composer phpstan` — no errors
- PHPCS clean on all changed files (only the pre-existing `print_r` warning in `Rules.php` that also exists on `v3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
