### PR TITLE
refactor: build normalized rule payload in the reaction

### DIFF
--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -74,4 +74,26 @@ class Comment extends Reaction {
 
 		return $reaction;
 	}
+
+	/**
+	 * Build the normalized payload from a comment.
+	 *
+	 * @param array<string, mixed> $reaction Raw comment data.
+	 * @return array<string, mixed> Normalized payload.
+	 */
+	protected static function build_payload( array $reaction ): array {
+		$url = $reaction['comment_author_url'] ?? '';
+
+		return [
+			'reaction_type' => static::$reaction_type,
+			'ip'            => $reaction['comment_author_IP'] ?? '',
+			'url'           => $url,
+			'host'          => $url ? DataHelper::parse_url( $url ) : '',
+			'body'          => $reaction['comment_content'] ?? '',
+			'email'         => $reaction['comment_author_email'] ?? '',
+			'author'        => $reaction['comment_author'] ?? '',
+			'useragent'     => $reaction['comment_agent'] ?? '',
+			'post_id'       => $reaction['comment_post_ID'] ?? null,
+		];
+	}
 }

--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -9,6 +9,7 @@ namespace AntispamBee\Handlers;
 
 use AntispamBee\GeneralOptions\IgnoreLinkbacks;
 use AntispamBee\Helpers\ContentTypeHelper;
+use AntispamBee\Helpers\DataHelper;
 use AntispamBee\Helpers\IpHelper;
 
 /**
@@ -42,5 +43,44 @@ class Linkback extends Reaction {
 		$reaction['comment_author_IP'] = IpHelper::get_client_ip();
 
 		return parent::process( $reaction );
+	}
+
+	/**
+	 * Build the normalized payload from a linkback.
+	 *
+	 * Linkback fields can arrive as arrays; they are normalized to scalars so
+	 * rules can treat every payload value uniformly.
+	 *
+	 * @param array<string, mixed> $reaction Raw linkback data.
+	 * @return array<string, mixed> Normalized payload.
+	 */
+	protected static function build_payload( array $reaction ): array {
+		$url = self::scalar( $reaction['comment_author_url'] ?? '' );
+
+		return [
+			'reaction_type' => static::$reaction_type,
+			'ip'            => self::scalar( $reaction['comment_author_IP'] ?? '' ),
+			'url'           => $url,
+			'host'          => $url ? DataHelper::parse_url( $url ) : '',
+			'body'          => self::scalar( $reaction['comment_content'] ?? '' ),
+			'email'         => '',
+			'author'        => '',
+			'useragent'     => '',
+			'post_id'       => self::scalar( $reaction['comment_post_ID'] ?? null ),
+		];
+	}
+
+	/**
+	 * Normalize a possibly array-valued linkback field to a scalar.
+	 *
+	 * @param mixed $value Raw field value.
+	 * @return mixed First element for arrays, the value otherwise.
+	 */
+	private static function scalar( $value ) {
+		if ( is_array( $value ) ) {
+			return reset( $value );
+		}
+
+		return $value;
 	}
 }

--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -64,7 +64,7 @@ class Linkback extends Reaction {
 			'host'          => $url ? DataHelper::parse_url( $url ) : '',
 			'body'          => self::scalar( $reaction['comment_content'] ?? '' ),
 			'email'         => '',
-			'author'        => '',
+			'author'        => self::scalar( $reaction['comment_author'] ?? '' ),
 			'useragent'     => '',
 			'post_id'       => self::scalar( $reaction['comment_post_ID'] ?? null ),
 		];

