### PR TITLE
Add author terms and Binance referral regex spam patterns

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -1619,6 +1619,7 @@ class Antispam_Bee {
 		$fields = array(
 			'ip',
 			'host',
+			'rawurl',
 			'body',
 			'email',
 			'author',
@@ -1640,7 +1641,7 @@ class Antispam_Bee {
 				'body' => '\<\!.+?mfunc.+?\>',
 			),
 			array(
-				'author' => 'moncler|north face|vuitton|handbag|burberry|outlet|prada|cialis|viagra|maillot|oakley|ralph lauren|ray ban|iphone|プラダ',
+				'author' => 'moncler|north face|vuitton|handbag|burberry|outlet|prada|cialis|viagra|maillot|oakley|ralph lauren|ray ban|iphone|プラダ|[^\w]?porn[o]?[s]?[^\w]?|[^\w]?pornstar[^\w]?|^20bet$',
 			),
 			array(
 				'host' => '^(www\.)?fkbook\.co\.uk$|^(www\.)?nsru\.net$|^(www\.)?goo\.gl$|^(www\.)?bit\.ly$',
@@ -1659,6 +1660,9 @@ class Antispam_Bee {
 				'body' => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
 				'email' => '@gmail\.com',
 				'author' => '^[A-Z][a-z]+\d{3,4}$',
+			),
+			array(
+				'rawurl' => '^http[s]?:\/\/(accounts\.)?binance\.com\/[a-zA-Z-]+\/register(-person)?\?ref=[\w]+',
 			),
 		);
 


### PR DESCRIPTION
## Summary

Extends `_is_regexp_spam()` with additional spam signatures, backporting patterns already present on `v3`:

- adds the `porn`/`pornstar`/`20bet` terms to the `author` pattern, and
- adds a Binance referral-registration URL pattern, matched against `rawurl`.

`rawurl` is added to the matched `$fields` so the URL pattern can fire (the caller already passes `rawurl` into the check).

## Test steps

1. Submit a comment whose author contains `porn`/`pornstar` or is `20bet` → flagged as spam (reason: regexp).
2. Submit a comment whose URL is a Binance referral link, e.g. `https://accounts.binance.com/en/register?ref=XXXXX` → flagged as spam (reason: regexp).
3. Regular comments are unaffected.
