### PR TITLE
ci: let the detection comparison choose between two corpora

### DIFF
--- a/.github/workflows/attach-snapshot.yml
+++ b/.github/workflows/attach-snapshot.yml
@@ -11,10 +11,14 @@
 # the corpus row id, the spam/ham status, and the matched rule slugs. See
 # "Baseline snapshots" in https://github.com/2ndkauboy/asb-detection-compare.
 #
-# If no matching artifact exists (e.g. the release was cut without a prepare
-# run), this fails loudly. Nothing breaks downstream — the next comparison
-# simply classifies its baseline as it always did — but the failure is the
-# signal that the chain was interrupted.
+# If no comparison run exists for the released commit at all (e.g. the release was
+# cut without a prepare run), this fails loudly. Nothing breaks downstream — the
+# next comparison simply classifies its baseline as it always did — but the
+# failure is the signal that the chain was interrupted.
+#
+# A run may legitimately carry a snapshot for only one corpus, though: a version
+# prepared with the full corpus has no small-corpus artifact and vice versa. That
+# is not a broken chain, so a corpus with no artifact is reported and skipped.
 
 name: Attach detection snapshot to release
 
@@ -29,6 +33,13 @@ permissions:
 jobs:
   attach:
     runs-on: ubuntu-latest
+    # Each corpus produces its own snapshot, named after that corpus's
+    # fingerprint, so a release can carry one per corpus and a later run only ever
+    # finds the baseline matching the corpus it is classifying.
+    strategy:
+      fail-fast: false
+      matrix:
+        corpus: [ full, small ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,14 +73,24 @@ jobs:
           echo "tag-sha=$tag_sha" >> "$GITHUB_OUTPUT"
 
       - name: Download the snapshot artifact
+        id: download
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh run download "${{ steps.find.outputs.run-id }}" \
-            --name asb-detection-snapshot --dir snapshot
+          # Not every release has a snapshot for every corpus — a version prepared
+          # with only the full corpus has no small-corpus artifact. That is not a
+          # failure; there is simply nothing to attach.
+          if gh run download "${{ steps.find.outputs.run-id }}" \
+              --name "asb-detection-snapshot-${{ matrix.corpus }}" --dir snapshot 2>/dev/null; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No ${{ matrix.corpus }}-corpus snapshot in that run; nothing to attach."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify it describes this release
+        if: steps.download.outputs.found == 'true'
         env:
           TAG_SHA: ${{ steps.find.outputs.tag-sha }}
         run: |
@@ -83,18 +104,30 @@ jobs:
 
           commit="$(echo "$manifest" | jq -r '.commit_sha')"
           publishable="$(echo "$manifest" | jq -r '.publishable')"
+          token="$(echo "$manifest" | jq -r '.corpus_token')"
 
           if [ "$commit" != "$TAG_SHA" ]; then
             echo "::error::Snapshot describes $commit, but the release is $TAG_SHA."
             exit 1
           fi
           if [ "$publishable" != "true" ]; then
-            echo "::error::Snapshot is not marked publishable (unsalted or not cluster-sharded)."
+            echo "::error::Snapshot is not marked publishable (unsalted, or not from a reproducible shard mode)."
             exit 1
           fi
+
+          # The asset filename carries the corpus token, and a later run looks the
+          # asset up by its own token. If the artifact were mislabelled the wrong
+          # corpus's snapshot would be attached and silently never matched — so
+          # check that the filename and the manifest agree.
+          case "$(basename "$file")" in
+            *"-$token.tsv.gz") ;;
+            *) echo "::error::Filename $(basename "$file") does not carry the manifest's corpus token $token."; exit 1 ;;
+          esac
+          echo "Corpus token $token, commit ${commit:0:12} — matches this release."
           echo "SNAPSHOT_FILE=$file" >> "$GITHUB_ENV"
 
       - name: Attach to the release
+        if: steps.download.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -6,7 +6,8 @@
 # https://github.com/2ndkauboy/asb-detection-compare. Three tiers:
 #
 #   • Pull requests             -> the SMALL corpus (~10k comments, ~25 s per
-#                                  pass), compared to the PR's base branch.
+#                                  pass), compared to the PR's base branch, with
+#                                  the language rule included.
 #                                  Forks get the bundled fixture instead.
 #   • prepare-* / release push  -> thorough check against the FULL corpus dump
 #                                  (~333k comments), compared to the
