### PR TITLE
feat: let a filter choose the address the country rule looks up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     * Fix: The country rule no longer asks the geolocation service about loopback, link-local and
       private addresses, which have no country anyway — a local installation and a site behind a
       reverse proxy without a `pre_comment_user_ip` filter stop sending requests altogether
+    * Enhancement: New `antispam_bee_country_spam_ip` filter to change which address the country
+      rule looks up — mask it differently, send the original one for a more precise country, or
+      return an empty string to skip the lookup
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
@@ -32,6 +35,9 @@
     * Fix: Die Länder-Regel fragt den Geolokalisierungs-Dienst nicht mehr zu Loopback-, Link-Local-
       und privaten Adressen, die ohnehin kein Land haben – eine lokale Installation und eine Seite
       hinter einem Reverse-Proxy ohne `pre_comment_user_ip`-Filter senden gar keine Anfragen mehr
+    * Verbesserung: Neuer Filter `antispam_bee_country_spam_ip`, um die Adresse zu ändern, die die
+      Länder-Regel abfragt – anders maskieren, die ursprüngliche Adresse für ein genaueres Land
+      senden oder mit einem leeren String die Abfrage ganz überspringen
 
 ### 2.11.12 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups
     * Fix: The country rule no longer asks the geolocation service about loopback, link-local and private addresses, which have no country anyway
+    * Enhancement: New `antispam_bee_country_spam_ip` filter to change which address the country rule looks up — mask it differently, send the original one for a more precise country, or return an empty string to skip the lookup
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -88,10 +88,22 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			return 0;
 		}
 
-		$anonymized_ip = IpHelper::anonymize_ip( $ip );
+		/**
+		 * Filters the IP address the country is looked up for.
+		 *
+		 * By default only the anonymized address is sent to the service. Return the
+		 * original address to trade privacy for a more precise country, mask it
+		 * differently, or return an empty string to skip the lookup altogether.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $lookup_ip The anonymized IP address.
+		 * @param string $ip        The original IP address.
+		 */
+		$lookup_ip = (string) apply_filters( 'antispam_bee_country_spam_ip', IpHelper::anonymize_ip( $ip ), $ip );
 
-		// Never look up an address that anonymization could not preserve.
-		if ( '' === $anonymized_ip ) {
+		// Anonymization can fail, and the filter can decline an address on purpose.
+		if ( '' === $lookup_ip ) {
 			return 0;
 		}
 
@@ -108,7 +120,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			esc_url_raw(
 				sprintf(
 					'https://www.iplocate.io/api/lookup/%s?apikey=%s',
-					$anonymized_ip,
+					$lookup_ip,
 					$apikey
 				),
 				[ 'https' ]

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -3,6 +3,7 @@
 namespace AntispamBee\Tests\Unit\Rules;
 
 use AntispamBee\Rules\CountrySpam;
+use function Brain\Monkey\Filters\expectApplied;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -70,6 +71,47 @@ class CountrySpamTest extends AbstractRuleTestCase {
 				"A $description address should not be sent to the service"
 			);
 		}
+	}
+
+	/**
+	 * The filter can return an empty string to decline an address, which must not
+	 * result in a lookup for no address at all.
+	 */
+	public function test_verify_does_not_call_the_service_for_an_empty_filtered_ip(): void {
+		$this->expect_no_request();
+
+		expectApplied( 'antispam_bee_country_spam_ip' )
+			->once()
+			->andReturn( '' );
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'An address the filter declined should not be sent to the service'
+		);
+	}
+
+	/**
+	 * A site that would rather trade privacy for a more precise country can return
+	 * the original address from the filter. It receives the anonymized address and
+	 * the original one to choose from.
+	 */
+	public function test_verify_looks_up_the_address_the_filter_returns(): void {
+		$this->expect_request(
+			'{"country_code":"DE"}',
+			'https://www.iplocate.io/api/lookup/198.51.100.42?apikey='
+		);
+
+		expectApplied( 'antispam_bee_country_spam_ip' )
+			->once()
+			->with( '198.51.100.0', '198.51.100.42' )
+			->andReturn( '198.51.100.42' );
+
+		self::assertSame(
+			1,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'The address returned by the filter should be used for the lookup'
+		);
 	}
 
 	public function test_verify_flags_a_reaction_from_a_denied_country(): void {
@@ -152,12 +194,19 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	/**
 	 * Expect a single request to the geolocation service.
 	 *
-	 * @param string $body The response body to return.
+	 * @param string      $body The response body to return.
+	 * @param string|null $url  The URL the request is expected to go to, if it matters.
 	 *
 	 * @return void
 	 */
-	private function expect_request( string $body ): void {
-		expect( 'wp_safe_remote_get' )->once()->andReturn( [ 'body' => $body ] );
+	private function expect_request( string $body, ?string $url = null ): void {
+		$expectation = expect( 'wp_safe_remote_get' )->once();
+
+		if ( null !== $url ) {
+			$expectation = $expectation->with( $url );
+		}
+
+		$expectation->andReturn( [ 'body' => $body ] );
 		when( 'wp_remote_retrieve_body' )->justReturn( $body );
 	}
 


### PR DESCRIPTION
Superseded by #817 — the description and discussion continue there.

This pull request was caught in stack #789 (rooted at the draft #506, `v3` → `master`), which made it impossible to merge or retarget. It was closed unchanged; the branch and its commits live on in #817.