### PR TITLE
feat(regexp): add stable identifier keys to default spam patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     * Complete code rewrite and backend UI overhaul
     * Allows extending Antispam Bee with your own rules
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
+    * The built-in patterns of the regular expression rule now have stable identifiers as array keys,
+      so single patterns can be removed or modified via the `antispam_bee_patterns` filter
     * Fix: The language rule now also checks comments written in a script that does not delimit
       its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be
@@ -16,6 +18,9 @@
     * Möglichkeit der Erweiterung von Antispam Bee um eigene Spam-Regeln
     * Erlaubt die Nutzung von Antispam Bee für andere Reaktionen als Kommentare, beispielsweise
       Formulare
+    * Die eingebauten Patterns der Regular-Expression-Regel haben nun feste Bezeichner als Array-Keys,
+      sodass einzelne Patterns über den Filter `antispam_bee_patterns` entfernt oder angepasst werden
+      können
     * Fix: Die Sprach-Regel prüft nun auch Kommentare in einer Schrift, die ihre Wörter nicht
       durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
     * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,28 @@ Whether Antispam Bee works with a comment form submitted via AJAX depends on how
 
 If the comments are sent to the `admin-ajax.php`, the `antispam_bee_disallow_ajax_calls` filter must be used to run ASB for requests to that file as well. If the script does not send all form data to the file, but only some selected ones, further customization is probably necessary, as [exemplified in this post by Torsten Landsiedel](https://torstenlandsiedel.de/2020/10/04/ajaxifizierte-kommentare-und-antispam-bee/) (in German).
 
+### How can I customize the regular expressions used for spam detection? ###
+The "Regular Expression" rule ships with a set of built-in patterns that can be adjusted via the `antispam_bee_patterns` filter. Every pattern is an array of subject fields (`ip`, `host`, `rawurl`, `body`, `email`, `author`, `useragent`) mapped to a regular expression without delimiters. All fields of a pattern must match for a reaction to be flagged as spam.
+
+Each built-in pattern has a stable identifier as its array key (prefixed with `asb-`), so single patterns can be removed or modified without touching the others:
+
+`
+add_filter( 'antispam_bee_patterns', function ( $patterns ) {
+    // Remove a built-in pattern.
+    unset( $patterns['asb-spam-keywords-author'] );
+
+    // Extend a built-in pattern.
+    $patterns['asb-known-spam-hosts']['host'] .= '|^(www\.)?example\.com$';
+
+    // Add your own pattern.
+    $patterns['my-plugin-crypto-body'] = [
+        'body' => 'crypto giveaway|free bitcoin',
+    ];
+
+    return $patterns;
+} );
+`
+
 ### Does Antispam Bee store any private user data, and is it compliant with GDPR? ###
 Antispam Bee is developed in Europe. You might have heard we can be a bit nitpicky over here when it comes to privacy. The plugin does not save private user data and is 100% compliant with GDPR.
 

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -67,60 +67,60 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		];
 
 		$patterns = [
-			[
+			'asb-gmail-numeric-domain'       => [
 				'host'  => '^(www\.)?\d+\w+\.com$',
 				'body'  => '^\w+\s\d+$',
 				'email' => '@gmail.com$',
 			],
-			[
+			'asb-gibberish-strings'          => [
 				'body'   => '\b[a-z]{30}\b',
 				'author' => '\b[a-z]{10}\b',
 				'host'   => '\b[a-z]{10}\b',
 			],
-			[
+			'asb-mfunc-injection'            => [
 				'body' => '\<\!.+?mfunc.+?\>',
 			],
-			[
+			'asb-spam-keywords-author'       => [
 				'author' => 'moncler|north face|vuitton|handbag|burberry|outlet|prada|cialis|viagra|maillot|oakley|ralph lauren|ray ban|iphone|プラダ|[^\w]?porn[o]?[s]?[^\w]?|[^\w]?pornstar[^\w]?|^20bet$',
 			],
-			[
+			'asb-known-spam-hosts'           => [
 				'host' => '^(www\.)?fkbook\.co\.uk$|^(www\.)?nsru\.net$|^(www\.)?goo\.gl$|^(www\.)?bit\.ly$',
 			],
-			[
+			'asb-traffic-and-pharma-body'    => [
 				'body' => 'target[t]?ed (visitors|traffic)|viagra|cialis',
 			],
-			[
+			'asb-luxury-brand-sale-body'     => [
 				'body' => 'purchase amazing|buy amazing|luxurybrandsale',
 			],
-			[
+			'asb-adult-pharma-russian-email' => [
 				'body'  => 'dating|sex|lotto|pharmacy',
 				'email' => '@mail\.ru|@yandex\.',
 			],
-			[
+			'asb-shorturl-fm-link-only-body' => [
 				'body'   => '^https?:\/\/shorturl\.fm\/[a-zA-Z0-9]{5}$',
 				'email'  => '@gmail\.com',
 				'author' => '^[A-Z][a-z]+\d{3,4}$',
 			],
-			[
+			'asb-binance-referral-url'       => [
 				'rawurl' => '^http[s]?:\/\/(accounts\.)?binance\.com\/[a-zA-Z-]+\/register(-person)?\?ref=[\w]+',
 			],
 		];
 
 		$quoted_author = preg_quote( $subject['author'], '/' );
 		if ( $quoted_author ) {
-			$patterns[] = [
+			$patterns['asb-author-name-as-link-text']    = [
 				'body' => sprintf(
 					'<a.+?>%s<\/a>$',
 					$quoted_author
 				),
 			];
-			$patterns[] = [
+			$patterns['asb-author-name-followed-by-url'] = [
 				'body' => sprintf(
 					'%s https?:.+?$',
 					$quoted_author
 				),
 			];
-			$patterns[] = [
+			$patterns['asb-author-name-as-host']         = [
 				'email'  => '@gmail.com$',
 				'author' => '^[a-z0-9-\.]+\.[a-z]{2,6}$',
 				'host'   => sprintf(
@@ -133,13 +133,18 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filters the regular expression patterns used to detect spam.
 		 *
-		 * Each pattern is an array that maps a reaction field (for example `email`,
-		 * `author`, `body` or `host`) to a regular expression. A reaction is flagged
-		 * as spam when all fields of a single pattern match.
+		 * Each entry is a map of subject field (`ip`, `host`, `rawurl`, `body`, `email`,
+		 * `author`, `useragent`) to a regular expression without delimiters. All fields of
+		 * an entry must match for the reaction to be flagged as spam. Array keys are stable
+		 * identifiers, so single default patterns can be modified or removed. The built-in
+		 * ones are prefixed with `asb-`.
 		 *
 		 * @since 2.5.2
+		 * @since 3.0.0 Patterns are keyed by a stable identifier instead of a numeric index.
 		 *
-		 * @param array $patterns A list of field-to-regular-expression pattern maps.
+		 * @param array<string, array<string, string>> $patterns Patterns, keyed by identifier.
+		 *
+		 * @return array<string, array<string, string>> Filtered patterns.
 		 */
 		$patterns = apply_filters(
 			'antispam_bee_patterns',

--- a/tests/Unit/Rules/RegexpSpamTest.php
+++ b/tests/Unit/Rules/RegexpSpamTest.php
@@ -72,6 +72,115 @@ class RegexpSpamTest extends AbstractRuleTestCase {
 		);
 	}
 
+	public function test_verify_allows_removing_a_default_pattern() {
+		$item           = self::make_comment();
+		$item['author'] = 'Buy Viagra';
+
+		expectApplied( 'antispam_bee_patterns' )
+			->once()
+			->andReturnUsing(
+				static function ( $patterns ) {
+					unset( $patterns['asb-spam-keywords-author'] );
+
+					return $patterns;
+				}
+			);
+
+		self::assertSame(
+			0,
+			RegexpSpam::verify( $item ),
+			'A default pattern removed by its identifier should no longer be applied'
+		);
+	}
+
+	public function test_verify_allows_modifying_a_default_pattern() {
+		expectApplied( 'antispam_bee_patterns' )
+			->twice()
+			->andReturnUsing(
+				static function ( $patterns ) {
+					$patterns['asb-spam-keywords-author']['author'] .= '|customspamword';
+
+					return $patterns;
+				}
+			);
+
+		$custom_match           = self::make_comment();
+		$custom_match['author'] = 'A customspamword author';
+		self::assertSame(
+			1,
+			RegexpSpam::verify( $custom_match ),
+			'A default pattern extended by its identifier should match the added keyword'
+		);
+
+		$default_match           = self::make_comment();
+		$default_match['author'] = 'Buy Viagra';
+		self::assertSame(
+			1,
+			RegexpSpam::verify( $default_match ),
+			'Extending a default pattern should keep its original keywords working'
+		);
+	}
+
+	public function test_verify_passes_all_documented_pattern_keys_to_the_filter() {
+		$expected_keys = [
+			'asb-gmail-numeric-domain',
+			'asb-gibberish-strings',
+			'asb-mfunc-injection',
+			'asb-spam-keywords-author',
+			'asb-known-spam-hosts',
+			'asb-traffic-and-pharma-body',
+			'asb-luxury-brand-sale-body',
+			'asb-adult-pharma-russian-email',
+			'asb-shorturl-fm-link-only-body',
+			'asb-binance-referral-url',
+			'asb-author-name-as-link-text',
+			'asb-author-name-followed-by-url',
+			'asb-author-name-as-host',
+		];
+
+		$filtered_keys = [];
+		expectApplied( 'antispam_bee_patterns' )
+			->once()
+			->andReturnUsing(
+				static function ( $patterns ) use ( &$filtered_keys ) {
+					$filtered_keys = array_keys( $patterns );
+
+					return $patterns;
+				}
+			);
+
+		RegexpSpam::verify( self::make_comment() );
+
+		self::assertSame(
+			$expected_keys,
+			$filtered_keys,
+			'The filter should receive all built-in patterns under their documented identifiers'
+		);
+	}
+
+	public function test_verify_still_supports_appended_patterns_without_a_key() {
+		$item         = self::make_comment();
+		$item['body'] = 'A perfectly harmless custom message.';
+
+		expectApplied( 'antispam_bee_patterns' )
+			->once()
+			->andReturnUsing(
+				static function ( $patterns ) {
+					$patterns[] = [
+						'body' => 'harmless custom message',
+					];
+
+					return $patterns;
+				}
+			);
+
+		self::assertSame(
+			1,
+			RegexpSpam::verify( $item ),
+			'Patterns appended without an identifier should still be applied'
+		);
+	}
+
 	/**
 	 * The `porn`/`pornstar`/`20bet` author terms must be detected.
 	 */


### PR DESCRIPTION
## Why

`RegexpSpam::verify()` exposes its default regex patterns through the `antispam_bee_patterns` filter, but the array was purely list-indexed. That means a third party could only *append* to it or *replace it wholesale* — targeting a single default pattern required relying on its numeric position, which shifts whenever a default is added or removed. Three of the entries are only appended at all when the comment author name is non-empty, so the indices are not even stable within a single request.

## What

Every built-in pattern now has a stable string key, prefixed with `asb-`:

| Key | Fields |
| --- | --- |
| `asb-gmail-numeric-domain` | `host`, `body`, `email` |
| `asb-gibberish-strings` | `body`, `author`, `host` |
| `asb-mfunc-injection` | `body` |
| `asb-spam-keywords-author` | `author` |
| `asb-known-spam-hosts` | `host` |
| `asb-traffic-and-pharma-body` | `body` |
| `asb-luxury-brand-sale-body` | `body` |
| `asb-adult-pharma-russian-email` | `body`, `email` |
| `asb-shorturl-fm-link-only-body` | `body`, `email`, `author` |
| `asb-binance-referral-url` | `rawurl` |
| `asb-author-name-as-link-text` | `body` |
| `asb-author-name-followed-by-url` | `body` |
| `asb-author-name-as-host` | `email`, `author`, `host` |

Which makes this possible:

```php
add_filter( 'antispam_bee_patterns', function ( $patterns ) {
	// Remove a built-in pattern.
	unset( $patterns['asb-spam-keywords-author'] );

	// Extend a built-in pattern.
	$patterns['asb-known-spam-hosts']['host'] .= '|^(www\.)?example\.com$';

	// Add your own pattern.
	$patterns['my-plugin-crypto-body'] = [
		'body' => 'crypto giveaway|free bitcoin',
	];

	return $patterns;
} );
```

Also adds a PHPDoc block for the filter (it had none), documenting the field whitelist, the AND semantics between fields of one pattern, and the key contract — plus `@since 2.5.2` / `@since 3.0.0` for the index change. The filter is now documented in `readme.txt` as well.

## Compatibility

The regular expressions themselves are unchanged, byte for byte, so detection behaviour is identical. The matching loop iterates values only, and `count( $hits ) === count( $pattern )` is unaffected. Third-party code doing `$patterns[] = [ ... ]` keeps working, since PHP assigns the next free integer index — there is a test covering exactly that.

The only way to notice the change is code that addressed a default pattern by its numeric index, which was never reliable in the first place.

## Testing

`tests/Unit/Rules/RegexpSpamTest.php` gains four tests, mirroring real third-party usage:

- removing a default pattern by key stops it from matching,
- extending a default pattern by key matches the added keyword while keeping the original ones,
- the filter receives all documented keys in the documented order (guards against silent renames),
- appending a pattern without a key still works.

Full suite is green (36 tests, 87 assertions), `phpcs` is clean on the changed files and `phpstan` reports no errors.