@@ -72,7 +73,8 @@ on:
       lang_api:
         description: >-
           Also compare the language rule, using a local franc service instead of
-          the public API. Off by default: it adds ~205k local requests per build.
+          the public API. Already on for the small corpus; ticking this adds it to
+          a full-corpus run too, at ~205k local requests.
         type: boolean
         default: false
       workers:
@@ -162,11 +164,27 @@ jobs:
           # A stock container's 128 MB pool is far below this workload's ~570 MB
           # working set, which collapses throughput part-way through a full run.
           buffer-pool: ${{ (github.event_name == 'workflow_dispatch' && inputs.buffer_pool) || '1G' }}
-          # Off unless a manual run asks for it. Enabling it selects the option
-          # fixture that turns the language rule on, which is a different
-          # experiment: those snapshots are fingerprinted separately, so such a
-          # run neither reuses nor produces a baseline for ordinary runs.
-          lang-api: ${{ (github.event_name == 'workflow_dispatch' && inputs.lang_api) && 'true' || 'false' }}
+          # On for the small corpus, off for the full one, and a manual run can
+          # switch it on for either.
+          #
+          # Without it the option fixture leaves the language rule disabled, so the
+          # comparison has no coverage of it at all — and the small corpus keeps the
+          # delimiter-less-script strata precisely because they are its material.
+          # On ~10k comments the cost is negligible (a whole two-pass comparison
+          # runs in ~80 s); on the full corpus it adds ~205k local requests, which
+          # is why it stays off there.
+          #
+          # It cannot disturb the snapshot chain. Enabling it selects a different
+          # option fixture, so its snapshots are fingerprinted separately — but
+          # reuse only applies to prepare-* runs against a release tag, and those
+          # use the full corpus with this off. Pull requests compare against their
+          # base *branch*, which never publishes or reuses a snapshot.
+          #
+          # Caveat: franc is a local stand-in, not api.pluginkollektiv.org. This
+          # compares the plugin's logic around detection — length guards, script
+          # awareness, "und" handling, macrolanguage mapping — not that the
+          # production service returns the same codes.
+          lang-api: ${{ ((env.ASB_CORPUS == 'small' && env.ASB_CORPUS_READY == 'true') || (github.event_name == 'workflow_dispatch' && inputs.lang_api)) && 'true' || 'false' }}
           # Pinned so published verdict snapshots stay valid across WordPress
           # releases; bumping it deliberately invalidates every snapshot.
           wp-version: '6.8.2'

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -5,19 +5,27 @@
 # verdict (and reason) via the reusable action
 # https://github.com/2ndkauboy/asb-detection-compare. Three tiers:
 #
-#   • Pull requests             -> fast smoke check against a small bundled
-#                                  fixture, compared to the PR's base branch.
+#   • Pull requests             -> the SMALL corpus (~10k comments, ~25 s per
+#                                  pass), compared to the PR's base branch.
+#                                  Forks get the bundled fixture instead.
 #   • prepare-* / release push  -> thorough check against the FULL corpus dump
-#                                  (decrypted in-workflow), compared to the
+#                                  (~333k comments), compared to the
 #                                  semver-resolved baseline release.
 #   • Manual (workflow_dispatch)-> run on ANY branch on demand, choosing the
-#                                  baseline and whether to use the full corpus.
+#                                  baseline and which corpus to use.
 #
-# The full corpus is real (PII) comments, so it is never public in the clear:
-# an encrypted blob is fetched from a public URL and decrypted with a passphrase
-# secret. pull_request runs (including forks) never receive secrets and fall
-# back to the bundled fixture; only trusted events (prepare-* pushes, manual
-# runs) decrypt the dump. If the corpus is not configured, they fall back too.
+# The small corpus exists because the full one is 97.6 % honeypot-caught spam,
+# and those comments short-circuit in Rules::apply() before the content rules run
+# — so the content rules only ever see about 2 % of it. The small corpus keeps
+# every comment where a non-final rule can still run, including all 6,755 ham
+# comments (the false-positive check), and caps the honeypot-caught strata.
+# Detecting a change that touches only a few dozen comments still needs the full
+# corpus, which stays authoritative for prepare-* runs.
+#
+# Both real corpora are real (PII) comments, so neither is ever public in the
+# clear: an encrypted blob is fetched from a public URL and decrypted with a
+# passphrase secret. Fork pull requests never receive secrets and fall back to
+# the bundled fixture; if a corpus is not configured, runs fall back too.
 #
 # Classifying the full corpus takes hours, and half of every run would re-derive
 # how the *baseline release* classifies it — which never changes. So a run
