### PR TITLE
ci: expose the language service and tuning knobs on the manual trigger

### DIFF
--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -59,6 +59,20 @@ on:
         description: 'Post the full-corpus result as a comment on this PR number (optional).'
         required: false
         default: ''
+      lang_api:
+        description: >-
+          Also compare the language rule, using a local franc service instead of
+          the public API. Off by default: it adds ~205k local requests per build.
+        type: boolean
+        default: false
+      workers:
+        description: 'Parallel classifier processes (the language service matches this).'
+        required: false
+        default: '4'
+      buffer_pool:
+        description: 'InnoDB buffer pool to request. Below ~1G a full-corpus run slows down badly.'
+        required: false
+        default: '1G'
 
 jobs:
   compare:
@@ -110,7 +124,16 @@ jobs:
           baseline-ref: ${{ (github.event_name == 'pull_request' && github.base_ref) || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref) || '' }}
           corpus-file: ${{ env.ASB_USE_FULL == 'true' && format('{0}/corpus.sql.gz', github.workspace) || '' }}
           fail-on-flips: ${{ (github.event_name == 'workflow_dispatch' && inputs.fail_on_flips == false) && 'false' || 'true' }}
-          workers: '4'
+          # Manual runs can tune these; every other event takes the defaults.
+          workers: ${{ (github.event_name == 'workflow_dispatch' && inputs.workers) || '4' }}
+          # A stock container's 128 MB pool is far below this workload's ~570 MB
+          # working set, which collapses throughput part-way through a full run.
+          buffer-pool: ${{ (github.event_name == 'workflow_dispatch' && inputs.buffer_pool) || '1G' }}
+          # Off unless a manual run asks for it. Enabling it selects the option
+          # fixture that turns the language rule on, which is a different
+          # experiment: those snapshots are fingerprinted separately, so such a
+          # run neither reuses nor produces a baseline for ordinary runs.
+          lang-api: ${{ (github.event_name == 'workflow_dispatch' && inputs.lang_api) && 'true' || 'false' }}
           # Pinned so published verdict snapshots stay valid across WordPress
           # releases; bumping it deliberately invalidates every snapshot.
           wp-version: '6.8.2'


### PR DESCRIPTION
Mirrors 2ndkauboy/asb-detection-compare#6, now released as `v1.6.0`.

## New manual inputs

| input | default | what it does |
|---|---|---|
| `lang_api` | `false` | also compare the language rule, against a local franc service |
| `workers` | `4` | parallel classifier processes |
| `buffer_pool` | `1G` | InnoDB buffer pool to request |

Pull requests and `prepare-*` pushes are unaffected — they take the same defaults
as before.

## Why `buffer_pool` is worth having

A stock database container ships a **128 MB** InnoDB buffer pool. This workload's
working set is ~570 MB (313 MB corpus, plus site tables growing past 255 MB
during a pass), so once the site tables outgrow the pool every insert hits disk.
Measured on a full corpus:

| buffer pool | throughput |
|---|---|
| 128 MB | ~10,700/min, collapsing to **~380/min** part-way through |
| 4 GB | **~9,100/min, flat to the last comment** |

This was the cause of the decay tracked in 2ndkauboy/asb-detection-compare#3.

## Why `lang_api` is off by default

`LangSpam` calls a language API once per eligible comment — about **205,000
requests per build** on the full corpus. Enabling it starts a local
[franc](https://github.com/wooorm/franc) service (the same approach as this
repo's own E2E tests) so nothing external is called, but it is still a heavier
run and, more importantly, **a different experiment**: it selects the option
fixture that turns the rule on, so its snapshots are fingerprinted separately and
will not reuse — or serve as — an ordinary baseline.

Everything inside `LangSpam::verify()` runs unchanged; only the transport is
redirected, via `antispam_bee_lang_api_url` and `http_request_host_is_external`.

## What it already found

Run against #781 over the full corpus, compared to its exact merge-base:

- **1 spam/ham flip** and **1,507 reason-only changes**
- 1,476 of the 1,508 changed comments are in Hangul, Han, Thai or kana — the
  scripts that patch targets
- it also removes **27 false positives**, by treating franc's `und` result as
  "no reason to assume spam"
