### PR TITLE
fix: let `RegexpSpam` `rawurl` patterns match by allow-listing the field

### DIFF
--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -49,6 +49,7 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		$fields = [
 			'ip',
 			'host',
+			'rawurl',
 			'body',
 			'email',
 			'author',

--- a/tests/Unit/Rules/RegexpSpamTest.php
+++ b/tests/Unit/Rules/RegexpSpamTest.php
@@ -73,6 +73,41 @@ class RegexpSpamTest extends AbstractRuleTestCase {
 	}
 
 	/**
+	 * The `porn`/`pornstar`/`20bet` author terms must be detected.
+	 */
+	public function test_verify_author_terms() {
+		$porn           = self::make_comment();
+		$porn['author'] = 'freehdporn';
+		self::assertSame( 1, RegexpSpam::verify( $porn ), 'A porn author term should be flagged' );
+
+		$bet           = self::make_comment();
+		$bet['author'] = '20bet';
+		self::assertSame( 1, RegexpSpam::verify( $bet ), 'The 20bet author term should be flagged' );
+	}
+
+	/**
+	 * A Binance referral registration URL must be detected via the `rawurl`
+	 * pattern.
+	 *
+	 * Regression test: the rule declares a `rawurl` subject and pattern, but the
+	 * field was missing from the `$fields` allow-list, so the pattern never fired.
+	 */
+	public function test_verify_binance_rawurl() {
+		$item        = self::make_comment();
+		$item['url'] = 'https://accounts.binance.com/en/register?ref=ABCDE123';
+		self::assertSame( 1, RegexpSpam::verify( $item ), 'A Binance referral URL should be flagged via rawurl' );
+	}
+
+	/**
+	 * A non-referral Binance URL must not match, guarding the pattern's specificity.
+	 */
+	public function test_verify_binance_non_referral() {
+		$item        = self::make_comment();
+		$item['url'] = 'https://www.binance.com/en/support';
+		self::assertSame( 0, RegexpSpam::verify( $item ), 'A non-referral Binance URL should not be flagged' );
+	}
+
+	/**
 	 * Set up the test environment.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

`RegexpSpam::verify()` builds a `rawurl` entry in its `$subject` and ships a `rawurl` pattern (the Binance referral-registration URL), but `rawurl` was missing from the `$fields` allow-list. The matching loop skips any field not in `$fields`, so the `rawurl` pattern never fired — a single-field pattern whose only field is skipped can never reach `count($hits) === count($pattern)`.

Add `rawurl` to `$fields` so the pattern matches as intended, and add `RegexpSpamTest` covering it.

## Test steps

1. `composer test:unit -- --filter RegexpSpam` — passes (benign, porn/`20bet` author, Binance `rawurl`, non-referral negative).
2. Removing `rawurl` from `$fields` again makes `test_verify_binance_rawurl` fail, confirming the guard.
3. Full suite: `composer test:unit` — 23 passing.