@@ -26,9 +34,10 @@
 # snapshot holds no personal data: per comment only a salted pseudonym of the
 # corpus row id, the spam/ham status and the matched rule slugs.
 #
-# Configure (for the full-corpus tiers):
-#   • variable ASB_CORPUS_ENC_URL -> public URL of corpus.sql.gz.gpg
-#   • secret   ASB_CORPUS_KEY     -> the gpg passphrase
+# Configure (for the encrypted-corpus tiers):
+#   • variable ASB_CORPUS_ENC_URL       -> public URL of corpus.sql.gz.gpg
+#   • variable ASB_CORPUS_SMALL_ENC_URL -> public URL of small-corpus.sql.gz.gpg
+#   • secret   ASB_CORPUS_KEY           -> the gpg passphrase (shared by both)
 # Encrypt with: gpg --batch --symmetric --cipher-algo AES256 \
 #   --passphrase "<pass>" -o corpus.sql.gz.gpg corpus.sql.gz
 
@@ -47,10 +56,11 @@ on:
         description: 'Baseline tag or branch to compare the current branch against.'
         required: true
         default: 'v3'
-      full_corpus:
-        description: 'Use the full encrypted corpus (otherwise the small bundled fixture).'
-        type: boolean
-        default: true
+      corpus:
+        description: 'Which corpus to classify.'
+        type: choice
+        options: [ full, small, fixture ]
+        default: small
       fail_on_flips:
         description: 'Fail the run if any spam/ham verdict flips.'
         type: boolean
@@ -84,9 +94,16 @@ jobs:
       contents: read        # look up the baseline snapshot on the release
       pull-requests: write  # post the full-corpus result on a PR (manual runs)
     env:
-      # Full corpus for prepare-* pushes and manual runs that ask for it, when
-      # the corpus is configured; otherwise the bundled fixture. PRs never use it.
-      ASB_USE_FULL: ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_corpus)) && vars.ASB_CORPUS_ENC_URL != '' }}
+      # Which corpus this run uses. Forks never get secrets, so they always fall
+      # back to the fixture. Pushes to prepare-* use the full corpus, same-repo
+      # pull requests the small one, manual runs choose. The fetch step degrades
+      # to the fixture when the corresponding URL is not configured.
+      ASB_CORPUS: >-
+        ${{ github.event.pull_request.head.repo.fork && 'fixture'
+         || (github.event_name == 'workflow_dispatch' && inputs.corpus)
+         || (github.event_name == 'push' && 'full')
+         || (github.event_name == 'pull_request' && 'small')
+         || 'fixture' }}
     services:
       mysql:
         image: mariadb:10.6
@@ -105,15 +122,26 @@ jobs:
         with:
           fetch-depth: 0        # full history/tags for baseline resolution
 
+      # Sets ASB_CORPUS_READY so a missing URL degrades to the bundled fixture
+      # instead of failing the run.
       - name: Fetch & decrypt the release corpus
-        if: env.ASB_USE_FULL == 'true'
+        if: env.ASB_CORPUS != 'fixture'
         env:
-          ASB_CORPUS_ENC_URL: ${{ vars.ASB_CORPUS_ENC_URL }}
           ASB_CORPUS_KEY: ${{ secrets.ASB_CORPUS_KEY }}
+          ENC_URL: >-
+            ${{ env.ASB_CORPUS == 'full' && vars.ASB_CORPUS_ENC_URL
+             || vars.ASB_CORPUS_SMALL_ENC_URL }}
         run: |
-          curl -fSL --retry 3 -o corpus.sql.gz.gpg "$ASB_CORPUS_ENC_URL"
+          set -euo pipefail
+          if [ -z "${ENC_URL:-}" ] || [ -z "${ASB_CORPUS_KEY:-}" ]; then
+            echo "::notice::No '${{ env.ASB_CORPUS }}' corpus configured; using the bundled fixture."
+            echo "ASB_CORPUS_READY=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          curl -fSL --retry 3 -o corpus.sql.gz.gpg "$ENC_URL"
           gpg --batch --quiet --yes --passphrase "$ASB_CORPUS_KEY" \
             -o corpus.sql.gz -d corpus.sql.gz.gpg
