### PR TITLE
ci: post the full-corpus comparison result on a pull request

### DIFF
--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -55,6 +55,10 @@ on:
         description: 'Fail the run if any spam/ham verdict flips.'
         type: boolean
         default: true
+      comment_pr:
+        description: 'Post the full-corpus result as a comment on this PR number (optional).'
+        required: false
+        default: ''
 
 jobs:
   compare:
@@ -64,6 +68,7 @@ jobs:
     timeout-minutes: 330
     permissions:
       contents: read        # look up the baseline snapshot on the release
+      pull-requests: write  # post the full-corpus result on a PR (manual runs)
     env:
       # Full corpus for prepare-* pushes and manual runs that ask for it, when
       # the corpus is configured; otherwise the bundled fixture. PRs never use it.
@@ -135,3 +140,39 @@ jobs:
           path: ${{ steps.compare.outputs.baseline-snapshot-file }}
           retention-days: 90
           if-no-files-found: error
+
+      # Post the result on a PR — only for full-corpus runs, since a PR-event run
+      # sees just the small bundled fixture and would report almost nothing.
+      # Updates its own comment in place instead of adding one per run.
+      #
+      # `always()` so a failing check (flips found) still reports: that is exactly
+      # the case someone needs the table for.
+      - name: Comment the result on the PR
+        if: always() && env.ASB_USE_FULL == 'true' && inputs.comment_pr != '' && steps.compare.outputs.report-markdown != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.comment_pr }}
+          REPORT: ${{ steps.compare.outputs.report-markdown }}
+        run: |
+          set -euo pipefail
+
+          # Fork PRs get a read-only token and cannot be commented on. Say so
+          # rather than failing the run with an opaque 403.
+          is_fork="$(gh pr view "$PR" --json isCrossRepository --jq .isCrossRepository)"
+          if [ "$is_fork" = "true" ]; then
+            echo "::notice::PR #$PR comes from a fork; skipping the comment (see the job summary instead)."
+            exit 0
+          fi
+
+          # Reuse our own previous comment when there is one.
+          existing="$(gh api "repos/${{ github.repository }}/issues/$PR/comments" --paginate \
+            --jq 'map(select(.body | contains("<!-- asb-detection-compare -->"))) | last | .id // empty')"
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$existing" \
+              -F body=@"$REPORT" >/dev/null
+            echo "Updated comment $existing on PR #$PR."
+          else
+            gh pr comment "$PR" --body-file "$REPORT"
+            echo "Posted a new comment on PR #$PR."
+          fi


### PR DESCRIPTION
Mirrors the comment step now documented in
[`examples/consuming-workflow.yml`](https://github.com/2ndkauboy/asb-detection-compare/blob/develop/examples/consuming-workflow.yml)
after 2ndkauboy/asb-detection-compare#5.

## What

The action renders the comparison as Markdown and exposes it as
`report-markdown`. This workflow now posts it as a pull-request comment, so the
result is visible without digging into a run's job summary.

- New `workflow_dispatch` input **`comment_pr`** — the PR number to comment on.
- Job gains `pull-requests: write`.
- New step after the snapshot uploads.

## Why it is manual-only

A `pull_request` run never uses the full corpus (`ASB_USE_FULL` is false, so fork
PRs can't reach the secrets), meaning it would post "0 flips over 112 comments"
on every push. The runs worth reporting are the `prepare-*` pushes — and those
have no PR attached, hence the explicit input.

Concretely: this is what would have posted the results we gathered by hand for
#763 (0 flips, 698 reason-only differences) and #764 (0 flips, 61,586 reason-only
differences) onto those PRs.

## Behaviour

- **Updates in place** — the report carries an `<!-- asb-detection-compare -->`
  marker, so a re-run PATCHes the existing comment rather than stacking a new one.
- **Skips forks** — a fork PR's token is read-only, so commenting would 403. The
  step detects `isCrossRepository` and emits a notice pointing at the job summary.
- **Runs under `always()`** — a failing check is precisely when someone wants the
  table.

Requires the action at `v1.5.0` or the moving `v1` tag, both of which now point at
the release carrying `report-markdown`.
