### PR TITLE
docs: align hook DocBlocks with WordPress documentation standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,24 @@ this via PHPCompatibilityWP.
 - **Text domain** — always `'antispam-bee'` (matches the plugin slug); do not use a variable or a
   different string.
 
+## Inline documentation
+
+Document every hook (`apply_filters()` / `do_action()`) following the
+[WordPress PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).
+
+- **Placement** — put the DocBlock on the line immediately preceding the `apply_filters()` /
+  `do_action()` call. If the call is embedded in an expression or condition, extract it into a
+  variable so the DocBlock attaches directly to the call.
+- **Tag order** — summary, then optional description, then `@since`, then `@param` (one per hook
+  argument, aligned).
+- **No `@return`** — hook DocBlocks never use `@return`. Action hooks return nothing, and filter
+  hooks always return their first parameter.
+- **`@since`** — use the three-digit version in which the hook was introduced (e.g. `@since 2.9.4`).
+  For a hook that already exists on `master`, trace the introducing commit and its release version;
+  for a hook new to `v3`, use `@since 3.0.0`.
+- Reuse of a WordPress core hook (e.g. `pre_comment_user_ip`, `allow_empty_comment`) is documented
+  the same way, with the `@since` reflecting when this plugin started applying it.
+
 ## Git workflow
 
 - Always work on a **feature branch** based on `v3`