+          echo "ASB_CORPUS_READY=true" >> "$GITHUB_ENV"
 
       - name: Compare spam detection
         id: compare
@@ -122,7 +150,12 @@ jobs:
           # PR -> the PR's base branch. Manual -> the chosen baseline. Prepare
           # push -> empty, so the baseline is resolved from the branch name.
           baseline-ref: ${{ (github.event_name == 'pull_request' && github.base_ref) || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref) || '' }}
-          corpus-file: ${{ env.ASB_USE_FULL == 'true' && format('{0}/corpus.sql.gz', github.workspace) || '' }}
+          # The decrypted corpus when one was fetched, else the bundled fixture.
+          corpus-file: ${{ env.ASB_CORPUS_READY == 'true' && format('{0}/corpus.sql.gz', github.workspace) || '' }}
+          # Names the snapshot asset, e.g. asb-snapshot-small-4eb1dc68.tsv.gz.
+          # Each corpus has its own fingerprint, so their snapshots never collide
+          # and a run only ever finds the baseline matching its own corpus.
+          corpus-label: ${{ env.ASB_CORPUS_READY == 'true' && env.ASB_CORPUS || 'fixture' }}
           fail-on-flips: ${{ (github.event_name == 'workflow_dispatch' && inputs.fail_on_flips == false) && 'false' || 'true' }}
           # Manual runs can tune these; every other event takes the defaults.
           workers: ${{ (github.event_name == 'workflow_dispatch' && inputs.workers) || '4' }}
@@ -141,13 +174,18 @@ jobs:
       # Keep this run's verdict snapshot. When this version is released,
       # attach-snapshot.yml attaches it to the release, and the next prepare run
       # reuses it as its baseline instead of classifying the corpus twice.
-      # Only full-corpus runs are worth keeping — a fixture snapshot is cheap to
-      # recompute and would only shadow the real one.
+      # Fixture snapshots are not worth keeping — cheap to recompute, and they
+      # would shadow a real one.
+      #
+      # The corpus label is part of the artifact name: with two corpora in play, a
+      # single fixed name would let attach-snapshot.yml attach one corpus's
+      # snapshot to a release under the other's token, where no later run would
+      # ever match it.
       - name: Upload the verdict snapshot
-        if: env.ASB_USE_FULL == 'true' && steps.compare.outputs.snapshot-file != ''
+        if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.snapshot-file != ''
         uses: actions/upload-artifact@v4
         with:
-          name: asb-detection-snapshot
+          name: asb-detection-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.snapshot-file }}
           retention-days: 90
           if-no-files-found: error
@@ -156,22 +194,22 @@ jobs:
       # tag and are just as publishable. Attach this one to that release and the
       # next comparison against it needs only a single pass.
       - name: Upload the baseline verdict snapshot
-        if: env.ASB_USE_FULL == 'true' && steps.compare.outputs.baseline-snapshot-file != ''
+        if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.baseline-snapshot-file != ''
         uses: actions/upload-artifact@v4
         with:
-          name: asb-detection-baseline-snapshot
+          name: asb-detection-baseline-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.baseline-snapshot-file }}
           retention-days: 90
           if-no-files-found: error
 
-      # Post the result on a PR — only for full-corpus runs, since a PR-event run
-      # sees just the small bundled fixture and would report almost nothing.
-      # Updates its own comment in place instead of adding one per run.
+      # Post the result on a PR. Skipped for fixture runs, which compare 112
+      # synthetic comments and would report almost nothing. Updates its own
+      # comment in place instead of adding one per run.
       #
       # `always()` so a failing check (flips found) still reports: that is exactly
       # the case someone needs the table for.
       - name: Comment the result on the PR
-        if: always() && env.ASB_USE_FULL == 'true' && inputs.comment_pr != '' && steps.compare.outputs.report-markdown != ''
+        if: always() && env.ASB_CORPUS_READY == 'true' && inputs.comment_pr != '' && steps.compare.outputs.report-markdown != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ inputs.comment_pr }}


