### PR TITLE
ci: add spam-detection comparison workflow

### DIFF
--- a/.github/workflows/attach-snapshot.yml
+++ b/.github/workflows/attach-snapshot.yml
@@ -1,0 +1,104 @@
+# The second half of the baseline-snapshot chain that spam-detection-comparison.yml
+# starts.
+#
+# The comparison workflow already classifies the prepared version against the
+# full corpus and uploads the resulting verdict snapshot as a workflow artifact.
+# When that version is released, this workflow attaches that snapshot to the
+# release — where the *next* prepare run will find it and skip classifying the
+# baseline entirely.
+#
+# The snapshot contains no personal data: per comment only a salted pseudonym of
+# the corpus row id, the spam/ham status, and the matched rule slugs. See
+# "Baseline snapshots" in https://github.com/2ndkauboy/asb-detection-compare.
+#
+# If no matching artifact exists (e.g. the release was cut without a prepare
+# run), this fails loudly. Nothing breaks downstream — the next comparison
+# simply classifies its baseline as it always did — but the failure is the
+# signal that the chain was interrupted.
+
+name: Attach detection snapshot to release
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write        # needed to upload a release asset
+  actions: read          # needed to list runs and download their artifacts
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find the run that classified this commit
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tag_sha="$(git rev-list -n 1 "$TAG")"
+          echo "Release $TAG is commit $tag_sha"
+
+          # The newest successful comparison run for exactly this commit.
+          run_id="$(gh run list \
+            --workflow 'Spam-detection comparison' \
+            --status success --limit 100 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.headSha == \"$tag_sha\")] | .[0].databaseId // empty")"
+
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful spam-detection comparison run found for $tag_sha."
+            echo "The baseline-snapshot chain is broken for this release; the next" \
+                 "comparison will classify its baseline from scratch."
+            exit 1
+          fi
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "tag-sha=$tag_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Download the snapshot artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh run download "${{ steps.find.outputs.run-id }}" \
+            --name asb-detection-snapshot --dir snapshot
+
+      - name: Verify it describes this release
+        env:
+          TAG_SHA: ${{ steps.find.outputs.tag-sha }}
+        run: |
+          set -euo pipefail
+          file="$(find snapshot -name 'asb-snapshot-*.tsv.gz' -type f | head -1)"
+          [ -n "$file" ] || { echo "::error::No snapshot file in the artifact."; exit 1; }
+
+          # The manifest is the second line of the (gzipped) snapshot.
+          manifest="$(zcat "$file" | sed -n '2p' | cut -f2-)"
+          echo "$manifest" | jq .
+
+          commit="$(echo "$manifest" | jq -r '.commit_sha')"
+          publishable="$(echo "$manifest" | jq -r '.publishable')"
+
+          if [ "$commit" != "$TAG_SHA" ]; then
+            echo "::error::Snapshot describes $commit, but the release is $TAG_SHA."
+            exit 1
+          fi
+          if [ "$publishable" != "true" ]; then
+            echo "::error::Snapshot is not marked publishable (unsalted or not cluster-sharded)."
+            exit 1
+          fi
+          echo "SNAPSHOT_FILE=$file" >> "$GITHUB_ENV"
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "$SNAPSHOT_FILE" --clobber
+          echo "Attached $(basename "$SNAPSHOT_FILE") to ${{ github.event.release.tag_name }}."

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -123,3 +123,15 @@ jobs:
           path: ${{ steps.compare.outputs.snapshot-file }}
           retention-days: 90
           if-no-files-found: error
+
+      # When the baseline had to be classified, its verdicts describe a released
+      # tag and are just as publishable. Attach this one to that release and the
+      # next comparison against it needs only a single pass.
+      - name: Upload the baseline verdict snapshot
+        if: env.ASB_USE_FULL == 'true' && steps.compare.outputs.baseline-snapshot-file != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: asb-detection-baseline-snapshot
+          path: ${{ steps.compare.outputs.baseline-snapshot-file }}
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -19,6 +19,13 @@
 # back to the bundled fixture; only trusted events (prepare-* pushes, manual
 # runs) decrypt the dump. If the corpus is not configured, they fall back too.
 #
+# Classifying the full corpus takes hours, and half of every run would re-derive
+# how the *baseline release* classifies it — which never changes. So a run
+# publishes its verdicts as an artifact, attach-snapshot.yml attaches that to the
+# release, and the next prepare run reuses it and skips the baseline pass. The
+# snapshot holds no personal data: per comment only a salted pseudonym of the
+# corpus row id, the spam/ham status and the matched rule slugs.
+#
 # Configure (for the full-corpus tiers):
 #   • variable ASB_CORPUS_ENC_URL -> public URL of corpus.sql.gz.gpg
 #   • secret   ASB_CORPUS_KEY     -> the gpg passphrase
