### PR TITLE
test: add an integration test harness and cover the v2 to v3 migration

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,6 +43,7 @@
 /phpcs.xml
 /phpstan-bootstrap.php
 /phpstan.neon
+/phpunit-integration.xml.dist
 /phpunit.xml.dist
 /playwright.config.ts
 /typos.toml

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,74 @@
+# Split out of the former `tests.yml`, like the unit and end-to-end workflows. The job is
+# named `test-integration`, matching the naming of the other test jobs.
+#
+# The suite runs through PHPUnit but needs a real WordPress, a database and the WordPress
+# PHPUnit test library, so it starts `wp-env` the way the end-to-end workflow does. That
+# makes it more expensive than the unit suite and cheaper than the nine-wide end-to-end
+# matrix, so it gets a path filter of its own rather than sharing either of theirs.
+#
+# Only `pull_request` is filtered — `push` to a major branch deliberately runs everything.
+# A merge carries the same diff the pull request carried, so a filter that is too narrow
+# would skip the check on the pull request *and* on the merge, and the gap would never
+# surface. The push run is also the only one that tests the code as it actually landed:
+# pull request checks run against a merge commit computed when they started, which goes
+# stale once the base branch moves on.
+
+name: Integration tests
+
+on:
+  push:
+    branches:
+      - master
+      - v3
+  pull_request:
+    paths:
+      - '**.php'
+      # The end-to-end suite drives a browser and cannot affect a PHPUnit run, so exclude it
+      # from the `**.php` match above.
+      - '!tests/e2e/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'phpunit-integration.xml.dist'
+      - 'tests/Integration/**'
+      - 'tests/integration-bootstrap.php'
+      - '.wp-env.json'
+      - '.github/workflows/integration.yml'
+      # The shared PHP setup is part of this workflow's setup, so a change to it has to run
+      # this workflow as well.
+      - '.github/actions/setup-php/**'
+  # Allow forcing a full run by hand, for example before cutting a release.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - name: Install npm dependencies
+      run: npm ci
+    # The dev dependencies are required: the suite runs through PHPUnit.
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
+      with:
+        php-version: '8.2'
+    # Provides WordPress, the database and the WordPress PHPUnit test library.
+    - name: Start wp-env
+      run: npm run env:start
+    - name: Run integration tests
+      run: npm run test:integration
+    - name: Run integration tests on multisite
+      run: npm run test:integration:multisite
+    - name: Stop wp-env
+      if: always()
+      run: npm run env:stop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,12 @@ treating it as project code produces false findings.
 | PHP code style          | `composer cs`                                |
 | PHPStan static analysis | `composer phpstan`                           |
 | PHP unit tests          | `composer test:unit`                         |
+| PHP integration tests   | `npm run env:start`, then `npm run test:integration` |
 | E2E tests               | `npm run env:start`, then `npm run test:e2e` |
+
+Unit tests mock WordPress with Brain Monkey and run without a database. Integration tests boot a
+real WordPress against the `wp-env` database — use them for anything touching options, the
+database or core hooks. `npm run test:integration:multisite` repeats the run on a network install.
 
 Fix code style violations automatically with `composer csfix`.
 

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
 		"test:unit": [
 			"phpunit -c phpunit.xml.dist --testsuite unit"
 		],
+		"test:integration": [
+			"phpunit -c phpunit-integration.xml.dist --testsuite integration"
+		],
 		"phpstan": [
 			"phpstan analyse --memory-limit=1G"
 		]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"env:stop": "wp-env stop",
 		"env:clean": "wp-env reset tests",
 		"env:destroy": "wp-env destroy",