### PR DESCRIPTION
Mirrors the corpus-selection support from [`2ndkauboy/asb-detection-compare#7`](https://github.com/2ndkauboy/asb-detection-compare/pull/7) into this repository's own copies of the two workflows.

## Why

The full corpus is **97.6 % honeypot-caught spam**, and since `is_final()` landed those comments return from `Rules::apply()` before `BBCode`, `RegexpSpam`, `LangSpam` or `DbSpam` are evaluated. The content rules therefore only ever see about **2 %** of it, while the other 325k comments contribute one boolean each — at half an hour a pass.

Meanwhile pull requests ran against the action's bundled 122-row fixture, which compares 112 *synthetic* comments and reports "0 flips" every time. Its ham text is generated, so it cannot serve as a false-positive check at all.

`2ndkauboy/asb-corpus` now also publishes a **small stratified corpus**: 9,750 comments, ~25 s per pass, keeping every comment where a non-final rule can still run — including all **6,755 ham comments**, which are the false-positive check — and capping the honeypot-caught strata. The full corpus stays authoritative for `prepare-*` runs, since a change touching only a few dozen comments still needs it.

| corpus | comments | per pass | used by |
|---|---|---|---|
| full | 332,834 | ~32 min | `prepare-*` pushes |
| **small** | **9,750** | **~25 s** | same-repo pull requests |
| fixture | 122 | seconds | fork pull requests |

## `spam-detection-comparison.yml`

- Replaces the `full_corpus` boolean with an `ASB_CORPUS` selection (`full` / `small` / `fixture`) and a `corpus` choice input.
- Fork pull requests keep falling back to the fixture, since they never receive secrets. `ASB_CORPUS_READY` degrades to the fixture when the corresponding URL is not configured, rather than failing the run.
- Passes `corpus-label`, so assets are legible as `asb-snapshot-small-<token>.tsv.gz`.
- Pull requests now get a **real false-positive check** instead of the fixture, so the PR comment is no longer restricted to full-corpus runs.

## `attach-snapshot.yml`

- Runs a matrix over both corpora. A corpus with no artifact is a notice rather than a failure: a version prepared with only one corpus legitimately has no artifact for the other. A release with no comparison run at all still fails loudly, as before.
- Verifies the manifest's `corpus_token` against the asset filename. A later run looks its baseline up by token, so a mislabelled asset would be attached and then silently never matched.

Both carry the corpus label in their artifact names — with two corpora in play, the previous fixed names would have let one corpus's snapshot be attached to a release under the other's token.

## Configuration

Needs a new `ASB_CORPUS_SMALL_ENC_URL` repository variable pointing at the small corpus asset. The existing `ASB_CORPUS_KEY` secret is shared by both corpora.

## Verification so far

Against the small corpus locally, comparing `3.0.0-beta.1` with current `v3`: 9,750 rows, token `4eb1dc68`, **9,084 compared, 0 flips**, 2 reason-only differences, in 45 s. Both workflow files parse as valid YAML, no `ASB_USE_FULL` / `full_corpus` references remain, and a real snapshot manifest carries `corpus_token: 4eb1dc68` with `publishable: true` alongside a filename ending `-4eb1dc68.tsv.gz`, so the new cross-check passes on genuine output.

## The language rule is now on for the small corpus

Without `lang-api` the option fixture leaves `LangSpam` disabled, so the comparison had no coverage of that rule at all — while the small corpus keeps the delimiter-less-script strata precisely because they are its material. On ~10k comments a complete two-pass comparison including the franc service ran in **82 s**, so the ~205k-request warning that kept this off (a full-corpus figure) does not apply. It stays off for the full corpus.

This cannot disturb the snapshot chain: enabling it selects a different option fixture, so its snapshots are fingerprinted separately — but reuse only applies to `prepare-*` runs against a release *tag*, and those use the full corpus with this off. Pull requests compare against their base *branch*, which never publishes or reuses a snapshot.

Caveat recorded in the workflow: franc is a local stand-in, not `api.pluginkollektiv.org`. This compares the plugin's logic around detection — length guards, script awareness, `und` handling, macrolanguage mapping — not that the production service returns the same codes.

## Relationship to `2ndkauboy/asb-detection-compare#7`

**This does not depend on that PR.** `v1` already exposes both `corpus-file` and `corpus-label`, so everything here works against the current tag — an earlier revision of this description claimed `v1` had to move first, which was wrong.

The only runtime difference in #7 is a 14-line fix in `ci-compare.sh`: WordPress' comment notifications call `gethostbyaddr()` on the commenter's IP, and spam IPs without a PTR record block for the resolver's full retry budget — up to 63 s for a single comment. On the small corpus that was 195 of 9,750 comments consuming 1,323 s of 1,499 s of classification time. So merging #7 and moving `v1` makes these runs markedly faster, but is not required for them to be correct.