--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -50,10 +50,9 @@ class Comment extends Reaction {
 		 * Reactions whose type is not part of this list are returned unchanged and
 		 * skip the spam verification for comments.
 		 *
-		 * @param array $types A list of comment types to process.
-		 *
-		 * @return array The list of comment types to process.
 		 * @since 3.0.0
+		 *
+		 * @param array $types A list of comment types to process.
 		 */
 		$comment_types = (array) apply_filters( 'antispam_bee_comment_types', [ '', 'comment', 'review' ] );
 

--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -45,9 +45,15 @@ class Comment extends Reaction {
 	 */
 	public static function process( array $reaction ): array {
 		/**
-		 * Filter processable comment types.
+		 * Filters the comment types that Antispam Bee processes.
 		 *
-		 * @param array $types A list of comment types.
+		 * Reactions whose type is not part of this list are returned unchanged and
+		 * skip the spam verification for comments.
+		 *
+		 * @param array $types A list of comment types to process.
+		 *
+		 * @return array The list of comment types to process.
+		 * @since 3.0.0
 		 */
 		$comment_types = (array) apply_filters( 'antispam_bee_comment_types', [ '', 'comment', 'review' ] );
 

--- a/src/Handlers/GeneralOptions.php
+++ b/src/Handlers/GeneralOptions.php
@@ -48,10 +48,9 @@ class GeneralOptions {
 		 * Use this filter to register additional option controls that are rendered
 		 * on the plugin’s general settings tab.
 		 *
-		 * @param array $options A list of controllable general options.
-		 *
-		 * @return array The list of controllable general options.
 		 * @since 3.0.0
+		 *
+		 * @param array $options A list of controllable general options.
 		 */
 		return apply_filters( 'antispam_bee_general_options', [] );
 	}

--- a/src/Handlers/GeneralOptions.php
+++ b/src/Handlers/GeneralOptions.php
@@ -42,6 +42,17 @@ class GeneralOptions {
 			return [];
 		}
 
+		/**
+		 * Filters the controllable general options.
+		 *
+		 * Use this filter to register additional option controls that are rendered
+		 * on the plugin’s general settings tab.
+		 *
+		 * @param array $options A list of controllable general options.
+		 *
+		 * @return array The list of controllable general options.
+		 * @since 3.0.0
+		 */
 		return apply_filters( 'antispam_bee_general_options', [] );
 	}
 }

--- a/src/Handlers/PostProcessors.php
+++ b/src/Handlers/PostProcessors.php
@@ -77,7 +77,22 @@ class PostProcessors {
 	 * @throws ReflectionException
 	 */
 	private static function filter( array $options ): array {
-		return ComponentsHelper::filter( apply_filters( 'antispam_bee_post_processors', [] ), $options );
+		/**
+		 * Filters the registered post-processors.
+		 *
+		 * Post-processors are the actions Antispam Bee runs on a reaction after the
+		 * rules have classified it (for example deleting spam or sending a
+		 * notification). Add or remove fully-qualified class names to change which
+		 * post-processors are available.
+		 *
+		 * @param array $post_processors A list of post-processor class names.
+		 *
+		 * @return array The list of post-processor class names.
+		 * @since 3.0.0
+		 */
+		$post_processors = apply_filters( 'antispam_bee_post_processors', [] );
+
+		return ComponentsHelper::filter( $post_processors, $options );
 	}
 
 	/**

--- a/src/Handlers/PostProcessors.php
+++ b/src/Handlers/PostProcessors.php
@@ -85,10 +85,9 @@ class PostProcessors {
 		 * notification). Add or remove fully-qualified class names to change which
 		 * post-processors are available.
 		 *
-		 * @param array $post_processors A list of post-processor class names.
-		 *
-		 * @return array The list of post-processor class names.
 		 * @since 3.0.0
+		 *
+		 * @param array $post_processors A list of post-processor class names.
 		 */
 		$post_processors = apply_filters( 'antispam_bee_post_processors', [] );
 

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -84,10 +84,9 @@ class Rules {
 		 * as spam or ham. Add or remove fully-qualified class names to change which
 		 * rules are available.
 		 *
-		 * @param array $rules A list of rule class names.
-		 *
-		 * @return array The list of rule class names.
 		 * @since 3.0.0
+		 *
+		 * @param array $rules A list of rule class names.
 		 */
 		$rules = apply_filters( 'antispam_bee_rules', [] );
 
@@ -130,10 +129,9 @@ class Rules {
 		 * A reaction whose accumulated rule score is lower than or equal to this
 		 * threshold is treated as ham, regardless of the individual rule results.
 		 *
-		 * @param float $no_spam_threshold The no-spam score threshold. Default 0.0.
-		 *
-		 * @return float The no-spam score threshold.
 		 * @since 3.0.0
+		 *
+		 * @param float $no_spam_threshold The no-spam score threshold. Default 0.0.
 		 */
 		$no_spam_threshold = (float) apply_filters( 'antispam_bee_no_spam_threshold', 0.0 );
 
@@ -143,10 +141,9 @@ class Rules {
 		 * A reaction whose accumulated rule score is higher than or equal to this
 		 * threshold is treated as spam.
 		 *
-		 * @param float $spam_threshold The spam score threshold. Default 0.0.
-		 *
-		 * @return float The spam score threshold.
 		 * @since 3.0.0
+		 *
+		 * @param float $spam_threshold The spam score threshold. Default 0.0.
 		 */
 		$spam_threshold = (float) apply_filters( 'antispam_bee_spam_threshold', 0.0 );
 

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -77,7 +77,21 @@ class Rules {
 	 * @throws ReflectionException
 	 */
 	private static function filter( array $options ): array {
-		return ComponentsHelper::filter( apply_filters( 'antispam_bee_rules', [] ), $options );
+		/**
+		 * Filters the registered rules.
+		 *
+		 * Rules are the checks Antispam Bee runs against a reaction to classify it
+		 * as spam or ham. Add or remove fully-qualified class names to change which
+		 * rules are available.
+		 *
+		 * @param array $rules A list of rule class names.
+		 *
+		 * @return array The list of rule class names.
+		 * @since 3.0.0
+		 */
+		$rules = apply_filters( 'antispam_bee_rules', [] );
+
+		return ComponentsHelper::filter( $rules, $options );
 	}
 
 	/**
@@ -110,8 +124,31 @@ class Rules {
 	public function apply( array $item ): bool {
 		$rules = self::get( $this->reaction_type, true );
 
+		/**
+		 * Filters the score threshold below which a reaction is considered no spam.
+		 *
+		 * A reaction whose accumulated rule score is lower than or equal to this
+		 * threshold is treated as ham, regardless of the individual rule results.
+		 *
+		 * @param float $no_spam_threshold The no-spam score threshold. Default 0.0.
+		 *
+		 * @return float The no-spam score threshold.
+		 * @since 3.0.0
+		 */
 		$no_spam_threshold = (float) apply_filters( 'antispam_bee_no_spam_threshold', 0.0 );
-		$spam_threshold    = (float) apply_filters( 'antispam_bee_spam_threshold', 0.0 );
+
+		/**
+		 * Filters the score threshold above which a reaction is considered spam.
+		 *
+		 * A reaction whose accumulated rule score is higher than or equal to this
+		 * threshold is treated as spam.
+		 *
+		 * @param float $spam_threshold The spam score threshold. Default 0.0.
+		 *
+		 * @return float The spam score threshold.
+		 * @since 3.0.0
+		 */
+		$spam_threshold = (float) apply_filters( 'antispam_bee_spam_threshold', 0.0 );
 
 		$score = 0.0;
 

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -37,10 +37,9 @@ class ContentTypeHelper {
 		 * general, comment and linkback types) together with the label shown in the
 		 * backend. The array key is the reaction type slug, the value its label.
 		 *
-		 * @param array $type_names A map of reaction type slugs to readable names.
-		 *
-		 * @return array The map of reaction type slugs to readable names.
 		 * @since 3.0.0
+		 *
+		 * @param array $type_names A map of reaction type slugs to readable names.
 		 */
 		$type_names = array_merge( apply_filters( 'antispam_bee_reaction_types', [] ), $type_names );
 
@@ -65,13 +64,12 @@ class ContentTypeHelper {
 		/**
 		 * Filters if a reaction is from a provided list of reaction types.
 		 *
+		 * @since 3.0.0
+		 *
 		 * @param bool   $is_one_of      Whether the reaction is one of the provided types.
 		 * @param array  $reaction       Reaction data array, reaction type needs to be provided as `comment_type`.
 		 * @param array  $reaction_types An array of reaction types to check for.
 		 * @param string $context        Optional context.
-		 *
-		 * @return bool Whether the reaction is one of the provided types.
-		 * @since 3.0.0
 		 */
 		return (bool) apply_filters( 'antispam_bee_reaction_is_one_of', $is_one_of, $reaction, $reaction_types, $context );
 	}

--- a/src/Helpers/ContentTypeHelper.php
+++ b/src/Helpers/ContentTypeHelper.php
@@ -30,6 +30,18 @@ class ContentTypeHelper {
 			self::LINKBACK_TYPE => __( 'Linkback', 'antispam-bee' ),
 		];
 
+		/**
+		 * Filters the additional reaction types and their human-readable names.
+		 *
+		 * Use this filter to register custom reaction types (beyond the built-in
+		 * general, comment and linkback types) together with the label shown in the
+		 * backend. The array key is the reaction type slug, the value its label.
+		 *
+		 * @param array $type_names A map of reaction type slugs to readable names.
+		 *
+		 * @return array The map of reaction type slugs to readable names.
+		 * @since 3.0.0
+		 */
 		$type_names = array_merge( apply_filters( 'antispam_bee_reaction_types', [] ), $type_names );
 
 		return $type_names[ $reaction_type ] ?? $reaction_type;
@@ -59,6 +71,7 @@ class ContentTypeHelper {
 		 * @param string $context        Optional context.
 		 *
 		 * @return bool Whether the reaction is one of the provided types.
+		 * @since 3.0.0
 		 */
 		return (bool) apply_filters( 'antispam_bee_reaction_is_one_of', $is_one_of, $reaction, $reaction_types, $context );
 	}

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -64,6 +64,7 @@ class Honeypot {
 		 * @param string $honeypot_styles The inline styles for the honeypot.
 		 *
 		 * @return string The inline styles for the honeypot.
+		 * @since 3.0.0
 		 */
 		$honeypot_styles = apply_filters( 'antispam_bee_honeypot_styles', 'padding:0 !important;clip:rect(1px, 1px, 1px, 1px) !important;position:absolute !important;white-space:nowrap !important;height:1px !important;width:1px !important;overflow:hidden !important;' );
 

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -61,10 +61,9 @@ class Honeypot {
 		 *
 		 * @see: https://wordpress.org/support/topic/honeypot-textarea-visible-with-strict-csp-header/
 		 *
-		 * @param string $honeypot_styles The inline styles for the honeypot.
-		 *
-		 * @return string The inline styles for the honeypot.
 		 * @since 3.0.0
+		 *
+		 * @param string $honeypot_styles The inline styles for the honeypot.
 		 */
 		$honeypot_styles = apply_filters( 'antispam_bee_honeypot_styles', 'padding:0 !important;clip:rect(1px, 1px, 1px, 1px) !important;position:absolute !important;white-space:nowrap !important;height:1px !important;width:1px !important;overflow:hidden !important;' );
 

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -15,23 +15,30 @@ class IpHelper {
 	/**
 	 * Return real client IP.
 	 *
-	 * By default, only `REMOTE_ADDR` is evaluated. Use the `pre_comment_user_ip`
-	 * filter to supply an IP from a trusted proxy header instead.
-	 *
-	 * @hook    string  pre_comment_user_ip  The client IP, defaults to REMOTE_ADDR.
-	 *
 	 * @return string Client IP.
 	 */
 	public static function get_client_ip(): string {
+		/**
+		 * Filters the IP address of the current client.
+		 *
+		 * This reuses WordPress core’s `pre_comment_user_ip` filter. By default the
+		 * value is taken from `REMOTE_ADDR`; use this filter to supply an IP from a
+		 * trusted proxy header instead.
+		 *
+		 * @param string $client_ip The client IP address. Defaults to REMOTE_ADDR.
+		 *
+		 * @return string The client IP address.
+		 * @since 2.6.7 - commit hash: d7b500c
+		 */
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-		return self::sanitize_ip(
-			(string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) )
-		);
+		$client_ip = (string) apply_filters( 'pre_comment_user_ip', wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
 		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+
+		return self::sanitize_ip( $client_ip );
 	}
 
 	/**

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -25,7 +25,7 @@ class IpHelper {
 		 * value is taken from `REMOTE_ADDR`; use this filter to supply an IP from a
 		 * trusted proxy header instead.
 		 *
-		 * @since 2.6.7 - commit hash: d7b500c
+		 * @since 2.6.1
 		 *
 		 * @param string $client_ip The client IP address. Defaults to REMOTE_ADDR.
 		 */

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -25,10 +25,9 @@ class IpHelper {
 		 * value is taken from `REMOTE_ADDR`; use this filter to supply an IP from a
 		 * trusted proxy header instead.
 		 *
-		 * @param string $client_ip The client IP address. Defaults to REMOTE_ADDR.
-		 *
-		 * @return string The client IP address.
 		 * @since 2.6.7 - commit hash: d7b500c
+		 *
+		 * @param string $client_ip The client IP address. Defaults to REMOTE_ADDR.
 		 */
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/src/Helpers/SpamReasonTextHelper.php
+++ b/src/Helpers/SpamReasonTextHelper.php
@@ -49,10 +49,9 @@ class SpamReasonTextHelper {
 		 * is displayed in the backend. The array key is the reason slug, the value
 		 * the label users see in the backend.
 		 *
-		 * @param array $additional_reasons A map of reason slugs to backend labels.
-		 *
-		 * @return array The map of reason slugs to backend labels.
 		 * @since 3.0.0
+		 *
+		 * @param array $additional_reasons A map of reason slugs to backend labels.
 		 */
 		$additional_reasons    = (array) apply_filters( 'antispam_bee_additional_spam_reasons', [] );
 		self::$slug_text_array = array_merge( $additional_reasons, self::$slug_text_array );

--- a/src/Helpers/SpamReasonTextHelper.php
+++ b/src/Helpers/SpamReasonTextHelper.php
@@ -43,9 +43,16 @@ class SpamReasonTextHelper {
 		}
 
 		/**
-		 * Allow adding more reasons.
+		 * Filters the additional spam reasons.
 		 *
-		 * @param array $additional_reasons An array of additional reasons. Key is the reason slug, value the label users see in the backend.
+		 * Use this filter to register spam reasons for custom rules so their label
+		 * is displayed in the backend. The array key is the reason slug, the value
+		 * the label users see in the backend.
+		 *
+		 * @param array $additional_reasons A map of reason slugs to backend labels.
+		 *
+		 * @return array The map of reason slugs to backend labels.
+		 * @since 3.0.0
 		 */
 		$additional_reasons    = (array) apply_filters( 'antispam_bee_additional_spam_reasons', [] );
 		self::$slug_text_array = array_merge( $additional_reasons, self::$slug_text_array );

--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -80,6 +80,7 @@ abstract class Base implements PostProcessor {
 		 * @param string $slug            The post-processor’s slug.
 		 *
 		 * @return array An array of supported types.
+		 * @since 3.0.0
 		 */
 		return (array) apply_filters( 'antispam_bee_post_processor_supported_types', static::$supported_types, static::$slug );
 	}

--- a/src/PostProcessors/Base.php
+++ b/src/PostProcessors/Base.php
@@ -76,11 +76,10 @@ abstract class Base implements PostProcessor {
 		/**
 		 * Filter the reaction types that are supported by the post-processor.
 		 *
+		 * @since 3.0.0
+		 *
 		 * @param array  $supported_types The supported types.
 		 * @param string $slug            The post-processor’s slug.
-		 *
-		 * @return array An array of supported types.
-		 * @since 3.0.0
 		 */
 		return (array) apply_filters( 'antispam_bee_post_processor_supported_types', static::$supported_types, static::$slug );
 	}

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -57,18 +57,28 @@ class SendEmail extends ControllableBase {
 
 				wp_mail(
 				/**
-				 * Filters the recipients of the spam notification.
+				 * Filters the recipients of the spam notification email.
 				 *
-				 * @param array $recipients The recipients array.
+				 * By default the notification is sent to the site’s admin email
+				 * address. Use this filter to send it to additional or different
+				 * recipients.
+				 *
+				 * @param array $recipients The list of recipient email addresses.
+				 *
+				 * @return array The list of recipient email addresses.
+				 * @since 2.8.0 - commit hash: f4718d6
 				 */
 					apply_filters(
 						'antispam_bee_notification_recipients',
 						[ get_bloginfo( 'admin_email' ) ]
 					),
 					/**
-					 * Filters the subject of the spam notification.
+					 * Filters the subject of the spam notification email.
 					 *
-					 * @param string $subject Subject line.
+					 * @param string $subject The email subject line.
+					 *
+					 * @return string The email subject line.
+					 * @since 2.6.7 - commit hash: d7b500c
 					 */
 					apply_filters(
 						'antispam_bee_notification_subject',

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -63,7 +63,7 @@ class SendEmail extends ControllableBase {
 				 * address. Use this filter to send it to additional or different
 				 * recipients.
 				 *
-				 * @since 2.8.0 - commit hash: f4718d6
+				 * @since 2.8.0
 				 *
 				 * @param array $recipients The list of recipient email addresses.
 				 */
@@ -74,7 +74,7 @@ class SendEmail extends ControllableBase {
 					/**
 					 * Filters the subject of the spam notification email.
 					 *
-					 * @since 2.6.7 - commit hash: d7b500c
+					 * @since 2.5.7
 					 *
 					 * @param string $subject The email subject line.
 					 */

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -63,10 +63,9 @@ class SendEmail extends ControllableBase {
 				 * address. Use this filter to send it to additional or different
 				 * recipients.
 				 *
-				 * @param array $recipients The list of recipient email addresses.
-				 *
-				 * @return array The list of recipient email addresses.
 				 * @since 2.8.0 - commit hash: f4718d6
+				 *
+				 * @param array $recipients The list of recipient email addresses.
 				 */
 					apply_filters(
 						'antispam_bee_notification_recipients',
@@ -75,10 +74,9 @@ class SendEmail extends ControllableBase {
 					/**
 					 * Filters the subject of the spam notification email.
 					 *
-					 * @param string $subject The email subject line.
-					 *
-					 * @return string The email subject line.
 					 * @since 2.6.7 - commit hash: d7b500c
+					 *
+					 * @param string $subject The email subject line.
 					 */
 					apply_filters(
 						'antispam_bee_notification_subject',

--- a/src/Rules/Base.php
+++ b/src/Rules/Base.php
@@ -83,11 +83,10 @@ abstract class Base implements Verifiable {
 		/**
 		 * Filter the reaction types that are supported by the rule.
 		 *
+		 * @since 3.0.0
+		 *
 		 * @param array  $supported_types The supported types.
 		 * @param string $slug            The rule’s slug.
-		 *
-		 * @return array An array of supported types.
-		 * @since 3.0.0
 		 */
 		return apply_filters( 'antispam_bee_rule_supported_types', static::$supported_types, static::$slug );
 	}

--- a/src/Rules/Base.php
+++ b/src/Rules/Base.php
@@ -87,6 +87,7 @@ abstract class Base implements Verifiable {
 		 * @param string $slug            The rule’s slug.
 		 *
 		 * @return array An array of supported types.
+		 * @since 3.0.0
 		 */
 		return apply_filters( 'antispam_bee_rule_supported_types', static::$supported_types, static::$slug );
 	}

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -64,13 +64,12 @@ class CountrySpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filter to hook into the `Country_Spam::verify` functionality to implement, for example, a custom IP check.
 		 *
+		 * @since 2.10.0
+		 *
 		 * @param null   $is_country_spam The `is_country_spam` result.
 		 * @param string $ip              The IP address.
 		 * @param array  $allowed         The list of allowed country codes.
 		 * @param array  $denied          The list of denied country codes.
-		 *
-		 * @return null|boolean The `is_country_spam` result or null.
-		 * @since 2.10.0
 		 */
 		$is_country_spam = apply_filters( 'antispam_bee_is_country_spam', null, $ip, $allowed, $denied );
 
@@ -81,10 +80,9 @@ class CountrySpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
 		 *
-		 * @param string $apikey The current IPLocate API key. Default is empty string.
-		 *
-		 * @return string The changed IPLocate API key.
 		 * @since 2.10.0
+		 *
+		 * @param string $apikey The current IPLocate API key. Default is empty string.
 		 */
 		$apikey = apply_filters( 'antispam_bee_country_spam_apikey', '' );
 

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -35,6 +35,19 @@ class EmptyData extends Base implements SpamReason {
 	 * @return int Numeric result.
 	 */
 	public static function verify( array $item ): int {
+		/**
+		 * Filters whether a reaction with empty content is allowed.
+		 *
+		 * This reuses WordPress core’s `allow_empty_comment` filter. When it returns
+		 * a truthy value, the empty-data rule does not flag the reaction as spam for
+		 * having no content.
+		 *
+		 * @param bool  $allow_empty_comment Whether to allow an empty reaction. Default false.
+		 * @param array $item                The reaction data being verified.
+		 *
+		 * @return bool Whether to allow an empty reaction.
+		 * @since 2.11.0 - commit hash: 1aaf8b1
+		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$allow_empty_reaction = apply_filters( 'allow_empty_comment', false, $item );
 		$content              = $item['body'] ?? '';

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -42,7 +42,7 @@ class EmptyData extends Base implements SpamReason {
 		 * a truthy value, the empty-data rule does not flag the reaction as spam for
 		 * having no content.
 		 *
-		 * @since 2.11.0 - commit hash: 1aaf8b1
+		 * @since 2.11.0
 		 *
 		 * @param bool  $allow_empty_comment Whether to allow an empty reaction. Default false.
 		 * @param array $item                The reaction data being verified.

--- a/src/Rules/EmptyData.php
+++ b/src/Rules/EmptyData.php
@@ -42,11 +42,10 @@ class EmptyData extends Base implements SpamReason {
 		 * a truthy value, the empty-data rule does not flag the reaction as spam for
 		 * having no content.
 		 *
+		 * @since 2.11.0 - commit hash: 1aaf8b1
+		 *
 		 * @param bool  $allow_empty_comment Whether to allow an empty reaction. Default false.
 		 * @param array $item                The reaction data being verified.
-		 *
-		 * @return bool Whether to allow an empty reaction.
-		 * @since 2.11.0 - commit hash: 1aaf8b1
 		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$allow_empty_reaction = apply_filters( 'allow_empty_comment', false, $item );

--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -51,11 +51,10 @@ class LangSpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filters the detected language. With this filter, other detection methods can skip in and detect the language.
 		 *
+		 * @since 2.8.2
+		 *
 		 * @param null   $detected_language The detected language.
 		 * @param string $comment_text      The text, to detect the language.
-		 *
-		 * @return null|string The detected language or null.
-		 * @since 2.8.2
 		 */
 		$detected_language = apply_filters( 'antispam_bee_detected_lang', null, $comment_text );
 		if ( null !== $detected_language ) {
@@ -99,10 +98,9 @@ class LangSpam extends ControllableBase implements SpamReason {
 		 * To use a local service for testing, hook antispam_bee_detected_lang
 		 * instead and make the HTTP call with wp_remote_post() directly.
 		 *
-		 * @param string $api_url The language API URL.
-		 *
-		 * @return string The language API URL.
 		 * @since 3.0.0
+		 *
+		 * @param string $api_url The language API URL.
 		 */
 		$api_url = apply_filters( 'antispam_bee_lang_api_url', 'https://api.pluginkollektiv.org/language/v1/' );
 
@@ -188,10 +186,9 @@ class LangSpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filter the possible languages for the language spam test.
 		 *
-		 * @param (array) $languages The languages.
-		 *
-		 * @return array The list of allowed languages.
 		 * @since 2.7.1
+		 *
+		 * @param (array) $languages The languages.
 		 */
 		$languages = (array) apply_filters( 'antispam_bee_get_allowed_translate_languages', $languages );
 

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -136,7 +136,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		 * `author`, `body` or `host`) to a regular expression. A reaction is flagged
 		 * as spam when all fields of a single pattern match.
 		 *
-		 * @since 2.6.7 - commit hash: d7b500c
+		 * @since 2.5.2
 		 *
 		 * @param array $patterns A list of field-to-regular-expression pattern maps.
 		 */

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -129,6 +129,18 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 			];
 		}
 
+		/**
+		 * Filters the regular expression patterns used to detect spam.
+		 *
+		 * Each pattern is an array that maps a reaction field (for example `email`,
+		 * `author`, `body` or `host`) to a regular expression. A reaction is flagged
+		 * as spam when all fields of a single pattern match.
+		 *
+		 * @param array $patterns A list of field-to-regular-expression pattern maps.
+		 *
+		 * @return array The list of field-to-regular-expression pattern maps.
+		 * @since 2.6.7 - commit hash: d7b500c
+		 */
 		$patterns = apply_filters(
 			'antispam_bee_patterns',
 			$patterns

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -136,10 +136,9 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		 * `author`, `body` or `host`) to a regular expression. A reaction is flagged
 		 * as spam when all fields of a single pattern match.
 		 *
-		 * @param array $patterns A list of field-to-regular-expression pattern maps.
-		 *
-		 * @return array The list of field-to-regular-expression pattern maps.
 		 * @since 2.6.7 - commit hash: d7b500c
+		 *
+		 * @param array $patterns A list of field-to-regular-expression pattern maps.
 		 */
 		$patterns = apply_filters(
 			'antispam_bee_patterns',

--- a/src/Rules/TooFastSubmit.php
+++ b/src/Rules/TooFastSubmit.php
@@ -97,10 +97,9 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 		 * A reaction that is submitted faster than this limit after the form was
 		 * rendered is considered spam, as it is likely sent by an automated bot.
 		 *
-		 * @param int $action_time_limit The minimum number of seconds. Default 5.
-		 *
-		 * @return int The minimum number of seconds.
 		 * @since 3.0.0
+		 *
+		 * @param int $action_time_limit The minimum number of seconds. Default 5.
 		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$action_time_limit = apply_filters( 'antispam_bee_action_time_limit', 5 );

--- a/src/Rules/TooFastSubmit.php
+++ b/src/Rules/TooFastSubmit.php
@@ -91,8 +91,21 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 			return 0;
 		}
 
+		/**
+		 * Filters the minimum time (in seconds) a form has to stay open before submission.
+		 *
+		 * A reaction that is submitted faster than this limit after the form was
+		 * rendered is considered spam, as it is likely sent by an automated bot.
+		 *
+		 * @param int $action_time_limit The minimum number of seconds. Default 5.
+		 *
+		 * @return int The minimum number of seconds.
+		 * @since 3.0.0
+		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-		if ( time() - $init_time < apply_filters( 'antispam_bee_action_time_limit', 5 ) ) {
+		$action_time_limit = apply_filters( 'antispam_bee_action_time_limit', 5 );
+
+		if ( time() - $init_time < $action_time_limit ) {
 			return 1;
 		}
 

--- a/src/load.php
+++ b/src/load.php
@@ -91,10 +91,9 @@ function init(): void {
 	 * By default the spam checks are not run on AJAX calls. Return false to also
 	 * run the checks during AJAX requests.
 	 *
-	 * @param bool $disallow_ajax Whether to skip the checks on AJAX calls. Default true.
-	 *
-	 * @return bool Whether to skip the checks on AJAX calls.
 	 * @since 2.9.4 - commit hash: dc60450
+	 *
+	 * @param bool $disallow_ajax Whether to skip the checks on AJAX calls. Default true.
 	 */
 	$disallow_ajax = apply_filters( 'antispam_bee_disallow_ajax_calls', true );
 

--- a/src/load.php
+++ b/src/load.php
@@ -88,10 +88,10 @@ function init(): void {
 	/**
 	 * Filters whether Antispam Bee should skip its checks during AJAX requests.
 	 *
-	 * By default the spam checks are not run on AJAX calls. Return false to also
+	 * By default, the spam checks are not run on AJAX calls. Return false to also
 	 * run the checks during AJAX requests.
 	 *
-	 * @since 2.9.4 - commit hash: dc60450
+	 * @since 2.9.4
 	 *
 	 * @param bool $disallow_ajax Whether to skip the checks on AJAX calls. Default true.
 	 */

--- a/src/load.php
+++ b/src/load.php
@@ -85,6 +85,17 @@ function init(): void {
 		ValidGravatar::class,
 	];
 
+	/**
+	 * Filters whether Antispam Bee should skip its checks during AJAX requests.
+	 *
+	 * By default the spam checks are not run on AJAX calls. Return false to also
+	 * run the checks during AJAX requests.
+	 *
+	 * @param bool $disallow_ajax Whether to skip the checks on AJAX calls. Default true.
+	 *
+	 * @return bool Whether to skip the checks on AJAX calls.
+	 * @since 2.9.4 - commit hash: dc60450
+	 */
 	$disallow_ajax = apply_filters( 'antispam_bee_disallow_ajax_calls', true );
 
 	$is_ajax_call = wp_doing_ajax();


### PR DESCRIPTION
## Summary

Aligns every hook (`apply_filters()`) DocBlock with the [WordPress PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/), and records the convention in `AGENTS.md` so future contributions follow it.

Stacked on top of `chore/code-cleanup` (base branch), so the diff shows only the three docs commits added here.

## What changed

- **Remove `@return` from all hook DocBlocks.** Per the standard, `@return` is not used for hooks — action hooks return nothing and filter hooks always return their first parameter.
- **Reorder tags** to `summary → description → @since → @param` (previously `@since` came after `@param`/`@return`).
- Applied to both the newly documented filters and the pre-existing DocBlocks in `CountrySpam` and `LangSpam`, so the whole set is consistent.
- **`AGENTS.md`** gains an *Inline documentation* section describing placement, tag order, the no-`@return` rule, and the three-digit `@since` convention, with a link to the standard.

## Notes

- `@since` uses the three-digit version in which each hook was introduced; hooks new to `v3` use `@since 3.0.0`.
- WordPress core hooks reused by the plugin (`pre_comment_user_ip`, `allow_empty_comment`) are documented the same way, with `@since` reflecting when the plugin started applying them.
- Docs-only change; no runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)