### PR TITLE
fix: detect languages in scripts without word delimiters (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@
     * Complete code rewrite and backend UI overhaul
     * Allows extending Antispam Bee with your own rules
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
+    * Fix: The language rule now also checks comments written in a script that does not delimit
+      its words with spaces, for example Chinese, Japanese, Korean or Thai
+    * Fix: The language rule no longer marks a comment as spam if the language could not be
+      determined at all
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
     * Möglichkeit der Erweiterung von Antispam Bee um eigene Spam-Regeln
     * Erlaubt die Nutzung von Antispam Bee für andere Reaktionen als Kommentare, beispielsweise
       Formulare
+    * Fix: Die Sprach-Regel prüft nun auch Kommentare in einer Schrift, die ihre Wörter nicht
+      durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
+    * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache
+      überhaupt nicht bestimmt werden konnte
 
 ### 2.11.12 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,8 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Complete code rewrite and backend UI overhaul
     * Allows extending Antispam Bee with your own rules
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
+    * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
+    * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/src/Helpers/LangHelper.php
+++ b/src/Helpers/LangHelper.php
@@ -26,6 +26,16 @@ class LangHelper {
 		$codes = [
 			'zha' => 'za',
 			'zho' => 'zh',
+
+			/*
+			 * Members of the Chinese macrolanguage the service reports individually. They
+			 * have no ISO 639-1 code of their own, so they are all mapped to Chinese.
+			 */
+			'cmn' => 'zh',
+			'yue' => 'zh',
+			'wuu' => 'zh',
+			'nan' => 'zh',
+			'hak' => 'zh',
 			'zul' => 'zu',
 			'yid' => 'yi',
 			'yor' => 'yo',

--- a/src/Helpers/TextHelper.php
+++ b/src/Helpers/TextHelper.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Text helper.
+ *
+ * @package AntispamBee\Helpers
+ */
+
+namespace AntispamBee\Helpers;
+
+/**
+ * Helper to analyze texts and the scripts they are written in.
+ */
+class TextHelper {
+
+	/**
+	 * Letters, including combining marks.
+	 *
+	 * @var string
+	 */
+	private const LETTERS = '[\p{L}\p{M}]';
+
+	/**
+	 * Letters of scripts that do not use spaces to delimit words.
+	 *
+	 * The lookahead keeps the punctuation of those scripts out of the match. Some of it,
+	 * for example the ideographic full stop, belongs to the Han script as well, which
+	 * would make the result incomparable to the number of letters of the whole text.
+	 *
+	 * @var string
+	 */
+	private const SPACELESS_SCRIPT_LETTERS = '/(?=' . self::LETTERS . ')[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}\p{Thai}\p{Lao}\p{Khmer}\p{Myanmar}\p{Tibetan}]/u';
+
+	/**
+	 * Collapse all whitespace into single spaces and trim the text.
+	 *
+	 * @param string $text The text.
+	 *
+	 * @return string The normalized text.
+	 */
+	public static function normalize_whitespace( string $text ): string {
+		$normalized = preg_replace( '/\s+/u', ' ', $text );
+
+		if ( null === $normalized ) {
+			// The text is not valid UTF-8, so fall back to matching bytes.
+			$normalized = preg_replace( '/\s+/', ' ', $text );
+		}
+
+		return trim( (string) $normalized );
+	}
+
+	/**
+	 * Count the words of a text, delimited by whitespace.
+	 *
+	 * @param string $text The text.
+	 *
+	 * @return int The number of words.
+	 */
+	public static function count_words( string $text ): int {
+		$words = preg_split( '/ /', self::normalize_whitespace( $text ), -1, PREG_SPLIT_NO_EMPTY );
+
+		return is_array( $words ) ? count( $words ) : 0;
+	}
+
+	/**
+	 * Count the characters of a text.
+	 *
+	 * @param string $text The text.
+	 *
+	 * @return int The number of characters.
+	 */
+	public static function count_characters( string $text ): int {
+		return self::count_matches( '/./u', $text );
+	}
+
+	/**
+	 * Count the letters of scripts that do not use spaces to delimit words.
+	 *
+	 * Those are, for example, the Chinese, Japanese, Korean or Thai scripts. The result
+	 * can be compared to {@see TextHelper::count_letters()} to tell how much of a text
+	 * is written in such a script.
+	 *
+	 * @param string $text The text.
+	 *
+	 * @return int The number of letters written in such a script.
+	 */
+	public static function count_spaceless_script_letters( string $text ): int {
+		return self::count_matches( self::SPACELESS_SCRIPT_LETTERS, $text );
+	}
+
+	/**
+	 * Count the letters of a text, including combining marks.
+	 *
+	 * Digits, punctuation and symbols are not counted.
+	 *
+	 * @param string $text The text.
+	 *
+	 * @return int The number of letters.
+	 */
+	public static function count_letters( string $text ): int {
+		return self::count_matches( '/' . self::LETTERS . '/u', $text );
+	}
+
+	/**
+	 * Count the matches of a pattern in a text.
+	 *
+	 * A text that cannot be matched, because it is not valid UTF-8, has no matches.
+	 *
+	 * @param string $pattern The pattern to match.
+	 * @param string $text    The text.
+	 *
+	 * @return int The number of matches.
+	 */
+	private static function count_matches( string $pattern, string $text ): int {
+		$count = preg_match_all( $pattern, $text );
+
+		return is_int( $count ) ? $count : 0;
+	}
+}

--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -10,6 +10,7 @@ namespace AntispamBee\Rules;
 use AntispamBee\Helpers\LangHelper;
 use AntispamBee\Helpers\Sanitize;
 use AntispamBee\Helpers\Settings;
+use AntispamBee\Helpers\TextHelper;
 use AntispamBee\Interfaces\SpamReason;
 
 /**
@@ -61,32 +62,7 @@ class LangSpam extends ControllableBase implements SpamReason {
 			return (int) ! in_array( $detected_language, $allowed_languages, true );
 		}
 
-		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $comment_text ) ?? '', ' ' );
-
-		if ( function_exists( 'wp_get_word_count_type' ) ) {
-			$word_count_type = wp_get_word_count_type();
-		} else {
-			/*
-			 * translators: If your word count is based on single characters (e.g. East Asian characters),
-			 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-			 * Do not translate into your own language.
-			 */
-			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
-		}
-
-		if ( strpos( $word_count_type, 'characters' ) === 0 && preg_match(
-			'/^utf\-?8$/i',
-			get_option( 'blog_charset' )
-		) ) {
-			preg_match_all( '/./u', $text, $words_array );
-			$word_count = count( $words_array[0] );
-		} else {
-			$words_array = preg_split( "/[\n\r\t ]+/", $text, -1, PREG_SPLIT_NO_EMPTY ) ?: [];
-			$word_count  = count( $words_array );
-		}
-
-		if ( $word_count < 10 ) {
+		if ( ! self::has_enough_text_for_detection( $comment_text ) ) {
 			return 0;
 		}
 
@@ -120,11 +96,75 @@ class LangSpam extends ControllableBase implements SpamReason {
 		}
 
 		$detected_language = json_decode( $detected_language );
-		if ( ! $detected_language || ! isset( $detected_language->code ) ) {
+		if ( ! $detected_language || ! isset( $detected_language->code ) || ! is_string( $detected_language->code ) ) {
+			return 0;
+		}
+
+		/*
+		 * The service returns the ISO 639-3 code "und" (undetermined) if it could not
+		 * identify the language. A language we do not know is no reason to assume spam.
+		 */
+		if ( '' === $detected_language->code || 'und' === $detected_language->code ) {
 			return 0;
 		}
 
 		return (int) ! in_array( LangHelper::map( $detected_language->code ), $allowed_languages, true );
+	}
+
+	/**
+	 * Check whether a text contains enough content to detect its language.
+	 *
+	 * The detection service needs a certain amount of text, because it compares
+	 * character sequences and is unreliable for short texts.
+	 *
+	 * Languages that delimit their words with spaces are measured in words. Scripts
+	 * that do not use spaces to delimit words, for example the Chinese, Japanese,
+	 * Korean or Thai script, are measured in characters instead, because such a text
+	 * would otherwise be counted as a single, far too short word.
+	 *
+	 * @param string $text The text to check.
+	 *
+	 * @return bool Whether the text contains enough content.
+	 */
+	private static function has_enough_text_for_detection( string $text ): bool {
+		$text = TextHelper::normalize_whitespace( $text );
+		if ( '' === $text ) {
+			return false;
+		}
+
+		$spaceless_script_letters = TextHelper::count_spaceless_script_letters( $text );
+		if ( $spaceless_script_letters > 0 ) {
+			/**
+			 * Filters the minimum number of characters needed to detect the language of a
+			 * text written in a script that does not use spaces to delimit words.
+			 *
+			 * @since 3.0.0
+			 *
+			 * @param int $min_characters The minimum number of characters.
+			 */
+			$min_characters = (int) apply_filters( 'antispam_bee_lang_min_characters', 10 );
+
+			/*
+			 * Such a script has to account for at least half of all letters. Otherwise, the
+			 * service would detect the language of the dominant, space delimited part of the
+			 * text, for which those few characters are just noise.
+			 */
+			if ( TextHelper::count_characters( $text ) >= $min_characters
+				&& ( $spaceless_script_letters * 2 ) >= TextHelper::count_letters( $text ) ) {
+				return true;
+			}
+		}
+
+		/**
+		 * Filters the minimum number of words needed to detect the language of a text.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $min_words The minimum number of words.
+		 */
+		$min_words = (int) apply_filters( 'antispam_bee_lang_min_words', 10 );
+
+		return TextHelper::count_words( $text ) >= $min_words;
 	}
 
 	/**

--- a/tests/Unit/Helpers/TextHelperTest.php
+++ b/tests/Unit/Helpers/TextHelperTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\TextHelper;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Unit tests for {@see TextHelper}.
+ */
+class TextHelperTest extends TestCase {
+
+	/**
+	 * A text that is not valid UTF-8.
+	 *
+	 * @var string
+	 */
+	private const INVALID_UTF8 = "abc\xC3\x28 def";
+
+	public function test_normalize_whitespace_collapses_and_trims(): void {
+		self::assertSame(
+			'A small text',
+			TextHelper::normalize_whitespace( "  A \n\r\t small    text  " ),
+			'All whitespace should be collapsed into single spaces and the text should be trimmed'
+		);
+
+		self::assertSame(
+			'a b',
+			TextHelper::normalize_whitespace( "a\xC2\xA0b" ),
+			'A non-breaking space should be collapsed as well'
+		);
+
+		self::assertSame(
+			'',
+			TextHelper::normalize_whitespace( '   ' ),
+			'A text consisting only of whitespace should become an empty string'
+		);
+	}
+
+	public function test_normalize_whitespace_handles_invalid_utf8(): void {
+		self::assertSame(
+			"abc\xC3\x28 def",
+			TextHelper::normalize_whitespace( self::INVALID_UTF8 ),
+			'An invalid UTF-8 text should be normalized bytewise instead of raising an error'
+		);
+	}
+
+	public function test_count_words(): void {
+		self::assertSame(
+			9,
+			TextHelper::count_words( 'A small text passes the test. Lets check this.' ),
+			'Words should be counted by their whitespace delimiters'
+		);
+
+		self::assertSame(
+			2,
+			TextHelper::count_words( " Two \n words  " ),
+			'Surrounding and repeated whitespace should not be counted as words'
+		);
+
+		self::assertSame( 0, TextHelper::count_words( '' ), 'An empty text should have no words' );
+
+		self::assertSame(
+			1,
+			TextHelper::count_words( '这是一个中文垃圾评论' ),
+			'A text without word delimiters should be counted as a single word'
+		);
+	}
+
+	public function test_count_characters(): void {
+		self::assertSame(
+			10,
+			TextHelper::count_characters( '这是一个中文垃圾评论' ),
+			'Multibyte characters should be counted as single characters'
+		);
+
+		self::assertSame( 0, TextHelper::count_characters( '' ), 'An empty text should have no characters' );
+
+		self::assertSame(
+			0,
+			TextHelper::count_characters( self::INVALID_UTF8 ),
+			'An invalid UTF-8 text should have no countable characters'
+		);
+	}
+
+	public function test_count_spaceless_script_letters(): void {
+		self::assertSame(
+			10,
+			TextHelper::count_spaceless_script_letters( '这是一个中文垃圾评论' ),
+			'Han characters should be counted'
+		);
+
+		self::assertSame(
+			8,
+			TextHelper::count_spaceless_script_letters( 'これはスパムです' ),
+			'Hiragana and Katakana characters should be counted'
+		);
+
+		self::assertSame(
+			13,
+			TextHelper::count_spaceless_script_letters( '안녕하세요 이것은 스팸입니다' ),
+			'Hangul characters should be counted, spaces should not'
+		);
+
+		self::assertSame(
+			23,
+			TextHelper::count_spaceless_script_letters( 'สวัสดีครับ นี่คือข้อความ' ),
+			'Thai characters should be counted, spaces should not'
+		);
+
+		self::assertSame(
+			0,
+			TextHelper::count_spaceless_script_letters( 'Ein völlig normaler Kommentar.' ),
+			'A latin text should have no letters of a script without word delimiters'
+		);
+
+		self::assertSame(
+			4,
+			TextHelper::count_spaceless_script_letters( '中文，垃圾。' ),
+			'Ideographic punctuation should not be counted, even though it belongs to the Han script'
+		);
+
+		self::assertSame(
+			0,
+			TextHelper::count_spaceless_script_letters( '这是' . self::INVALID_UTF8 ),
+			'An invalid UTF-8 text should have no countable characters'
+		);
+	}
+
+	public function test_count_letters(): void {
+		self::assertSame(
+			26,
+			TextHelper::count_letters( 'Ein völlig normaler Kommentar.' ),
+			'Umlauts should be counted, spaces and punctuation should not'
+		);
+
+		self::assertSame(
+			4,
+			TextHelper::count_letters( '中文，垃圾。' ),
+			'Fullwidth punctuation should not be counted as letters'
+		);
+
+		self::assertSame(
+			0,
+			TextHelper::count_letters( '1234 !?' ),
+			'Digits, spaces and punctuation should not be counted as letters'
+		);
+	}
+}

--- a/tests/Unit/Helpers/TextHelperTest.php
+++ b/tests/Unit/Helpers/TextHelperTest.php
@@ -110,7 +110,7 @@ class TextHelperTest extends TestCase {
 
 		self::assertSame(
 			0,
-			TextHelper::count_spaceless_script_letters( 'Ein völlig normaler Kommentar.' ),
+			TextHelper::count_spaceless_script_letters( 'Ein völlig normaler Kommentar.' ), // spellchecker:disable-line
 			'A latin text should have no letters of a script without word delimiters'
 		);
 
@@ -130,7 +130,7 @@ class TextHelperTest extends TestCase {
 	public function test_count_letters(): void {
 		self::assertSame(
 			26,
-			TextHelper::count_letters( 'Ein völlig normaler Kommentar.' ),
+			TextHelper::count_letters( 'Ein völlig normaler Kommentar.' ), // spellchecker:disable-line
 			'Umlauts should be counted, spaces and punctuation should not'
 		);
 

--- a/tests/Unit/Rules/LangSpamTest.php
+++ b/tests/Unit/Rules/LangSpamTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Rules;
+
+use AntispamBee\Rules\LangSpam;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see LangSpam}.
+ */
+class LangSpamTest extends AbstractRuleTestCase {
+
+	/**
+	 * The spam comment from the bug report, written in Chinese.
+	 *
+	 * @var string
+	 */
+	private const CHINESE_SPAM = '致力于为开发者提供快速、便捷的企业级AI接口调用方案，打造稳定且易于使用的 API 接口平台，一站式集成几乎所有 AI 大模型。';
+
+	/**
+	 * The languages the rule allows, as stored by the checkbox group.
+	 *
+	 * @var array
+	 */
+	private $allowed_languages = [];
+
+	public function __construct() {
+		parent::__construct( LangSpam::class, 'asb-lang-spam' );
+	}
+
+	public function test_verify_does_not_call_the_service_without_content(): void {
+		$this->expect_no_request();
+
+		$item         = self::make_comment();
+		$item['body'] = '';
+
+		self::assertSame( 0, LangSpam::verify( $item ), 'A comment without content should not be flagged' );
+	}
+
+	public function test_verify_does_not_call_the_service_for_a_short_latin_text(): void {
+		$this->expect_no_request();
+
+		self::assertSame(
+			0,
+			LangSpam::verify( self::make_comment_with( 'A small text passes the test. Lets check this.' ) ),
+			'A latin text with less than ten words should not be sent to the service'
+		);
+	}
+
+	public function test_verify_flags_a_comment_in_a_script_without_word_delimiters(): void {
+		$this->expect_request( '{"code":"cmn"}' );
+
+		self::assertSame(
+			1,
+			LangSpam::verify( self::make_comment_with( self::CHINESE_SPAM ) ),
+			'A Chinese comment should be sent to the service and flagged, because only German is allowed'
+		);
+	}
+
+	public function test_verify_does_not_call_the_service_for_a_very_short_chinese_text(): void {
+		$this->expect_no_request();
+
+		self::assertSame(
+			0,
+			LangSpam::verify( self::make_comment_with( '中文垃圾' ) ),
+			'A text with less than ten characters should not be sent to the service'
+		);
+	}
+
+	public function test_verify_does_not_call_the_service_for_a_dominantly_latin_text(): void {
+		$this->expect_no_request();
+
+		self::assertSame(
+			0,
+			LangSpam::verify( self::make_comment_with( 'Great article thanks for sharing 中文垃圾评论' ) ),
+			'A few characters of another script should not make a latin text be sent to the service'
+		);
+	}
+
+	public function test_verify_does_not_flag_an_undetermined_language(): void {
+		$this->expect_request( '{"code":"und"}' );
+
+		self::assertSame(
+			0,
+			LangSpam::verify( self::make_comment_with( self::CHINESE_SPAM ) ),
+			'A language the service could not determine should not be flagged'
+		);
+	}
+
+	public function test_verify_maps_the_chinese_macrolanguage(): void {
+		$this->expect_request( '{"code":"cmn"}' );
+		$this->allowed_languages = [ 'zh' => 'on' ];
+
+		self::assertSame(
+			0,
+			LangSpam::verify( self::make_comment_with( self::CHINESE_SPAM ) ),
+			'A Chinese comment should not be flagged if Chinese is allowed'
+		);
+	}
+
+	public function test_verify_respects_the_minimum_words_filter(): void {
+		$this->expect_request( '{"code":"eng"}' );
+
+		expectApplied( 'antispam_bee_lang_min_words' )
+			->once()
+			->andReturn( 3 );
+
+		self::assertSame(
+			1,
+			LangSpam::verify( self::make_comment_with( 'Just four little words.' ) ),
+			'A lowered word threshold should let a shorter text be sent to the service'
+		);
+	}
+
+	public function test_verify_respects_the_minimum_characters_filter(): void {
+		$this->expect_request( '{"code":"cmn"}' );
+
+		expectApplied( 'antispam_bee_lang_min_characters' )
+			->once()
+			->andReturn( 4 );
+
+		self::assertSame(
+			1,
+			LangSpam::verify( self::make_comment_with( '中文垃圾' ) ),
+			'A lowered character threshold should let a shorter text be sent to the service'
+		);
+	}
+
+	public function test_verify_detected_lang_filter_skips_the_length_check(): void {
+		$this->expect_no_request();
+
+		expectApplied( 'antispam_bee_detected_lang' )
+			->once()
+			->andReturn( 'zh' );
+
+		self::assertSame(
+			1,
+			LangSpam::verify( self::make_comment_with( '中文' ) ),
+			'A language detected by the filter should be used, no matter how short the text is'
+		);
+	}
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'AntispamBee\MAIN_PLUGIN_FILE' ) ) {
+			define( 'AntispamBee\MAIN_PLUGIN_FILE', dirname( __DIR__, 3 ) . '/antispam_bee.php' );
+		}
+
+		when( 'wp_strip_all_tags' )->returnArg();
+		when( 'wp_json_encode' )->alias( 'json_encode' );
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+
+		// Keep the plugin update logic, which the settings run into, from touching the database.
+		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0' ] );
+
+		$this->allowed_languages = [ 'de' => 'on' ];
+
+		when( 'get_option' )->alias(
+			function ( string $option ) {
+				if ( 'antispambee_db_version' === $option ) {
+					return '3.0.0';
+				}
+
+				return [
+					'comment' => [
+						'rule_asb_lang_spam_allowed' => $this->allowed_languages,
+					],
+				];
+			}
+		);
+	}
+
+	/**
+	 * Generate a comment with the given content.
+	 *
+	 * @param string $content The comment content.
+	 *
+	 * @return array Comment array.
+	 */
+	private static function make_comment_with( string $content ): array {
+		return self::make_comment( 1, 'Test Author', 'test.author@example.com', 'www.example.com', '192.0.2.1', $content );
+	}
+
+	/**
+	 * Expect a single request to the detection service.
+	 *
+	 * @param string $body The response body to return.
+	 *
+	 * @return void
+	 */
+	private function expect_request( string $body ): void {
+		expect( 'wp_safe_remote_post' )->once()->andReturn( [ 'body' => $body ] );
+		when( 'wp_remote_retrieve_body' )->justReturn( $body );
+	}
+
+	/**
+	 * Expect that the detection service is not called at all.
+	 *
+	 * @return void
+	 */
+	private function expect_no_request(): void {
+		expect( 'wp_safe_remote_post' )->never();
+	}
+}

--- a/tests/Unit/Rules/LangSpamTest.php
+++ b/tests/Unit/Rules/LangSpamTest.php
@@ -79,6 +79,22 @@ class LangSpamTest extends AbstractRuleTestCase {
 		);
 	}
 
+	public function test_verify_measures_a_dominantly_latin_text_in_words(): void {
+		$this->expect_request( '{"code":"eng"}' );
+
+		// The handful of Chinese characters does not carry the text, so the character
+		// threshold does not apply and the word count decides - and this text has
+		// enough words. Guards the fall-through out of the spaceless-script branch:
+		// returning early there instead would stop such a text being checked at all.
+		self::assertSame(
+			1,
+			LangSpam::verify(
+				self::make_comment_with( 'Great article thanks for sharing this with all of us here 中文垃圾评论' )
+			),
+			'A long latin text with a few characters of another script should be sent to the service'
+		);
+	}
+
 	public function test_verify_does_not_flag_an_undetermined_language(): void {
 		$this->expect_request( '{"code":"und"}' );
 

--- a/tests/e2e/specs/filter.spec.ts
+++ b/tests/e2e/specs/filter.spec.ts
@@ -345,6 +345,90 @@ test.describe( 'Spam filter mechanisms', () => {
 		await expect( page.locator( 'body' ) ).not.toContainText( 'Language' );
 	} );
 
+	test( 'language rule blocks comment in a script without word delimiters', async ( {
+		                                                                                  page,
+		                                                                                  cli
+	                                                                                  } ) => {
+		const opts = cli.optionGet( 'antispam_bee_options' );
+		opts.comment.rule_asb_lang_spam_active = 'on';
+		opts.comment.rule_asb_lang_spam_allowed = { de: 'on' };
+		opts.comment.rule_asb_regexp_active = '';
+		opts.comment.rule_asb_db_spam_active = '';
+		opts.comment.rule_asb_honeypot_active = '';
+		opts.comment.rule_asb_bbcode_active = '';
+		opts.comment.rule_asb_approved_email_active = '';
+		cli.optionUpdate( 'antispam_bee_options', opts );
+
+		await fillComment( page, {
+			// Chinese uses hardly any spaces, so this is a single word but plenty of characters.
+			// Keep it free of URLs: the local API mock, unlike the real service, does not strip them.
+			comment:
+				'致力于为开发者提供快速、便捷的企业级AI接口调用方案，打造稳定且易于使用的 API 接口平台，一站式集成几乎所有 AI 大模型。',
+			author: 'Monty',
+			email: 'monty.1983@example.com',
+			url: 'https://example.com',
+		} );
+
+		await adminLogin( page );
+		await page.goto( '/wp-admin/edit-comments.php?comment_status=spam' );
+		await expect( page.locator( 'body' ) ).toContainText( 'Language' );
+	} );
+
+	test( 'language rule skips very short comments in a script without word delimiters', async ( {
+		                                                                                             page,
+		                                                                                             cli
+	                                                                                             } ) => {
+		const opts = cli.optionGet( 'antispam_bee_options' );
+		opts.comment.rule_asb_lang_spam_active = 'on';
+		opts.comment.rule_asb_lang_spam_allowed = { de: 'on' };
+		opts.comment.rule_asb_regexp_active = '';
+		opts.comment.rule_asb_db_spam_active = '';
+		opts.comment.rule_asb_honeypot_active = '';
+		opts.comment.rule_asb_bbcode_active = '';
+		opts.comment.rule_asb_approved_email_active = '';
+		cli.optionUpdate( 'antispam_bee_options', opts );
+
+		await fillComment( page, {
+			// Too few characters for a reliable detection, the service would answer "undetermined".
+			comment: '中文垃圾',
+			author: 'Monty',
+			email: 'monty.1983@example.com',
+			url: 'https://example.com',
+		} );
+
+		await adminLogin( page );
+		await page.goto( '/wp-admin/edit-comments.php?comment_status=spam' );
+		await expect( page.locator( 'body' ) ).not.toContainText( 'Language' );
+	} );
+
+	test( 'language rule skips a latin comment with a few foreign characters', async ( {
+		                                                                                  page,
+		                                                                                  cli
+	                                                                                  } ) => {
+		const opts = cli.optionGet( 'antispam_bee_options' );
+		opts.comment.rule_asb_lang_spam_active = 'on';
+		opts.comment.rule_asb_lang_spam_allowed = { de: 'on' };
+		opts.comment.rule_asb_regexp_active = '';
+		opts.comment.rule_asb_db_spam_active = '';
+		opts.comment.rule_asb_honeypot_active = '';
+		opts.comment.rule_asb_bbcode_active = '';
+		opts.comment.rule_asb_approved_email_active = '';
+		cli.optionUpdate( 'antispam_bee_options', opts );
+
+		await fillComment( page, {
+			// The few Chinese characters must not trigger the character based check: the text is
+			// too short for the word based one, and the service detects Danish for it.
+			comment: 'Great article thanks for sharing 中文垃圾评论',
+			author: 'Monty',
+			email: 'monty.1983@example.com',
+			url: 'https://example.com',
+		} );
+
+		await adminLogin( page );
+		await page.goto( '/wp-admin/edit-comments.php?comment_status=spam' );
+		await expect( page.locator( 'body' ) ).not.toContainText( 'Language' );
+	} );
+
 	test( 'language rule allows comment in the allowed language', async ( { page, cli } ) => {
 		const opts = cli.optionGet( 'antispam_bee_options' );
 		opts.comment.rule_asb_lang_spam_active = 'on';


### PR DESCRIPTION
Fixes #776.

## Problem

The language rule only sends a comment to the detection service if it contains enough text, because the service is unreliable for short texts. Whether that amount was measured in words or in characters was decided by `wp_get_word_count_type()` and `get_option( 'blog_charset' )` — so by the locale of the **site**, not by the script of the **comment**.

On a site that allows only German and English, the Chinese comment from the report (66 characters) therefore counted as a single word, never reached the service, and was never recognized as spam.

## Solution

The guard now looks at the comment itself. Letters of scripts that do not delimit their words with spaces (Han, Hiragana, Katakana, Hangul, Thai, Lao, Khmer, Myanmar, Tibetan) are counted as characters, everything else keeps being counted as words:

* **at least 10 code points** — this mirrors the minimum length of the service itself. `franc` returns `und` for anything shorter, before it even looks at the script (`value.length < minLength`, `minLength = 10`), so a lower threshold would only ever produce "undetermined".
* **at least half of all letters** have to belong to such a script — otherwise the service detects the language of the dominant, space delimited part of the text, for which those few characters are just noise.

`wp_get_word_count_type()`, the `_x( 'words', … )` fallback for WordPress < 6.2 and `get_option( 'blog_charset' )` are gone. The last one was also a real `preg_match(): Passing null` deprecation on PHP 8.1 when the option is missing.

Measured against both the production API and the exact `franc` version the E2E mock uses:

| Comment | Before | After |
| --- | --- | --- |
| The Chinese comment from #776 (64 characters) | not checked | sent, flagged |
| `中文垃圾` (4 characters) | not checked | not checked |
| `Great article thanks for sharing 中文垃圾评论` | not checked | not checked |
| `A small text passes the test. Lets check this.` (9 words) | not checked | not checked |

The third row is the reason for the dominance rule: the service answers `dan` (Danish) for that text and `bem` for a comparable mix, so sending it would flag English comments as spam on an English-only site.

## Two defects fixed along the way

Both of these are latent today, because the ten word threshold hides them — and both would have become live false-positive sources the moment the threshold got lowered:

* **`und` was treated as a language.** The service returns the ISO 639-3 code `und` if it could not determine the language, and really does so in production. `LangHelper::map()` passes unknown codes through, so `und` was compared to the allowed languages and **every comment the service could not identify was marked as spam**. It now returns the neutral result, like every other case in which the rule cannot decide.
* **`cmn` was not mapped to `zh`.** The service reports Mandarin as `cmn`, and only `zho` was mapped, so allowing Chinese via `antispam_bee_get_allowed_translate_languages` had no effect. The other members of the Chinese macrolanguage without an ISO 639-1 code of their own (`yue`, `wuu`, `nan`, `hak`) are now mapped as well.

## Structure

The mechanical counting lives in a new `AntispamBee\Helpers\TextHelper`, which makes no WordPress calls at all and is therefore testable without any stubs. The thresholds and the policy stay in the rule and can be adjusted with two new filters, `antispam_bee_lang_min_words` and `antispam_bee_lang_min_characters`.

One detail worth pointing out: PCRE counts the ideographic full stop `。` and the ideographic comma `、` as `\p{Han}`, while they are not letters. The pattern for scripts without word delimiters therefore carries a `(?=[\p{L}\p{M}])` lookahead, so its result stays comparable to the number of letters of the whole text and cannot be inflated with punctuation.

URLs are deliberately **not** stripped before the check, even though the production service strips them. The E2E mock does not, so the same input yields `cmn` in production and `fra` locally. Stripping client side would make the guard more permissive than the detector actually is, so comments mixing a script without word delimiters with URLs are skipped — the conservative direction for a spam filter. See #780.

## Tests

* `tests/Unit/Helpers/TextHelperTest.php` — normalization (including non-breaking spaces and invalid UTF-8) and all counters per script.
* `tests/Unit/Rules/LangSpamTest.php` — the rule had no unit test at all so far. Covers the case from #776, the short and the latin-dominant cases (asserting that **no** request is made), the `und` regression, the `cmn` mapping, both new filters, and that `antispam_bee_detected_lang` still short-circuits the whole check.
* `tests/e2e/specs/filter.spec.ts` — three cases added, mirroring the unit tests end to end. The existing "skips short comments" case is unaffected, its text contains no such characters.

`composer test:unit`, `composer lint-php` and `composer phpstan` are clean. The E2E suite was not run locally (`wp-env` would have contended for ports with another running project), only the spec collection was verified.

## Follow-ups

* #779 — recognizing very short comments such as `调用` locally, which is impossible through the service.
* #780 — the E2E mock does not preprocess the text like the real service.