--- a/src/Handlers/Reaction.php
+++ b/src/Handlers/Reaction.php
@@ -63,7 +63,8 @@ abstract class Reaction {
 	public static function process( array $reaction ): array {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		$rules   = new Rules( static::$reaction_type );
-		$is_spam = $rules->apply( $reaction );
+		$payload = static::build_payload( $reaction );
+		$is_spam = $rules->apply( $payload );
 
 		if ( $is_spam ) {
 			return self::handle_spam( $reaction, $rules );
@@ -71,6 +72,19 @@ abstract class Reaction {
 
 		return $reaction;
 	}
+
+	/**
+	 * Build the normalized payload from the raw reaction data.
+	 *
+	 * Each reaction is responsible for mapping its own content (e.g. the
+	 * WordPress `comment_*` fields) onto the generic payload attributes the
+	 * rules consume, and for any helper-based enrichment (IP lookup, host
+	 * parsing). The returned payload must include the `reaction_type` attribute.
+	 *
+	 * @param array<string, mixed> $reaction Raw reaction data.
+	 * @return array<string, mixed> Normalized payload.
+	 */
+	abstract protected static function build_payload( array $reaction ): array;
 
 	/**
 	 * Handle spam.

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -102,24 +102,29 @@ class Rules {
 	/**
 	 * Apply rules.
 	 *
-	 * @param array<string, mixed> $item Item to apply rules to.
+	 * @param array<string, mixed> $item Normalized payload to apply rules to.
 	 *
 	 * @return bool Whether the item was identified as spam.
+	 * @throws ReflectionException
 	 */
 	public function apply( array $item ): bool {
-		$item['reaction_type'] = $this->reaction_type;
-		$rules                 = self::get( $this->reaction_type, true );
+		$rules = self::get( $this->reaction_type, true );
 
 		$no_spam_threshold = (float) apply_filters( 'antispam_bee_no_spam_threshold', 0.0 );
 		$spam_threshold    = (float) apply_filters( 'antispam_bee_spam_threshold', 0.0 );
 
 		$score = 0.0;
 
-		$log_item = $item;
-		unset( $log_item['comment_author_email'] );
-		unset( $log_item['comment_author_IP'] );
-		unset( $log_item['user_id'] );
-		unset( $log_item['user_ID'] );
+		/**
+		 * Filters the payload attributes that are anonymized (removed) before the
+		 * payload is written to the debug log.
+		 *
+		 * @param string[]             $attributes Attribute keys to remove from the log entry.
+		 * @param array<string, mixed> $item       The normalized payload (includes `reaction_type`).
+		 */
+		$anonymized_attributes = (array) apply_filters( 'antispam_bee_log_anonymized_attributes', [ 'ip', 'email' ], $item );
+
+		$log_item = array_diff_key( $item, array_flip( $anonymized_attributes ) );
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		DebugMode::log( 'Looping through spam rules for reaction with the following data: ' . print_r( $log_item, true ) );
 

--- a/src/Helpers/DataHelper.php
+++ b/src/Helpers/DataHelper.php
@@ -13,46 +13,6 @@ namespace AntispamBee\Helpers;
 class DataHelper {
 
 	/**
-	 * Get the values by keys.
-	 *
-	 * @param array<array-key>        $keys A list of keys.
-	 * @param array<array-key, mixed> $data The data to filter.
-	 *
-	 * @return array<array-key, mixed> Data elements with matching keys.
-	 */
-	public static function get_values_by_keys( array $keys, array $data ): array {
-		$results = [];
-		foreach ( $keys as $key ) {
-			if ( isset( $data[ $key ] ) ) {
-				$results[ $key ] = $data[ $key ];
-			}
-		}
-
-		return $results;
-	}
-
-	/**
-	 * Get the values with a key containing given values.
-	 *
-	 * @param string[]                $substrs The key substrings to filter.
-	 * @param array<array-key, mixed> $data    The data to filter.
-	 *
-	 * @return array<array-key, mixed> Data elements with matching keys.
-	 */
-	public static function get_values_where_key_contains( array $substrs, array $data ): array {
-		$results = [];
-		foreach ( $data as $key => $value ) {
-			foreach ( $substrs as $substr ) {
-				if ( strpos( $key, $substr ) ) {
-					$results[ $key ] = $value;
-				}
-			}
-		}
-
-		return $results;
-	}
-
-	/**
 	 * Parse URL wrapper.
 	 *
 	 * @param string $url       URL to parse.

--- a/src/Interfaces/Verifiable.php
+++ b/src/Interfaces/Verifiable.php
@@ -15,7 +15,12 @@ interface Verifiable {
 	 * Verify an item.
 	 * Applies logic and returns a numeric value, positive, negative or zero (neutral).
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Receives the normalized payload built by the reaction (see
+	 * {@see \AntispamBee\Handlers\Reaction::build_payload()}), keyed by generic
+	 * attributes (`reaction_type`, `ip`, `url`, `host`, `body`, `email`,
+	 * `author`, `useragent`, `post_id`) rather than the raw reaction data.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Weighted result.
 	 */

--- a/src/Rules/ApprovedEmail.php
+++ b/src/Rules/ApprovedEmail.php
@@ -8,7 +8,6 @@
 namespace AntispamBee\Rules;
 
 use AntispamBee\Helpers\ContentTypeHelper;
-use AntispamBee\Helpers\DataHelper;
 
 /**
  * Checks if the email is from an already approved commenter.
@@ -32,17 +31,17 @@ class ApprovedEmail extends ControllableBase {
 	/**
 	 * Verify an item.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `email`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$email = DataHelper::get_values_where_key_contains( [ 'email' ], $item );
+		$email = $item['email'] ?? '';
 		if ( empty( $email ) ) {
 			return 0;
 		}
-
-		$email = array_shift( $email );
 
 		$approved_comments_count = get_comments(
 			[

--- a/src/Rules/BBCode.php
+++ b/src/Rules/BBCode.php
@@ -26,12 +26,17 @@ class BBCode extends ControllableBase implements SpamReason {
 	 *
 	 * Check whether any content part contains BBCode links.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Iterates over all payload attributes (e.g. `body`, `author`, `url`).
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
 		foreach ( $item as $value ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
 			if ( true === (bool) preg_match( '/\[url[=\]].*\[\/url\]/is', $value ) ) {
 				return 1;
 			}

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -29,15 +29,17 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 *
 	 * Check whether a reaction originates from an allowed country.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `ip`, `reaction_type`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		if ( empty( $item['comment_author_IP'] ) ) {
+		if ( empty( $item['ip'] ) ) {
 			return 0;
 		}
-		$ip = $item['comment_author_IP'];
+		$ip = $item['ip'];
 
 		$country_allowed = Settings::get_option( static::get_option_name( 'allowed' ), $item['reaction_type'] ) ?: '';
 		$country_denied  = Settings::get_option( static::get_option_name( 'denied' ), $item['reaction_type'] ) ?: '';

--- a/src/Rules/DbSpam.php
+++ b/src/Rules/DbSpam.php
@@ -7,7 +7,6 @@
 
 namespace AntispamBee\Rules;
 
-use AntispamBee\Helpers\DataHelper;
 use AntispamBee\Interfaces\SpamReason;
 
 /**
@@ -27,33 +26,34 @@ class DbSpam extends ControllableBase implements SpamReason {
 	 *
 	 * Test item for spam patterns from the database.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `url`, `ip`, `email`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
 		$params = [];
 		$filter = [];
-		$values = DataHelper::get_values_where_key_contains( [ 'url' ], $item );
-		$url    = wp_unslash( array_shift( $values ) );
+		$url    = wp_unslash( $item['url'] ?? '' );
 
 		if ( ! empty( $url ) ) {
 			$filter[] = '`comment_author_url` = %s';
 			$params[] = $url;
 		}
 
-		$ip = DataHelper::get_values_by_keys( [ 'comment_author_IP' ], $item );
+		$ip = $item['ip'] ?? '';
 
 		if ( ! empty( $ip ) ) {
 			$filter[] = '`comment_author_IP` = %s';
-			$params[] = wp_unslash( array_shift( $ip ) );
+			$params[] = wp_unslash( $ip );
 		}
 
-		$email = DataHelper::get_values_where_key_contains( [ 'email' ], $item );
+		$email = $item['email'] ?? '';
 
 		if ( ! empty( $email ) ) {
 			$filter[] = '`comment_author_email` = %s';
-			$params[] = wp_unslash( array_shift( $email ) );
+			$params[] = wp_unslash( $email );
 		}
 		if ( empty( $params ) ) {
 			return 0;

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -27,30 +27,33 @@ class EmptyData extends Base implements SpamReason {
 	 *
 	 * Check for empty content or author.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `body`, `ip`, `email`, `author`, `url`,
+	 * `reaction_type`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$allow_empty_reaction = apply_filters( 'allow_empty_comment', false, $item );
-		$content              = $item['comment_content'] ?? '';
+		$content              = $item['body'] ?? '';
 		if ( ! $allow_empty_reaction && empty( $content ) ) {
 			return 999;
 		}
 
-		if ( empty( $item['comment_author_IP'] ) ) {
+		if ( empty( $item['ip'] ) ) {
 			return 999;
 		}
 
 		if ( ContentTypeHelper::COMMENT_TYPE === $item['reaction_type'] ) {
-			if ( get_option( 'require_name_email' ) && ( empty( $item['comment_author_email'] ) || empty( $item['comment_author'] ) ) ) {
+			if ( get_option( 'require_name_email' ) && ( empty( $item['email'] ) || empty( $item['author'] ) ) ) {
 				return 999;
 			}
 		}
 
 		if ( ContentTypeHelper::LINKBACK_TYPE === $item['reaction_type'] ) {
-			$url = $item['comment_author_url'] ?? '';
+			$url = $item['url'] ?? '';
 			if ( empty( $url ) ) {
 				return 999;
 			}

--- a/src/Rules/Honeypot.php
+++ b/src/Rules/Honeypot.php
@@ -58,7 +58,9 @@ class Honeypot extends ControllableBase implements SpamReason {
 	 *
 	 * Check if request contains data from the honeypot field.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Consumes no payload attributes; reads the request (`$_POST`) directly.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */

--- a/src/Rules/InvalidRequest.php
+++ b/src/Rules/InvalidRequest.php
@@ -26,7 +26,9 @@ class InvalidRequest extends Base implements SpamReason {
 	 *
 	 * Check for invalid request content in POST data.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Consumes no payload attributes; reads the request (`$_POST`) directly.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */

--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -7,7 +7,6 @@
 
 namespace AntispamBee\Rules;
 
-use AntispamBee\Helpers\DataHelper;
 use AntispamBee\Helpers\LangHelper;
 use AntispamBee\Helpers\Sanitize;
 use AntispamBee\Helpers\Settings;
@@ -30,19 +29,20 @@ class LangSpam extends ControllableBase implements SpamReason {
 	 *
 	 * Check for allowed languages.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `body`, `reaction_type`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
 		$allowed_languages = array_keys( (array) Settings::get_option( static::get_option_name( 'allowed' ), $item['reaction_type'] ) );
 
-		$comment_content = DataHelper::get_values_where_key_contains( [ 'content' ], $item );
+		$comment_content = $item['body'] ?? '';
 		if ( empty( $comment_content ) ) {
 			return 0;
 		}
-		$comment_content = array_shift( $comment_content );
-		$comment_text    = wp_strip_all_tags( $comment_content );
+		$comment_text = wp_strip_all_tags( $comment_content );
 
 		if ( empty( $allowed_languages ) || empty( $comment_text ) ) {
 			return 0;

--- a/src/Rules/LinkbackFromMyself.php
+++ b/src/Rules/LinkbackFromMyself.php
@@ -41,19 +41,19 @@ class LinkbackFromMyself extends Base implements SpamReason {
 	 *
 	 * Test if a linkback originates from its own target.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `url`, `post_id`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$url            = $item['comment_author_url'] ?? null;
-		$target_post_id = $item['comment_post_ID'] ?? null;
+		$url            = $item['url'] ?? null;
+		$target_post_id = $item['post_id'] ?? null;
 		if ( empty( $url ) || empty( $target_post_id ) ) {
 			return 0;
 		}
 
-		$url            = $url[0];
-		$target_post_id = $target_post_id[0];
 		if ( 0 !== strpos( $url, home_url() ) ) {
 			return 0;
 		}

--- a/src/Rules/LinkbackPostTitleIsBlogName.php
+++ b/src/Rules/LinkbackPostTitleIsBlogName.php
@@ -34,13 +34,15 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	 *
 	 * Test if a linkback title is blog name.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `body`, `author`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$body      = $item['comment_content'] ?? null;
-		$blog_name = $item['comment_author'] ?? null;
+		$body      = $item['body'] ?? null;
+		$blog_name = $item['author'] ?? null;
 		preg_match( '/<strong>(.*)<\/strong>\\n\\n/', $body, $matches );
 		if ( ! isset( $matches[1] ) ) {
 			return 0;

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -7,8 +7,6 @@
 
 namespace AntispamBee\Rules;
 
-use AntispamBee\Helpers\ContentTypeHelper;
-use AntispamBee\Helpers\DataHelper;
 use AntispamBee\Interfaces\SpamReason;
 
 /**
@@ -29,16 +27,20 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 	 *
 	 * Content fields using pre-defined and custom regular expressions.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `ip`, `url`, `host`, `body`, `email`,
+	 * `author`, `useragent`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @phpstan-param array{
-	 *     reaction_type: string,
-	 *     comment_author_IP?: string,
-	 *     comment_author_url?: string,
-	 *     comment_content?: string,
-	 *     comment_author_email?: string,
-	 *     comment_author?: string,
-	 *     comment_agent?: string,
+	 *     reaction_type?: string,
+	 *     ip?: string,
+	 *     url?: string,
+	 *     host?: string,
+	 *     body?: string,
+	 *     email?: string,
+	 *     author?: string,
+	 *     useragent?: string,
 	 * } $item
 	 *
 	 * @return int Numeric result.
@@ -53,43 +55,15 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 			'useragent',
 		];
 
-		$subject = null;
-
-		if ( ContentTypeHelper::COMMENT_TYPE === $item['reaction_type'] ) {
-			$ip        = $item['comment_author_IP'] ?? '';
-			$url       = $item['comment_author_url'] ?? '';
-			$body      = $item['comment_content'] ?? '';
-			$email     = $item['comment_author_email'] ?? '';
-			$author    = $item['comment_author'] ?? '';
-			$useragent = $item['comment_agent'] ?? '';
-			$subject   = [
-				'ip'        => $ip,
-				'rawurl'    => $url,
-				'host'      => DataHelper::parse_url( $url ),
-				'body'      => $body,
-				'email'     => $email,
-				'author'    => $author,
-				'useragent' => $useragent,
-			];
-		}
-
-		if ( ContentTypeHelper::LINKBACK_TYPE === $item['reaction_type'] ) {
-			$ip      = $item['comment_author_IP'] ?? '';
-			$url     = $item['comment_author_url'] ?? '';
-			$body    = $item['comment_content'] ?? '';
-			$subject = [
-				'ip'     => $ip,
-				'rawurl' => $url,
-				'host'   => DataHelper::parse_url( $url ),
-				'body'   => $body,
-				'email'  => '',
-				'author' => '',
-			];
-		}
-
-		if ( ! $subject ) {
-			return 0;
-		}
+		$subject = [
+			'ip'        => $item['ip'] ?? '',
+			'rawurl'    => $item['url'] ?? '',
+			'host'      => $item['host'] ?? '',
+			'body'      => $item['body'] ?? '',
+			'email'     => $item['email'] ?? '',
+			'author'    => $item['author'] ?? '',
+			'useragent' => $item['useragent'] ?? '',
+		];
 
 		$patterns = [
 			[
@@ -168,7 +142,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 			$hits = [];
 
 			foreach ( $pattern as $field => $regexp ) {
-				if ( empty( $field ) || ! in_array( $field, $fields, true ) || empty( $regexp ) || ! isset( $subject[ $field ] ) ) {
+				if ( empty( $field ) || ! in_array( $field, $fields, true ) || empty( $regexp ) ) {
 					continue;
 				}
 

--- a/src/Rules/TooFastSubmit.php
+++ b/src/Rules/TooFastSubmit.php
@@ -73,7 +73,9 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	 *
 	 * Test for time between page initialization and reaction.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Consumes no payload attributes; reads the request (`$_POST`) directly.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */

--- a/src/Rules/ValidGravatar.php
+++ b/src/Rules/ValidGravatar.php
@@ -8,7 +8,6 @@
 namespace AntispamBee\Rules;
 
 use AntispamBee\Helpers\ContentTypeHelper;
-use AntispamBee\Helpers\DataHelper;
 
 /**
  * Rule that is responsible for checking if the commenter has a valid gravatar.
@@ -34,16 +33,17 @@ class ValidGravatar extends ControllableBase {
 	 *
 	 * Test if author's email points to a valid Gravatar.
 	 *
-	 * @param array<string, mixed> $item Item to verify.
+	 * Handled payload attributes: `email`.
+	 *
+	 * @param array<string, mixed> $item Normalized payload to verify.
 	 *
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
-		$email = DataHelper::get_values_where_key_contains( [ 'email' ], $item );
+		$email = $item['email'] ?? '';
 		if ( empty( $email ) ) {
 			return 0;
 		}
-		$email = array_shift( $email );
 
 		$response = wp_safe_remote_get(
 			sprintf(

--- a/tests/Unit/Handlers/LinkbackTest.php
+++ b/tests/Unit/Handlers/LinkbackTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\Handlers\Linkback;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see Linkback}.
+ */
+class LinkbackTest extends TestCase {
+
+	/**
+	 * Invoke the protected static build_payload().
+	 *
+	 * @param array $reaction Raw reaction data.
+	 * @return array Normalized payload.
+	 */
+	private static function build_payload( array $reaction ): array {
+		when( 'wp_parse_url' )->alias( 'parse_url' ); // used for the 'host' attribute
+		$method = new \ReflectionMethod( Linkback::class, 'build_payload' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $reaction );
+	}
+
+	/**
+	 * The linkback's blog name lives in comment_author; the normalized payload
+	 * must carry it so LinkbackPostTitleIsBlogName can compare it to the title.
+	 */
+	public function test_payload_maps_author_from_comment_author() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => 'Example Blog',
+				'comment_content'    => 'Some excerpt.',
+				'comment_author_url' => 'https://example.com/post/',
+				'comment_author_IP'  => '192.0.2.10',
+				'comment_post_ID'    => 1,
+			]
+		);
+
+		self::assertSame( 'linkback', $payload['reaction_type'] );
+		self::assertSame( 'Example Blog', $payload['author'], 'author must be mapped from comment_author' );
+		self::assertSame( 'Some excerpt.', $payload['body'] );
+		self::assertSame( 'https://example.com/post/', $payload['url'] );
+		self::assertSame( 'example.com', $payload['host'] );
+	}
+
+	/**
+	 * Linkback fields can arrive as arrays; they must be normalized to scalars.
+	 */
+	public function test_payload_normalizes_array_valued_author() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => [ 'Example Blog', 'ignored' ],
+				'comment_content'    => 'x',
+				'comment_author_url' => '',
+				'comment_author_IP'  => '192.0.2.10',
+			]
+		);
+
+		self::assertSame( 'Example Blog', $payload['author'], 'array author must be reduced to its first element' );
+	}
+
+	/**
+	 * A missing author yields an empty string (not a warning / null).
+	 */
+	public function test_payload_author_defaults_to_empty() {
+		$payload = self::build_payload(
+			[
+				'comment_content'    => 'x',
+				'comment_author_url' => '',
+				'comment_author_IP'  => '192.0.2.10',
+			]
+		);
+
+		self::assertSame( '', $payload['author'] );
+	}
+}

--- a/tests/Unit/Rules/AbstractRuleTestCase.php
+++ b/tests/Unit/Rules/AbstractRuleTestCase.php
@@ -27,40 +27,6 @@ abstract class AbstractRuleTestCase extends TestCase {
 	}
 
 	/**
-	 * Generate a test comment.
-	 *
-	 * @param int    $id           Comment ID.
-	 * @param string $author       Author name.
-	 * @param string $author_email Author email.
-	 * @param string $author_url   Author URL.
-	 * @param string $author_ip    Author IP address.
-	 * @param string $content      Comment content.
-	 * @param string $agent        User agent.
-	 *
-	 * @return array Comment array.
-	 */
-	protected static function make_comment(
-		int $id = 1,
-		string $author = 'Test Author',
-		string $author_email = 'test.author@example.com',
-		string $author_url = 'www.example.com',
-		string $author_ip = '192.0.2.1',
-		string $content = 'This is the base test comment.',
-		string $agent = 'Mozilla/5.0'
-	): array {
-		return [
-			'reaction_type'        => ContentTypeHelper::COMMENT_TYPE,
-			'comment_ID'           => $id,
-			'comment_author'       => $author,
-			'comment_author_email' => $author_email,
-			'comment_author_url'   => $author_url,
-			'comment_author_IP'    => $author_ip,
-			'comment_content'      => $content,
-			'comment_agent'        => $agent,
-		];
-	}
-
-	/**
 	 * Test for expected slug.
 	 * Might seem redundant, but we might just have forgotten about this...
 	 *
@@ -84,5 +50,39 @@ abstract class AbstractRuleTestCase extends TestCase {
 			has_filter( 'antispam_bee_rules', [ $this->rule, 'add_rule' ] ),
 			'The add_rule filter was not added'
 		);
+	}
+
+	/**
+	 * Generate a normalized test payload for a comment.
+	 *
+	 * @param int    $post_id      Post ID.
+	 * @param string $author       Author name.
+	 * @param string $author_email Author email.
+	 * @param string $author_url   Author URL.
+	 * @param string $author_ip    Author IP address.
+	 * @param string $content      Comment content.
+	 * @param string $agent        User agent.
+	 *
+	 * @return array<string, mixed> Normalized payload.
+	 */
+	protected static function make_comment(
+		int $post_id = 1,
+		string $author = 'Test Author',
+		string $author_email = 'test.author@example.com',
+		string $author_url = 'www.example.com',
+		string $author_ip = '192.0.2.1',
+		string $content = 'This is the base test comment.',
+		string $agent = 'Mozilla/5.0'
+	): array {
+		return [
+			'reaction_type' => ContentTypeHelper::COMMENT_TYPE,
+			'post_id'       => $post_id,
+			'author'        => $author,
+			'email'         => $author_email,
+			'url'           => $author_url,
+			'ip'            => $author_ip,
+			'body'          => $content,
+			'useragent'     => $agent,
+		];
 	}
 }

--- a/tests/Unit/Rules/BBCodeTest.php
+++ b/tests/Unit/Rules/BBCodeTest.php
@@ -14,22 +14,22 @@ class BBCodeTest extends AbstractRuleTestCase {
 		$item = [];
 		self::assertSame( 0, BBCode::verify( $item ), 'Unexpected result for empty item' );
 
-		$item['comment_content'] = 'No link here.';
+		$item['body'] = 'No link here.';
 		self::assertSame( 0, BBCode::verify( $item ), 'Unexpected result for comment without BBCode' );
 
-		$item['comment_content'] = 'Link to [url]https://example.com[/url].';
+		$item['body'] = 'Link to [url]https://example.com[/url].';
 		self::assertSame( 1, BBCode::verify( $item ), 'Unexpected result for comment with simple URL' );
 
-		$item['comment_content'] = 'This is a [url=https://example.com]link[/url].';
+		$item['body'] = 'This is a [url=https://example.com]link[/url].';
 		self::assertSame( 1, BBCode::verify( $item ), 'Unexpected result for comment with wrapped URL' );
 
-		$item['comment_content'] = 'This is a [UrL=https://example.com]link[/uRl].';
+		$item['body'] = 'This is a [UrL=https://example.com]link[/uRl].';
 		self::assertSame( 1, BBCode::verify( $item ), 'Check should be case-insensitive' );
 
-		$item['comment_content'] = 'This is [b]bold[/b] and [i]italic[/i] text.';
+		$item['body'] = 'This is [b]bold[/b] and [i]italic[/i] text.';
 		self::assertSame( 0, BBCode::verify( $item ), 'Unexpected result for comment with other BBCodes' );
 
-		$item['test'] = 'Unknown [url=https://example.com]field[/url].';
+		$item['author'] = 'Unknown [url=https://example.com]field[/url].';
 		self::assertSame( 1, BBCode::verify( $item ), 'Unexpected result for BBCode in different fields' );
 	}
 }

--- a/tests/Unit/Rules/EmptyDataTest.php
+++ b/tests/Unit/Rules/EmptyDataTest.php
@@ -16,20 +16,20 @@ class EmptyDataTest extends AbstractRuleTestCase {
 		$item = [ 'reaction_type' => ContentTypeHelper::COMMENT_TYPE ];
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result for empty comment' );
 
-		$item['comment_content'] = 'This is a test.';
+		$item['body'] = 'This is a test.';
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result for empty author IP' );
 
-		$item['comment_author_IP'] = '192.0.2.91';
+		$item['ip'] = '192.0.2.91';
 		when( 'get_option' )->justReturn( false );
 		self::assertSame( 0, EmptyData::verify( $item ), 'Unexpected result with no name required' );
 
 		when( 'get_option' )->justReturn( true );
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result without name and mail' );
 
-		$item['comment_author_email'] = 'comments@example.com';
+		$item['email'] = 'comments@example.com';
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result without author name' );
 
-		$item['comment_author'] = 'A. Tester';
+		$item['author'] = 'A. Tester';
 		self::assertSame( 0, EmptyData::verify( $item ), 'Unexpected result with name and mail' );
 	}
 
@@ -37,13 +37,13 @@ class EmptyDataTest extends AbstractRuleTestCase {
 		$item = [ 'reaction_type' => ContentTypeHelper::LINKBACK_TYPE ];
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result for empty comment' );
 
-		$item['comment_content'] = 'This is a test.';
+		$item['body'] = 'This is a test.';
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result for empty author IP' );
 
-		$item['comment_author_IP'] = '192.0.2.91';
+		$item['ip'] = '192.0.2.91';
 		self::assertSame( 999, EmptyData::verify( $item ), 'Unexpected result with empty URL' );
 
-		$item['comment_author_url'] = 'https://linkback.example.com/';
+		$item['url'] = 'https://linkback.example.com/';
 		self::assertSame( 0, EmptyData::verify( $item ), 'Unexpected result with non-empty URL' );
 	}
 }

--- a/tests/Unit/Rules/RegexpSpamTest.php
+++ b/tests/Unit/Rules/RegexpSpamTest.php
@@ -25,25 +25,25 @@ class RegexpSpamTest extends AbstractRuleTestCase {
 			'Unknown reaction type should not be flagged'
 		);
 
-		$spam_author                   = self::make_comment();
-		$spam_author['comment_author'] = 'Buy Viagra';
+		$spam_author           = self::make_comment();
+		$spam_author['author'] = 'Buy Viagra';
 		self::assertSame(
 			1,
 			RegexpSpam::verify( $spam_author ),
 			'Known spam word in the author name should be flagged'
 		);
 
-		$spam_body                         = self::make_comment();
-		$spam_body['comment_content']      = 'this is a pharmacy, why does it work now?.';
-		$spam_body['comment_author_email'] = 'test@yandex.ru';
+		$spam_body          = self::make_comment();
+		$spam_body['body']  = 'this is a pharmacy, why does it work now?.';
+		$spam_body['email'] = 'test@yandex.ru';
 		self::assertSame(
 			1,
 			RegexpSpam::verify( $spam_body ),
 			'Matching body and email pattern combination should be flagged'
 		);
 
-		$partial_match                    = self::make_comment();
-		$partial_match['comment_content'] = 'this is a pharmacy, why does it work now?.';
+		$partial_match         = self::make_comment();
+		$partial_match['body'] = 'this is a pharmacy, why does it work now?.';
 		self::assertSame(
 			0,
 			RegexpSpam::verify( $partial_match ),
@@ -52,8 +52,8 @@ class RegexpSpamTest extends AbstractRuleTestCase {
 	}
 
 	public function test_verify_respects_custom_patterns_filter() {
-		$item                    = self::make_comment();
-		$item['comment_content'] = 'A perfectly harmless custom message.';
+		$item         = self::make_comment();
+		$item['body'] = 'A perfectly harmless custom message.';
 
 		expectApplied( 'antispam_bee_patterns' )
 			->once()


### PR DESCRIPTION
## Summary

Moves responsibility for shaping rule input from the individual rules to the `Reaction`. Each reaction now maps its own content onto a **normalized payload** with generic keys via a new `build_payload()` method, so rules read only generic keys and no longer branch on the reaction type or know about WordPress `comment_*` fields.

## What changed

- **`Reaction::build_payload()`** (abstract) — `Comment` and `Linkback` implement it, mapping their raw fields onto the generic vocabulary `reaction_type`, `ip`, `url`, `host`, `body`, `email`, `author`, `useragent`, `post_id`. Helper-based enrichment (host parsing via `DataHelper::parse_url()`, IP lookup) now happens in the reaction. `Linkback` normalizes its array-valued fields to scalars.
- **`Rules::apply()`** is now reaction-agnostic and anonymizes sensitive keys for the debug log through the new `antispam_bee_log_anonymized_attributes` filter, which also receives the payload so callbacks can react on `reaction_type`.
- **Rules** read generic keys and each documents the payload attributes it handles. Removed the reaction-type branches in `RegexpSpam`, the fuzzy `DataHelper` lookups in `DbSpam`/`LangSpam`/`ApprovedEmail`/`ValidGravatar`, and the `[0]` indexing in `LinkbackFromMyself`. `Honeypot`/`InvalidRequest`/`TooFastSubmit` note they read `$_POST` directly.
- Removed the now-unused `DataHelper::get_values_by_keys()` and `get_values_where_key_contains()`.
- The raw reaction still flows to WordPress and the post-processors unchanged (`UpdateSpamLog` keeps its `comment_post_ID` / `comment_author_IP`).

## Verification

- `composer test:unit` — 21 passed; `composer phpstan` — no errors (level 8); `composer lint-php` — clean.
- End-to-end on wp-env: a real submission via `wp_handle_comment_submission()` (→ `preprocess_comment` → `Comment::process` → `build_payload` → `Rules::apply`) was stored as `approved='spam'` with `antispam_bee_reason=asb-regexp`. Per-rule diagnostic on normalized payloads: clean comment → no rule fired; spammy author → `asb-regexp`; BBCode body → `asb-bbcode`; empty body → `asb-empty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)