### PR TITLE
chore: integrate `wp-since` check, update workflows and ignore files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,9 @@
 /bin
 /docs
 /tests
+/vendor
+!/vendor/autoload.php
+!/vendor/composer/
 
 # Files
 /.distignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,9 @@
 /bin export-ignore
 /docs export-ignore
 /tests export-ignore
+/vendor/* export-ignore
+/vendor/composer/ export-negate
+/vendor/autoload.php export-negate
 
 # Files
 /.distignore export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,20 @@ jobs:
         ./vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
         composer cs
 
+  wp-since:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer
+    - name: Check for unavailable WordPress functions
+      run: |
+        composer install --ignore-platform-req=php
+        ./vendor/bin/wp-since check .
+
   spelling:
     name: Typos
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 		"wp-coding-standards/wpcs": "^3.2.0",
 		"yoast/wp-test-utils": "^1.2",
 		"phpstan/phpstan": "^2.2",
-		"szepeviktor/phpstan-wordpress": "^2.0"
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"eduardovillao/wp-since": "^1.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv, websupporter, schlessera, zodiac1978, swissspidy, krafit, kau-boy, florianbrinkmann, pfefferle
 * Tags:              anti-spam, antispam, comments, spam filter, spam protection
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 4.6
+* Requires at least: 4.7
 * Tested up to:      7.0
 * Requires PHP:      7.4
 * Stable tag:        3.0.0-beta.1


### PR DESCRIPTION
Maybe we should split up the `tests.yml` file into multiple actions now? Or rename it to `ci.yml` or something similar?