+		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/antispam-bee -- composer test:integration",
+		"test:integration:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/antispam-bee -- env WP_MULTISITE=1 composer test:integration",
 		"test:e2e": "wp-scripts test-playwright",
 		"test:e2e:ui": "wp-scripts test-playwright --ui",
 		"test:e2e:debug": "wp-scripts test-playwright --debug"

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Integration test suite: boots a real WordPress against a real database.
+
+	Kept separate from `phpunit.xml.dist` because the two suites need different
+	bootstraps. The unit bootstrap loads the WP function stubs from `tests/_stubs/`,
+	which would shadow the real WordPress functions here.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="tests/integration-bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         convertErrorsToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertDeprecationsToExceptions="false">
+	<testsuites>
+		<testsuite name="integration">
+			<directory suffix=".php">tests/Integration</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,8 +13,5 @@
 		<testsuite name="unit">
 			<directory suffix=".php">tests/Unit</directory>
 		</testsuite>
-		<testsuite name="integration">
-			<directory suffix=".php">tests/Integration</directory>
-		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Integration/Handlers/PluginStateChangeHandlerTest.php
+++ b/tests/Integration/Handlers/PluginStateChangeHandlerTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Integration tests for activation, deactivation and uninstall.
+ *
+ * @package AntispamBee\Tests\Integration\Handlers
+ */
+
+namespace AntispamBee\Tests\Integration\Handlers;
+
+use AntispamBee\Crons\DeleteSpamCron;
+use AntispamBee\Handlers\PluginStateChangeHandler;
+use AntispamBee\Handlers\PluginUpdate;
+use AntispamBee\Helpers\Settings;
+use ReflectionClass;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Uninstall removes user data, so it is asserted against the real options table.
+ */
+final class PluginStateChangeHandlerTest extends TestCase {
+
+	/**
+	 * The legacy option written by Antispam Bee 2.x.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_OPTION = 'antispam_bee';
+
+	/**
+	 * The option holding the database revision.
+	 *
+	 * @var string
+	 */
+	private const DB_VERSION_OPTION = 'antispambee_db_version';
+
+	/**
+	 * Start from a known state.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->reset_plugin_update_state();
+	}
+
+	/**
+	 * Remove anything the handler may have scheduled or written.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		wp_clear_scheduled_hook( DeleteSpamCron::CRONJOB_NAME );
+		$this->reset_plugin_update_state();
+
+		parent::tear_down();
+	}
+
+	public function test_uninstall_removes_the_plugin_options_when_enabled(): void {
+		$this->seed_install( 'on' );
+
+		PluginStateChangeHandler::uninstall();
+
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'The plugin options have to be removed on uninstall.'
+		);
+		self::assertFalse(
+			get_option( self::DB_VERSION_OPTION ),
+			'The database version has to be removed on uninstall.'
+		);
+	}
+
+	public function test_uninstall_keeps_the_plugin_options_when_disabled(): void {
+		$this->seed_install( '' );
+
+		PluginStateChangeHandler::uninstall();
+
+		self::assertNotFalse(
+			get_option( Settings::OPTION_NAME ),
+			'The plugin options must survive an uninstall that was not opted into.'
+		);
+		self::assertNotFalse(
+			get_option( self::DB_VERSION_OPTION ),
+			'The database version must survive an uninstall that was not opted into.'
+		);
+	}
+
+	/**
+	 * Guards the deferred cleanup tracked in issue #744.
+	 *
+	 * The two deletions are commented out in `maybe_remove_antispam_bee_data()` on purpose
+	 * while v3 is in beta. When they are enabled for the stable 3.0 release, this test
+	 * turns red and documents exactly what has to be inverted.
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_still_keeps_the_legacy_data(): void {
+		$this->seed_install( 'on' );
+
+		$comment_id = self::factory()->comment->create();
+		add_comment_meta( $comment_id, 'antispam_bee_reason', 'css' );
+
+		PluginStateChangeHandler::uninstall();
+
+		self::assertNotFalse(
+			get_option( self::LEGACY_OPTION ),
+			'The legacy option is kept as a safety net until the stable 3.0 release (see #744).'
+		);
+		self::assertSame(
+			'css',
+			get_comment_meta( $comment_id, 'antispam_bee_reason', true ),
+			'The legacy comment meta is kept until the stable 3.0 release (see #744).'
+		);
+	}
+
+	public function test_uninstall_removes_the_options_of_every_site(): void {
+		if ( ! is_multisite() ) {
+			self::markTestSkipped( 'Requires a multisite installation (WP_MULTISITE=1).' );
+		}
+
+		$this->seed_install( 'on' );
+
+		$second_site = self::factory()->blog->create();
+		switch_to_blog( $second_site );
+		$this->seed_install( 'on' );
+		restore_current_blog();
+
+		PluginStateChangeHandler::uninstall();
+
+		switch_to_blog( $second_site );
+		$options_of_second_site = get_option( Settings::OPTION_NAME );
+		restore_current_blog();
+
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'The options of the main site have to be removed.'
+		);
+		self::assertFalse(
+			$options_of_second_site,
+			'The options of every site of the network have to be removed.'
+		);
+	}
+
+	public function test_deactivation_unschedules_the_cron_job(): void {
+		wp_schedule_event( time(), 'daily', DeleteSpamCron::CRONJOB_NAME );
+
+		PluginStateChangeHandler::deactivate();
+
+		self::assertFalse(
+			wp_next_scheduled( DeleteSpamCron::CRONJOB_NAME ),
+			'Deactivating the plugin has to unschedule the cron job.'
+		);
+	}
+
+	/**
+	 * Store an install that opted into (or out of) data removal on uninstall.
+	 *
+	 * @param string $delete_data_on_uninstall Whether to remove the data, `on` or an empty string.
+	 *
+	 * @return void
+	 */
+	private function seed_install( string $delete_data_on_uninstall ): void {
+		update_option(
+			Settings::OPTION_NAME,
+			[
+				'general' => [
+					'general_delete_data_on_uninstall_active' => $delete_data_on_uninstall,
+				],
+			]
+		);
+		update_option( self::DB_VERSION_OPTION, '3.0.0-beta.1' );
+		update_option( self::LEGACY_OPTION, [ 'regexp_check' => 1 ] );
+
+		wp_cache_delete( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Clear the private static caches that make the migration run at most once per request.
+	 *
+	 * Reading the settings triggers `PluginUpdate::maybe_run_plugin_updated_logic()`, so the
+	 * caches leak between tests unless they are reset here as well.
+	 *
+	 * @return void
+	 */
+	private function reset_plugin_update_state(): void {
+		$reflection = new ReflectionClass( PluginUpdate::class );
+
+		$triggered = $reflection->getProperty( 'db_update_triggered' );
+		$triggered->setAccessible( true );
+		$triggered->setValue( null, false );
+
+		$is_current = $reflection->getProperty( 'db_version_is_current' );
+		$is_current->setAccessible( true );
+		$is_current->setValue( null, null );
+
+		wp_cache_delete( Settings::OPTION_NAME );
+	}
+}

--- a/tests/Integration/Handlers/PluginUpdateTest.php
+++ b/tests/Integration/Handlers/PluginUpdateTest.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Integration tests for the v2 to v3 option migration.
+ *
+ * @package AntispamBee\Tests\Integration\Handlers
+ */
+
+namespace AntispamBee\Tests\Integration\Handlers;
+
+use AntispamBee\Handlers\PluginUpdate;
+use AntispamBee\Helpers\Settings;
+use ReflectionClass;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * The migration runs once per site and its result becomes the user's configuration,
+ * so it is asserted against the stored option rather than against a mock.
+ */
+final class PluginUpdateTest extends TestCase {
+
+	/**
+	 * The legacy option written by Antispam Bee 2.x.
+	 *
+	 * @var string
+	 */
+	private const LEGACY_OPTION = 'antispam_bee';
+
+	/**
+	 * The option holding the database revision.
+	 *
+	 * @var string
+	 */
+	private const DB_VERSION_OPTION = 'antispambee_db_version';
+
+	/**
+	 * Reset the plugin state that outlives a single request.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->reset_plugin_update_state();
+	}
+
+	/**
+	 * Reset the plugin state again so a failing test cannot poison the next one.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		$this->reset_plugin_update_state();
+
+		parent::tear_down();
+	}
+
+	public function test_a_complete_v2_option_array_migrates_to_the_v3_structure(): void {
+		$this->seed_legacy_install();
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$options = get_option( Settings::OPTION_NAME );
+
+		self::assertSame(
+			[
+				'post_processor_asb_delete_spam_active' => 'on',
+				'post_processor_asb_send_email_active' => 'on',
+				'post_processor_asb_save_reason_active' => '',
+				'rule_asb_regexp_active'               => '',
+				'rule_asb_honeypot_active'             => 'on',
+				'rule_asb_db_spam_active'              => 'on',
+				'rule_asb_approved_email_active'       => '',
+				'rule_asb_too_fast_submit_active'      => 'on',
+				'post_processor_asb_delete_for_reasons_active' => 'on',
+				'post_processor_asb_delete_for_reasons_reasons' => [
+					'asb-honeypot'  => 'on',
+					'asb-empty'     => 'on',
+					'asb-lang-spam' => 'on',
+				],
+				'rule_asb_bbcode_active'               => '',
+				'rule_asb_valid_gravatar_active'       => 'on',
+				'rule_asb_country_spam_active'         => 'on',
+				'rule_asb_country_spam_denied'         => 'RU,CN',
+				'rule_asb_country_spam_allowed'        => 'DE',
+				'rule_asb_lang_spam_active'            => 'on',
+				'rule_asb_lang_spam_allowed'           => [
+					'de' => 'on',
+					'en' => 'on',
+				],
+			],
+			$options['comment'],
+			'The comment reaction type was not migrated as expected.'
+		);
+
+		self::assertSame(
+			[
+				'post_processor_asb_delete_spam_active' => 'on',
+				'post_processor_asb_send_email_active' => 'on',
+				'post_processor_asb_save_reason_active' => '',
+				'rule_asb_regexp_active'               => '',
+				'rule_asb_db_spam_active'              => 'on',
+				'post_processor_asb_delete_for_reasons_active' => 'on',
+				'post_processor_asb_delete_for_reasons_reasons' => [
+					'asb-honeypot'  => 'on',
+					'asb-empty'     => 'on',
+					'asb-lang-spam' => 'on',
+				],
+				'rule_asb_bbcode_active'               => '',
+				'rule_asb_valid_gravatar_active'       => 'on',
+				'rule_asb_country_spam_active'         => 'on',
+				'rule_asb_country_spam_denied'         => 'RU,CN',
+				'rule_asb_country_spam_allowed'        => 'DE',
+				'rule_asb_lang_spam_active'            => 'on',
+				'rule_asb_lang_spam_allowed'           => [
+					'de' => 'on',
+					'en' => 'on',
+				],
+			],
+			$options['linkback'],
+			'The linkback reaction type was not migrated as expected.'
+		);
+
+		self::assertSame(
+			[
+				'general_delete_spam_cronjob_enabled_active' => 'on',
+				'general_delete_spam_cronjob_enabled_delete_spam_cronjob_days' => 14,
+				'general_statistics_on_dashboard_active' => 'on',
+				'general_ignore_linkbacks_active' => 'on',
+				'general_delete_data_on_uninstall_active' => '',
+			],
+			$options['general'],
+			'The general options were not migrated as expected.'
+		);
+
+		self::assertSame( 4711, $options['spam_count'], 'The spam count was not carried over.' );
+	}
+
+	public function test_spam_reasons_are_mapped_and_removed_reasons_are_dropped(): void {
+		$this->seed_legacy_install(
+			[
+				'reasons_enable' => 1,
+				'ignore_reasons' => [ 'css', 'time', 'empty', 'localdb', 'server', 'country', 'bbcode', 'lang', 'regexp', 'title_is_name', 'manually' ],
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$options = get_option( Settings::OPTION_NAME );
+
+		self::assertSame(
+			[
+				'asb-honeypot'                        => 'on',
+				'asb-too-fast-submit'                 => 'on',
+				'asb-empty'                           => 'on',
+				'asb-db-spam'                         => 'on',
+				'asb-country-spam'                    => 'on',
+				'asb-bbcode'                          => 'on',
+				'asb-lang-spam'                       => 'on',
+				'asb-regexp'                          => 'on',
+				'asb-linkback-post-title-is-blogname' => 'on',
+				'asb-marked-manually'                 => 'on',
+			],
+			$options['comment']['post_processor_asb_delete_for_reasons_reasons'],
+			'The `server` reason maps to null and must not end up in the migrated reasons.'
+		);
+	}
+
+	public function test_a_fresh_install_records_the_version_without_migrating(): void {
+		delete_option( self::DB_VERSION_OPTION );
+		delete_option( Settings::OPTION_NAME );
+		wp_cache_delete( Settings::OPTION_NAME );
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertNotFalse(
+			get_option( self::DB_VERSION_OPTION ),
+			'A fresh install has to record the current database version.'
+		);
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'A fresh install must not write migrated options.'
+		);
+	}
+
+	public function test_the_iphash_comment_meta_is_removed_below_db_version_1_01(): void {
+		$this->seed_legacy_install( [], '1.0' );
+
+		$comment_id = self::factory()->comment->create();
+		add_comment_meta( $comment_id, 'antispam_bee_iphash', 'deadbeef' );
+		add_comment_meta( $comment_id, 'antispam_bee_reason', 'css' );
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertSame(
+			'',
+			get_comment_meta( $comment_id, 'antispam_bee_iphash', true ),
+			'The unused iphash meta has to be deleted.'
+		);
+		self::assertSame(
+			'css',
+			get_comment_meta( $comment_id, 'antispam_bee_reason', true ),
+			'Only the iphash meta may be deleted.'
+		);
+	}
+
+	public function test_the_country_options_are_renamed_below_db_version_1_02(): void {
+		$this->seed_legacy_install(
+			[
+				'country_black' => 'RU',
+				'country_white' => 'DE',
+			],
+			'1.01'
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$legacy = get_option( self::LEGACY_OPTION );
+
+		self::assertSame( 'RU', $legacy['country_denied'], '`country_black` has to become `country_denied`.' );
+		self::assertSame( 'DE', $legacy['country_allowed'], '`country_white` has to become `country_allowed`.' );
+		self::assertArrayNotHasKey( 'country_black', $legacy, 'The old key has to be removed.' );
+		self::assertArrayNotHasKey( 'country_white', $legacy, 'The old key has to be removed.' );
+	}
+
+	public function test_the_iphash_meta_survives_at_db_version_1_02(): void {
+		$this->seed_legacy_install( [], '1.02' );
+
+		$comment_id = self::factory()->comment->create();
+		add_comment_meta( $comment_id, 'antispam_bee_iphash', 'deadbeef' );
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertSame(
+			'deadbeef',
+			get_comment_meta( $comment_id, 'antispam_bee_iphash', true ),
+			'The iphash cleanup must not run again for installs that already passed it.'
+		);
+	}
+
+	public function test_an_install_already_on_3_0_is_not_migrated_again(): void {
+		$this->seed_legacy_install( [], '3.0.0-alpha.1' );
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'An install at or above 3.0.0-alpha.1 must not run the option migration again.'
+		);
+	}
+
+	public function test_the_migration_is_idempotent(): void {
+		$this->seed_legacy_install();
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+		$first_run = get_option( Settings::OPTION_NAME );
+
+		$this->reset_plugin_update_state();
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertSame(
+			$first_run,
+			get_option( Settings::OPTION_NAME ),
+			'Running the update logic twice must not change the migrated options.'
+		);
+	}
+
+	/**
+	 * Store a legacy install: the v2 option array plus the database revision it was left at.
+	 *
+	 * @param array<string, mixed> $overrides   Values replacing the v2 defaults.
+	 * @param string               $db_version  The database revision the install is on.
+	 *
+	 * @return void
+	 */
+	private function seed_legacy_install( array $overrides = [], string $db_version = '1.02' ): void {
+		update_option( self::LEGACY_OPTION, array_merge( $this->legacy_options(), $overrides ) );
+		update_option( self::DB_VERSION_OPTION, $db_version );
+
+		delete_option( Settings::OPTION_NAME );
+		wp_cache_delete( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * A complete v2 option array.
+	 *
+	 * The keys mirror the defaults of Antispam Bee 2.x. Values deliberately deviate from
+	 * those defaults so that a mapping pointing at the wrong source key is visible.
+	 *
+	 * @return array<string, mixed> The v2 options.
+	 */
+	private function legacy_options(): array {
+		return [
+			'regexp_check'             => 0,
+			'spam_ip'                  => 1,
+			'already_commented'        => 0,
+			'gravatar_check'           => 1,
+			'time_check'               => 1,
+			'ignore_pings'             => 1,
+			'dashboard_chart'          => 0,
+			'dashboard_count'          => 1,
+			'country_code'             => 1,
+			'country_denied'           => 'RU,CN',
+			'country_allowed'          => 'DE',
+			'translate_api'            => 1,
+			'translate_lang'           => [ 'de', 'en' ],
+			'bbcode_check'             => 0,
+			'flag_spam'                => 0,
+			'email_notify'             => 1,
+			'no_notice'                => 1,
+			'cronjob_enable'           => 1,
+			'cronjob_interval'         => 14,
+			'ignore_filter'            => 0,
+			'ignore_type'              => 0,
+			'reasons_enable'           => 1,
+			'ignore_reasons'           => [ 'css', 'empty', 'server', 'lang' ],
+			'delete_data_on_uninstall' => 0,
+			'spam_count'               => 4711,
+		];
+	}
+
+	/**
+	 * Clear the private static caches that make the migration run at most once per request.
+	 *
+	 * @return void
+	 */
+	private function reset_plugin_update_state(): void {
+		$reflection = new ReflectionClass( PluginUpdate::class );
+
+		$triggered = $reflection->getProperty( 'db_update_triggered' );
+		$triggered->setAccessible( true );
+		$triggered->setValue( null, false );
+
+		$is_current = $reflection->getProperty( 'db_version_is_current' );
+		$is_current->setAccessible( true );
+		$is_current->setValue( null, null );
+
+		wp_cache_delete( Settings::OPTION_NAME );
+	}
+}

--- a/tests/integration-bootstrap.php
+++ b/tests/integration-bootstrap.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * PHPUnit bootstrap for the integration test suite.
+ *
+ * Boots a real WordPress against a real database. Deliberately does NOT reuse
+ * `tests/bootstrap.php`: that file loads the function stubs from `tests/_stubs/`,
+ * which would shadow the real WordPress functions this suite exists to exercise.
+ *
+ * The WordPress test library is located through the `WP_TESTS_DIR` environment
+ * variable, which `wp-env` sets to `/wordpress-phpunit` inside its `tests-cli`
+ * container. Run the suite with `npm run test:integration`.
+ *
+ * @package AntispamBee
+ */
+
+namespace AntispamBee\Tests;
+
+use Yoast\WPTestUtils\WPIntegration;
+
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+$asb_tests_dir = WPIntegration\get_path_to_wp_test_dir();
+
+if ( false === $asb_tests_dir ) {
+	echo PHP_EOL, 'ERROR: Could not find the WordPress test library. Set the WP_TESTS_DIR ';
+	echo 'environment variable, or run the suite via `npm run test:integration`.', PHP_EOL;
+	exit( 1 );
+}
+
+// Give access to tests_add_filter().
+require_once $asb_tests_dir . 'includes/functions.php';
+
+/*
+ * Load the plugin as a mu-plugin so it is active for every test without going
+ * through the activation hooks.
+ */
+tests_add_filter(
+	'muplugins_loaded',
+	static function () {
+		require dirname( __DIR__ ) . '/antispam_bee.php';
+	}
+);
+
+WPIntegration\bootstrap_it();


### PR DESCRIPTION
Fixes #791.

## Why

`Handlers\PluginUpdate` had no test of any kind, although it is the one code path every upgrading site runs. It executes at most once per install, so a mistake in it silently becomes the user's configuration with no way back.

Neither existing suite could reach it. The unit suite mocks WordPress with Brain Monkey and has no database — `wp_cache_set()` is a no-op stub and `$wpdb` does not exist, so a test would assert against its own mocks. The E2E suite drives a browser against a shared database with `workers: 1`, and the migration fires once from a v2-seeded install and renders nothing.

## The harness

`phpunit.xml.dist` already declared an `integration` suite, but it could never have run: the file has a single `bootstrap` attribute, and `tests/bootstrap.php` loads the function stubs from `tests/_stubs/`, which shadow the real WordPress functions. `tests/Integration/` held only a `.gitkeep`.

The two suites are now split so each gets its own bootstrap. `phpunit-integration.xml.dist` points at `tests/integration-bootstrap.php`, which boots a real WordPress through `yoast/wp-test-utils` and loads the plugin on `muplugins_loaded`.

**No new dependencies.** `wp-env` is already used for the E2E tests and provides WordPress, MySQL *and* the WordPress PHPUnit test library, exporting `WP_TESTS_DIR=/wordpress-phpunit` in its `tests-cli` container. That removes the need for `wp-phpunit`, a WordPress core package and a database service in CI. `yoast/wp-test-utils` was already a dev dependency and ships the integration `TestCase`.

```
npm run test:integration
npm run test:integration:multisite
```

One deliberate deviation from the unit config: `convertDeprecationsToExceptions` is off, because WordPress core emits deprecations of its own on recent PHP versions. Warnings and notices are still converted, which is what catches undefined array keys in the code under test.

## Coverage

13 tests, green on single site and on multisite.

**Migration** (`tests/Integration/Handlers/PluginUpdateTest.php`) — asserted against the stored option, not a mock:

* a complete v2 array maps to the expected `comment`, `linkback` and `general` structures. The fixture's values deliberately deviate from the v2 defaults, so a mapping reading the wrong source key is visible rather than accidentally correct
* every spam reason is mapped, and `server`, which maps to `null`, is dropped
* the `antispam_bee_iphash` comment meta is deleted below database version 1.01 — and only that meta
* `country_black` / `country_white` are renamed below database version 1.02
* version gating, fresh install, and idempotence

`maybe_update_database()` is private and both of its guards are private statics with no reset, so the tests drive the public `maybe_run_plugin_updated_logic()` and clear them by reflection. Reading the settings calls that method, so the reset also has to happen in `tear_down()`.

**Uninstall** (`tests/Integration/Handlers/PluginStateChangeHandlerTest.php`):

* options removed when the user opted in; kept when not. Note an absent option row falls back to `Settings::$defaults`, where removal is *enabled*, so the opt-out has to be persisted explicitly
* every site of a network is cleaned up, exercising the real `switch_to_blog()` loop
* deactivation unschedules the cron job
* `test_uninstall_still_keeps_the_legacy_data()` pins the deferred cleanup from #744: it turns red when those two commented-out deletions are enabled for the stable release, and documents what has to be inverted then

## Two bugs found, filed separately

Both are in `3.0.0-beta.2` and deliberately not fixed here, to keep this reviewable:

* **#792** — `DeleteSpamCron` reads `general.delete_spam_cronjob_enabled`, while the settings UI and the migration both write `general.general_delete_spam_cronjob_enabled_active`. "Delete existing spam after N days" never registers and never runs.
* **#793** — 15 legacy keys are read without `??`, so a partial v2 array warns. Worse, `antispambee_db_version` is bumped *before* the migration runs, so on a site that converts warnings to exceptions the migration aborts and never runs again — silent, unrecoverable loss of the configuration.

## Verification

```
npm run test:integration              # 13 tests, 23 assertions, 1 skipped (multisite)
npm run test:integration:multisite    # 13 tests, 25 assertions
composer test:unit                    # 62 tests, 150 assertions — unchanged
composer phpstan                      # no errors
composer cs                           # clean
```

The migration assertions were mutation-tested: breaking a mapping in `PluginUpdate` and a value in the `$new_options` structure both turn the suite red, so they bite rather than merely pass.