@@ -52,6 +59,11 @@ on:
 jobs:
   compare:
     runs-on: ubuntu-latest
+    # A full-corpus pass is long; the baseline half is skipped whenever the
+    # baseline release already carries a verdict snapshot (see below).
+    timeout-minutes: 330
+    permissions:
+      contents: read        # look up the baseline snapshot on the release
     env:
       # Full corpus for prepare-* pushes and manual runs that ask for it, when
       # the corpus is configured; otherwise the bundled fixture. PRs never use it.
@@ -85,6 +97,7 @@ jobs:
             -o corpus.sql.gz -d corpus.sql.gz.gpg
 
       - name: Compare spam detection
+        id: compare
         uses: 2ndkauboy/asb-detection-compare@v1
         with:
           # PR -> the PR's base branch. Manual -> the chosen baseline. Prepare
@@ -92,3 +105,21 @@ jobs:
           baseline-ref: ${{ (github.event_name == 'pull_request' && github.base_ref) || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref) || '' }}
           corpus-file: ${{ env.ASB_USE_FULL == 'true' && format('{0}/corpus.sql.gz', github.workspace) || '' }}
           fail-on-flips: ${{ (github.event_name == 'workflow_dispatch' && inputs.fail_on_flips == false) && 'false' || 'true' }}
+          workers: '4'
+          # Pinned so published verdict snapshots stay valid across WordPress
+          # releases; bumping it deliberately invalidates every snapshot.
+          wp-version: '6.8.2'
+
+      # Keep this run's verdict snapshot. When this version is released,
+      # attach-snapshot.yml attaches it to the release, and the next prepare run
+      # reuses it as its baseline instead of classifying the corpus twice.
+      # Only full-corpus runs are worth keeping — a fixture snapshot is cheap to
+      # recompute and would only shadow the real one.
+      - name: Upload the verdict snapshot
+        if: env.ASB_USE_FULL == 'true' && steps.compare.outputs.snapshot-file != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: asb-detection-snapshot
+          path: ${{ steps.compare.outputs.snapshot-file }}
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -8,16 +8,20 @@
 #   • Pull requests            -> fast smoke check against a small bundled
 #                                 fixture, compared to the PR's base branch.
 #   • prepare-* / release push -> thorough check against the FULL corpus dump
-#                                 downloaded from a secret, compared to the
+#                                 (decrypted in-workflow), compared to the
 #                                 semver-resolved baseline release.
 #
-# Security: pull_request runs (including from forks) never receive secrets, so
-# they always fall back to the bundled fixture. Only trusted pushes to prepare-*
-# branches use the private dump. If the secrets are unset, prepare pushes fall
-# back to the fixture too.
+# The full corpus is real (PII) comments, so it is never public in the clear:
+# an encrypted blob is fetched from a public URL and decrypted with a passphrase
+# secret. pull_request runs (including forks) never receive secrets and fall
+# back to the bundled fixture; only trusted pushes to prepare-* branches decrypt
+# the dump. If the corpus is not configured, prepare pushes fall back too.
 #
-# Secrets (optional, for the release tier): ASB_CORPUS_URL (URL of a .sql/.sql.gz
-# dump) and ASB_CORPUS_AUTH (e.g. "Bearer <token>" for a private asset).
+# Configure (for the release tier):
+#   • variable ASB_CORPUS_ENC_URL -> public URL of corpus.sql.gz.gpg
+#   • secret   ASB_CORPUS_KEY     -> the gpg passphrase
+# Encrypt with: gpg --batch --symmetric --cipher-algo AES256 \
+#   --passphrase "<pass>" -o corpus.sql.gz.gpg corpus.sql.gz
 
 name: Spam-detection comparison
 
@@ -50,13 +54,26 @@ jobs:
         with:
           fetch-depth: 0        # full history/tags for baseline resolution
 
+      # Release tier only: download the encrypted full corpus (public ciphertext,
+      # useless without the key) and decrypt it with the passphrase secret.
+      # Skipped when the corpus is not configured, so PRs use the bundled fixture.
+      - name: Fetch & decrypt the release corpus
+        if: github.event_name == 'push' && vars.ASB_CORPUS_ENC_URL != ''
+        env:
+          ASB_CORPUS_ENC_URL: ${{ vars.ASB_CORPUS_ENC_URL }}
+          ASB_CORPUS_KEY: ${{ secrets.ASB_CORPUS_KEY }}
+        run: |
+          curl -fSL --retry 3 -o corpus.sql.gz.gpg "$ASB_CORPUS_ENC_URL"
+          gpg --batch --quiet --yes --passphrase "$ASB_CORPUS_KEY" \
+            -o corpus.sql.gz -d corpus.sql.gz.gpg
+
       - name: Compare spam detection
         uses: 2ndkauboy/asb-detection-compare@v1
         with:
           # PR: compare against the PR's base branch. Prepare push: leave empty
           # so the baseline is resolved from the branch name (semver).
           baseline-ref: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
-          # PR: bundled fixture. Prepare push: full dump from the secret.
-          corpus-url: ${{ github.event_name == 'push' && secrets.ASB_CORPUS_URL || '' }}
-          corpus-auth: ${{ github.event_name == 'push' && secrets.ASB_CORPUS_AUTH || '' }}
+          # Release tier: the decrypted full corpus. PRs (or unconfigured): empty
+          # -> the action's bundled fixture.
+          corpus-file: ${{ (github.event_name == 'push' && vars.ASB_CORPUS_ENC_URL != '') && format('{0}/corpus.sql.gz', github.workspace) || '' }}
           fail-on-flips: 'true'

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -3,21 +3,23 @@
 #
 # It replays a corpus of comments through both builds and diffs the spam/ham
 # verdict (and reason) via the reusable action
-# https://github.com/2ndkauboy/asb-detection-compare. Two tiers:
+# https://github.com/2ndkauboy/asb-detection-compare. Three tiers:
 #
-#   • Pull requests            -> fast smoke check against a small bundled
-#                                 fixture, compared to the PR's base branch.
-#   • prepare-* / release push -> thorough check against the FULL corpus dump
-#                                 (decrypted in-workflow), compared to the
-#                                 semver-resolved baseline release.
+#   • Pull requests             -> fast smoke check against a small bundled
+#                                  fixture, compared to the PR's base branch.
+#   • prepare-* / release push  -> thorough check against the FULL corpus dump
+#                                  (decrypted in-workflow), compared to the
+#                                  semver-resolved baseline release.
+#   • Manual (workflow_dispatch)-> run on ANY branch on demand, choosing the
+#                                  baseline and whether to use the full corpus.
 #
 # The full corpus is real (PII) comments, so it is never public in the clear:
 # an encrypted blob is fetched from a public URL and decrypted with a passphrase
 # secret. pull_request runs (including forks) never receive secrets and fall
-# back to the bundled fixture; only trusted pushes to prepare-* branches decrypt
-# the dump. If the corpus is not configured, prepare pushes fall back too.
+# back to the bundled fixture; only trusted events (prepare-* pushes, manual
+# runs) decrypt the dump. If the corpus is not configured, they fall back too.
 #
-# Configure (for the release tier):
+# Configure (for the full-corpus tiers):
 #   • variable ASB_CORPUS_ENC_URL -> public URL of corpus.sql.gz.gpg
 #   • secret   ASB_CORPUS_KEY     -> the gpg passphrase
 # Encrypt with: gpg --batch --symmetric --cipher-algo AES256 \
@@ -32,10 +34,28 @@ on:
     branches:
       - 'prepare-*'
       - 'chore/prepare-*'
+  workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: 'Baseline tag or branch to compare the current branch against.'
+        required: true
+        default: 'v3'
+      full_corpus:
+        description: 'Use the full encrypted corpus (otherwise the small bundled fixture).'
+        type: boolean
+        default: true
+      fail_on_flips:
+        description: 'Fail the run if any spam/ham verdict flips.'
+        type: boolean
+        default: true
 
 jobs:
   compare:
     runs-on: ubuntu-latest
+    env:
+      # Full corpus for prepare-* pushes and manual runs that ask for it, when
+      # the corpus is configured; otherwise the bundled fixture. PRs never use it.
+      ASB_USE_FULL: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_corpus)) && vars.ASB_CORPUS_ENC_URL != '' }}
     services:
       mysql:
         image: mariadb:10.6
@@ -54,11 +74,8 @@ jobs:
         with:
           fetch-depth: 0        # full history/tags for baseline resolution
 
-      # Release tier only: download the encrypted full corpus (public ciphertext,
-      # useless without the key) and decrypt it with the passphrase secret.
-      # Skipped when the corpus is not configured, so PRs use the bundled fixture.
       - name: Fetch & decrypt the release corpus
-        if: github.event_name == 'push' && vars.ASB_CORPUS_ENC_URL != ''
+        if: env.ASB_USE_FULL == 'true'
         env:
           ASB_CORPUS_ENC_URL: ${{ vars.ASB_CORPUS_ENC_URL }}
           ASB_CORPUS_KEY: ${{ secrets.ASB_CORPUS_KEY }}
@@ -70,10 +87,8 @@ jobs:
       - name: Compare spam detection
         uses: 2ndkauboy/asb-detection-compare@v1
         with:
-          # PR: compare against the PR's base branch. Prepare push: leave empty
-          # so the baseline is resolved from the branch name (semver).
-          baseline-ref: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
-          # Release tier: the decrypted full corpus. PRs (or unconfigured): empty
-          # -> the action's bundled fixture.
-          corpus-file: ${{ (github.event_name == 'push' && vars.ASB_CORPUS_ENC_URL != '') && format('{0}/corpus.sql.gz', github.workspace) || '' }}
-          fail-on-flips: 'true'
+          # PR -> the PR's base branch. Manual -> the chosen baseline. Prepare
+          # push -> empty, so the baseline is resolved from the branch name.
+          baseline-ref: ${{ (github.event_name == 'pull_request' && github.base_ref) || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref) || '' }}
+          corpus-file: ${{ env.ASB_USE_FULL == 'true' && format('{0}/corpus.sql.gz', github.workspace) || '' }}
+          fail-on-flips: ${{ (github.event_name == 'workflow_dispatch' && inputs.fail_on_flips == false) && 'false' || 'true' }}

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -1,0 +1,62 @@
+# Compare Antispam Bee spam detection between the current code and a baseline
+# release, so decision regressions are caught before a release.
+#
+# It replays a corpus of comments through both builds and diffs the spam/ham
+# verdict (and reason) via the reusable action
+# https://github.com/2ndkauboy/asb-detection-compare. Two tiers:
+#
+#   • Pull requests            -> fast smoke check against a small bundled
+#                                 fixture, compared to the PR's base branch.
+#   • prepare-* / release push -> thorough check against the FULL corpus dump
+#                                 downloaded from a secret, compared to the
+#                                 semver-resolved baseline release.
+#
+# Security: pull_request runs (including from forks) never receive secrets, so
+# they always fall back to the bundled fixture. Only trusted pushes to prepare-*
+# branches use the private dump. If the secrets are unset, prepare pushes fall
+# back to the fixture too.
+#
+# Secrets (optional, for the release tier): ASB_CORPUS_URL (URL of a .sql/.sql.gz
+# dump) and ASB_CORPUS_AUTH (e.g. "Bearer <token>" for a private asset).
+
+name: Spam-detection comparison
+
+on:
+  pull_request:
+    branches: [ v3, master ]
+  push:
+    branches:
+      - 'prepare-*'
+      - 'chore/prepare-*'
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mariadb:10.6
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history/tags for baseline resolution
+
+      - name: Compare spam detection
+        uses: 2ndkauboy/asb-detection-compare@v1
+        with:
+          # PR: compare against the PR's base branch. Prepare push: leave empty
+          # so the baseline is resolved from the branch name (semver).
+          baseline-ref: ${{ github.event_name == 'pull_request' && github.base_ref || '' }}
+          # PR: bundled fixture. Prepare push: full dump from the secret.
+          corpus-url: ${{ github.event_name == 'push' && secrets.ASB_CORPUS_URL || '' }}
+          corpus-auth: ${{ github.event_name == 'push' && secrets.ASB_CORPUS_AUTH || '' }}
+          fail-on-flips: 'true'


### PR DESCRIPTION
Adds `.github/workflows/spam-detection-comparison.yml`, which replays a corpus of comments through the current code and a baseline release and diffs the spam/ham verdicts, catching detection regressions before a release.

It uses the reusable action [`2ndkauboy/asb-detection-compare`](https://github.com/2ndkauboy/asb-detection-compare) (bootstraps WordPress once via WP-CLI and drives the real comment pipeline in-process, so results match real submissions).

## Two tiers

- **Pull requests** (to `v3` / `master`) — a fast smoke check against a small bundled, PII-free fixture, compared to the PR's base branch.
- **`prepare-*` / `chore/prepare-*` pushes** — a thorough check against the **full corpus dump** downloaded from a secret, compared to the semver-resolved baseline release:
  - a prerelease (`prepare-3.0.0-beta.2`) compares to the latest earlier `3.0.0` beta/RC;
  - a stable version (`prepare-2.11.13`) compares to the latest earlier stable release.

## Security

`pull_request` runs (including from forks) never receive secrets, so they always fall back to the bundled fixture. Only trusted pushes to `prepare-*` branches use the private dump. If the secrets are unset, prepare pushes fall back to the fixture too.

## Setup

Optional secrets for the release tier (without them, everything uses the bundled fixture):

- `ASB_CORPUS_URL` — URL of a corpus dump (`.sql` or `.sql.gz`).
- `ASB_CORPUS_AUTH` — optional `Authorization` header value (e.g. `Bearer <token>`) for a private asset.

The check fails on spam/ham decision **flips**; reason-only differences stay informational (`fail-on-flips: true`).