### PR TITLE
feat: add a public spam check API for third-party integrations

### DIFF
--- a/docs/adding-rules.md
+++ b/docs/adding-rules.md
@@ -1,6 +1,8 @@
 # Adding rules
 
-ASB 3 makes it possible for third-party plugins to add custom rules.
+ASB 3 makes it possible for third-party plugins to add custom rules. If you instead want your own
+content checked by the rules that already exist, see
+[Integrating your own content](integrating-own-content.md).
 
 Each Rule is a class that extends the `ControllableBase` (if your rule has options, like for
 disabling/enabling) or `Base` (if your rule works invisible in the background) class and implements
@@ -16,3 +18,33 @@ honeypot field). Final rules are checked before all other rules, and a positive 
 item as spam immediately, without evaluating the remaining rules. The finals-first ordering can be
 disabled with the `antispam_bee_sort_final_rules_first` filter (return `false`), in which case all
 rules are checked in their registered order.
+
+## Registering a rule
+
+Rules are registered by adding their class name to the `antispam_bee_rules` filter. Extending `Base`
+or `ControllableBase` gives you an `init()` method that does this, so calling it is enough:
+
+```php
+add_action(
+    'plugins_loaded',
+    function (): void {
+        if ( class_exists( '\AntispamBee\Rules\Base' ) ) {
+            \My_Plugin\Rules\My_Rule::init();
+        }
+    }
+);
+```
+
+The `asb-` slug prefix is reserved for the rules that ship with Antispam Bee. Rules from other
+plugins using that prefix are rejected, so pick a prefix of your own.
+
+Which reaction types a rule applies to is declared with the `$supported_types` property, which
+defaults to comments and linkbacks. A rule extending `ControllableBase` is only applied when it is
+active for the reaction type, which means it needs a default or an administrator enabling it — see
+[Integrating your own content](integrating-own-content.md) for how that works.
+
+## Payload
+
+`verify()` receives the normalized payload, not the raw reaction. Its attributes are the same ones
+listed in [Integrating your own content](integrating-own-content.md), so a rule that reads `body` and
+`email` works for comments, linkbacks and any reaction type a third-party plugin registers.

--- a/docs/integrating-own-content.md
+++ b/docs/integrating-own-content.md
@@ -162,13 +162,15 @@ affected by this at all.
 If you enable the [debug mode](https://antispambee.pluginkollektiv.org/documentation/), Antispam Bee
 logs when it finds no active rule for a reaction type, which makes both of these cases visible.
 
-## Reacting to spam the way Antispam Bee does
+## Reacting to spam
 
-`check()` only classifies. It does not count the item, store a reason, notify anybody, or delete
-anything. If you handle storage and notification yourself, that is all you need.
+`check()` only classifies. It does not store anything, notify anybody, or delete anything. Deciding
+what happens to a spam submission is your plugin’s job, and for most integrations doing that directly
+is all you need.
 
-To have Antispam Bee react as it does to its own spam — updating the spam counter and the statistics,
-sending notifications — pass the result to the post-processors:
+If you want that handling to be pluggable — so that site owners or add-ons can change it, and so it
+can be switched on and off from the Antispam Bee settings page — write it as a post-processor and run
+the post-processors for your reaction type:
 
 ```php
 if ( $result->is_spam() ) {
@@ -180,8 +182,57 @@ if ( $result->is_spam() ) {
 }
 ```
 
-Without this, the spam your integration catches will not show up in Antispam Bee’s spam count or
-dashboard widget.
+Note that `post_process()` runs the post-processors registered for **your** reaction type. Out of the
+box that is none, so the call does nothing until you register one — see below.
+
+### Antispam Bee’s own post-processors are comment-specific
+
+The post-processors that ship with Antispam Bee support the `comment` and `linkback` reaction types
+only, and that is deliberate rather than an omission: they are implementations for WordPress comments,
+not generic hooks. Saving a spam reason writes comment meta, the notification email is built from a
+stored comment and worded for one, and deletion is carried out by the comment handler. The spam
+counter is shown in WordPress’ *At a Glance* dashboard widget next to the comment counts, and is
+labelled as a number of spam comments.
+
+So please do not opt them into a custom reaction type with
+`antispam_bee_post_processor_supported_types`. They would either do nothing or produce results that
+are wrong for your content — and the count of blocked spam comments would no longer be a count of
+comments. Write your own instead.
+
+### Registering your own post-processor
+
+A post-processor implements `\AntispamBee\Interfaces\PostProcessor`, or extends
+`\AntispamBee\PostProcessors\Base` (or `ControllableBase`, if it should be switchable on your settings
+tab) and is registered on the `antispam_bee_post_processors` filter. As with rules, extending the base
+class gives you an `init()` method that does the registration:
+
+```php
+namespace My_Plugin\PostProcessors;
+
+class Store_Submission extends \AntispamBee\PostProcessors\Base {
+
+    protected static $slug = 'my-plugin-store-submission';
+
+    protected static $supported_types = [ 'my_plugin_form' ];
+
+    public static function process( array $item ): array {
+        // $item['asb_reasons'] holds the rule slugs that flagged the submission.
+        return $item;
+    }
+}
+```
+
+`process()` receives the item you passed to `post_process()`, with `asb_reasons` and `reaction_type`
+added, and returns it for the next post-processor. Set `$marks_as_delete` to `true` if your
+post-processor decides an item should not be stored; those run first, and they signal the decision by
+setting `asb_marked_as_delete` on the item — acting on that flag is up to the caller.
+
+Extending `ControllableBase` instead gives the post-processor a checkbox on the settings tab of its
+reaction type. It then also needs `get_name()` and `get_label()` from the `Controllable` interface, and
+it only runs when it is active — so give it a default, the same way rules need one.
+
+The `asb-` slug prefix is reserved for the post-processors that ship with Antispam Bee, so pick a
+prefix of your own.
 
 ## Adding your own rules
 

--- a/docs/integrating-own-content.md
+++ b/docs/integrating-own-content.md
@@ -1,0 +1,188 @@
+# Integrating your own content
+
+Plugins that handle their own content — contact forms, registrations, custom post types — can have
+Antispam Bee classify that content. This page describes the supported way to do that.
+
+`\AntispamBee\Api\SpamCheck` is the entry point. Everything outside the `\AntispamBee\Api` namespace
+and the documented hooks is internal and may change in any release, so please do not call
+`\AntispamBee\Handlers\Rules` or `\AntispamBee\Handlers\PostProcessors` directly.
+
+## Checking an item
+
+```php
+if ( ! class_exists( '\AntispamBee\Api\SpamCheck' ) ) {
+    return;
+}
+
+$result = \AntispamBee\Api\SpamCheck::check(
+    [
+        'author' => $name,
+        'body'   => $message,
+        'email'  => $email,
+        'url'    => $website,
+    ],
+    'my_plugin_form'
+);
+
+if ( $result->is_spam() ) {
+    // Store the slugs, not the texts – see “Spam reasons” below.
+    $reasons = $result->get_reasons();
+}
+```
+
+The item is normalized before the rules see it, so you only need to pass the attributes your content
+actually has. Recognized attributes:
+
+| Attribute   | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `author`    | Name of the author.                                                         |
+| `body`      | The content to check.                                                       |
+| `email`     | Email address of the author.                                                |
+| `url`       | A URL submitted with the content, like a website field.                     |
+| `host`      | Host of that URL. Derived from `url` when omitted.                          |
+| `ip`        | IP address of the author. Defaults to the IP of the current request.        |
+| `useragent` | User agent of the author. Defaults to the one of the current request.       |
+| `post_id`   | ID of a related post, if any.                                               |
+
+Anything you leave out defaults to an empty value. Use the `antispam_bee_api_payload` filter if you
+need to adjust the normalized payload.
+
+`check()` returns an `\AntispamBee\Api\CheckResult`:
+
+* `is_spam()` – whether the item was classified as spam.
+* `get_reasons()` – slugs of the rules that flagged it.
+* `get_reason_texts()` – human-readable texts for those slugs.
+* `get_payload()` – the normalized payload the rules were applied to.
+* `was_evaluated()` – whether any rule ran at all, see below.
+
+## Nothing is checked until a rule is active
+
+A result can report no spam simply because no rule was active for your reaction type, and that is
+the most common reason an integration appears to do nothing. Use `was_evaluated()` on a result, or
+`SpamCheck::has_active_rules()` up front, to tell that apart from a clean item — for example to warn
+an administrator while setting things up:
+
+```php
+if ( ! \AntispamBee\Api\SpamCheck::has_active_rules( 'my_plugin_form' ) ) {
+    // No rule is enabled for this reaction type, nothing will be caught.
+}
+```
+
+## Using your own reaction type
+
+Reusing `comment` means your content is checked with the rules and options the site owner configured
+for comments. That is a reasonable starting point, but a custom reaction type gets its own settings
+tab, so rules can be enabled for your content independently.
+
+Three hooks are involved:
+
+```php
+// 1. Register the reaction type so it has a readable name.
+add_filter(
+    'antispam_bee_reaction_types',
+    function ( array $types ): array {
+        $types['my_plugin_form'] = __( 'My plugin', 'my-plugin' );
+
+        return $types;
+    }
+);
+
+// 2. Opt existing rules into the reaction type. This is also what creates its settings tab.
+add_filter(
+    'antispam_bee_rule_supported_types',
+    function ( array $supported_types, string $slug ): array {
+        if ( in_array( $slug, [ 'asb-bbcode', 'asb-regexp' ], true ) ) {
+            $supported_types[] = 'my_plugin_form';
+        }
+
+        return $supported_types;
+    },
+    10,
+    2
+);
+
+// 3. Declare which of those rules should be active out of the box.
+add_filter(
+    'antispam_bee_default_options',
+    function ( array $defaults ): array {
+        $defaults['my_plugin_form'] = [
+            'rule_asb_bbcode_active' => 'on',
+            'rule_asb_regexp_active' => 'on',
+        ];
+
+        return $defaults;
+    }
+);
+```
+
+Step 3 matters: most rules are only applied when they are active for the reaction type, and a fresh
+reaction type has no stored options, so without defaults nothing is checked until an administrator
+enables rules on the new settings tab. Defaults only apply to reaction types that are absent from the
+stored options — once a reaction type has been saved, the stored state wins, so a rule that an
+administrator deliberately disabled stays disabled.
+
+Post-processors can be opted in the same way, via `antispam_bee_post_processor_supported_types`.
+
+## Spam reasons
+
+`get_reasons()` returns rule slugs. Store those, and resolve them to texts with
+`get_reason_texts()` at the moment you display them — the slug-to-text map is populated on the `init`
+action, so resolving too early yields placeholders.
+
+For slugs you stored earlier and no longer have a result for, `SpamCheck::get_reason_texts()` resolves
+them directly:
+
+```php
+$texts = \AntispamBee\Api\SpamCheck::get_reason_texts( $stored_slugs );
+```
+
+## AJAX and REST requests
+
+Antispam Bee skips its module initialization during AJAX requests, and rules register themselves
+during that initialization. If your submission is handled over AJAX, no rule will be registered and
+`check()` will find nothing to apply. Allow initialization for your own request:
+
+```php
+add_filter(
+    'antispam_bee_disallow_ajax_calls',
+    function ( bool $disallow ): bool {
+        $action = sanitize_key( wp_unslash( $_REQUEST['action'] ?? '' ) );
+
+        return 'my-plugin-submit' === $action ? false : $disallow;
+    }
+);
+```
+
+Register this filter early — while your plugin file loads, not on `plugins_loaded` — because
+Antispam Bee evaluates it during its own `plugins_loaded` callback.
+
+REST requests are not AJAX requests as far as `wp_doing_ajax()` is concerned, so they are not
+affected by this at all.
+
+If you enable the [debug mode](https://antispambee.pluginkollektiv.org/documentation/), Antispam Bee
+logs when it finds no active rule for a reaction type, which makes both of these cases visible.
+
+## Reacting to spam the way Antispam Bee does
+
+`check()` only classifies. It does not count the item, store a reason, notify anybody, or delete
+anything. If you handle storage and notification yourself, that is all you need.
+
+To have Antispam Bee react as it does to its own spam — updating the spam counter and the statistics,
+sending notifications — pass the result to the post-processors:
+
+```php
+if ( $result->is_spam() ) {
+    $item = \AntispamBee\Api\SpamCheck::post_process( $result, $my_item, 'my_plugin_form' );
+
+    if ( isset( $item['asb_marked_as_delete'] ) ) {
+        // A post-processor decided this item should not be stored at all.
+    }
+}
+```
+
+Without this, the spam your integration catches will not show up in Antispam Bee’s spam count or
+dashboard widget.
+
+## Adding your own rules
+
+See [Adding rules](adding-rules.md).

--- a/docs/program-flow.md
+++ b/docs/program-flow.md
@@ -24,7 +24,10 @@
            $is_spam = $rules->apply( $reaction );
            ```
            Where `$reaction` is an array of comment data. The `apply` method returns a boolean
-           indicating if the reaction is spam or not.
+           indicating if the reaction is spam or not.\
+           Note that `\AntispamBee\Handlers\Rules` is internal. Other plugins that want their own
+           content checked should use `\AntispamBee\Api\SpamCheck` instead, see
+           [Integrating your own content](integrating-own-content.md).
         2. If it is spam, you can apply the post processors (code snippet from the
            `\AntispamBee\Handlers\Reaction::process` method):
            ```php

--- a/src/Api/CheckResult.php
+++ b/src/Api/CheckResult.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Result of a spam check.
+ *
+ * @package AntispamBee\Api
+ */
+
+namespace AntispamBee\Api;
+
+/**
+ * Immutable value object describing the outcome of a spam check.
+ *
+ * Instances are created by {@see SpamCheck::check()}. Third-party code should
+ * not construct them directly.
+ *
+ * @since 3.0.0
+ */
+final class CheckResult {
+
+	/**
+	 * Whether the item was classified as spam.
+	 *
+	 * @var bool
+	 */
+	private $is_spam;
+
+	/**
+	 * Slugs of the rules that classified the item as spam.
+	 *
+	 * @var string[]
+	 */
+	private $reasons;
+
+	/**
+	 * The normalized payload the rules were applied to.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $payload;
+
+	/**
+	 * Whether any rule was actually evaluated.
+	 *
+	 * @var bool
+	 */
+	private $was_evaluated;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool                 $is_spam       Whether the item is spam.
+	 * @param string[]             $reasons       Slugs of the rules that flagged the item.
+	 * @param array<string, mixed> $payload       The normalized payload that was checked.
+	 * @param bool                 $was_evaluated Whether any rule was evaluated.
+	 */
+	public function __construct( bool $is_spam, array $reasons, array $payload, bool $was_evaluated = true ) {
+		$this->is_spam       = $is_spam;
+		$this->reasons       = $reasons;
+		$this->payload       = $payload;
+		$this->was_evaluated = $was_evaluated;
+	}
+
+	/**
+	 * Create a result for an item that could not be evaluated.
+	 *
+	 * @param array<string, mixed> $payload The normalized payload.
+	 *
+	 * @return self A result reporting no spam and no evaluation.
+	 */
+	public static function not_evaluated( array $payload ): self {
+		return new self( false, [], $payload, false );
+	}
+
+	/**
+	 * Whether the item was classified as spam.
+	 *
+	 * @return bool Whether the item is spam.
+	 */
+	public function is_spam(): bool {
+		return $this->is_spam;
+	}
+
+	/**
+	 * Whether any rule was evaluated.
+	 *
+	 * A result can report no spam simply because no rule was active for the
+	 * reaction type. Callers that want to distinguish “checked and clean” from
+	 * “not checked at all” — for example to warn an administrator that no rule
+	 * is enabled — should consult this method.
+	 *
+	 * @return bool Whether at least one rule was evaluated.
+	 */
+	public function was_evaluated(): bool {
+		return $this->was_evaluated;
+	}
+
+	/**
+	 * Get the slugs of the rules that flagged the item as spam.
+	 *
+	 * These slugs are the stable representation, to be translated later. Persist
+	 * these rather than the texts from {@see self::get_reason_texts()}.
+	 *
+	 * @return string[] A list of rule slugs.
+	 */
+	public function get_reasons(): array {
+		return $this->reasons;
+	}
+
+	/**
+	 * Get human-readable texts for the spam reasons.
+	 *
+	 * Only useful once the `init` action has run, because the underlying slug
+	 * map is populated on `init`. When resolving reasons for display later (for
+	 * example in an admin table), persist the slugs from
+	 * {@see self::get_reasons()} and call this method at render time.
+	 *
+	 * @return string[] A list of reason texts.
+	 */
+	public function get_reason_texts(): array {
+		return SpamCheck::get_reason_texts( $this->reasons );
+	}
+
+	/**
+	 * Get the normalized payload the rules were applied to.
+	 *
+	 * Useful when passing the item on to {@see SpamCheck::post_process()}, and
+	 * for debugging what the rules actually saw.
+	 *
+	 * @return array<string, mixed> The normalized payload.
+	 */
+	public function get_payload(): array {
+		return $this->payload;
+	}
+}

--- a/src/Api/SpamCheck.php
+++ b/src/Api/SpamCheck.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Public entry point for third-party spam checks.
+ *
+ * @package AntispamBee\Api
+ */
+
+namespace AntispamBee\Api;
+
+use AntispamBee\Handlers\PostProcessors;
+use AntispamBee\Handlers\Rules;
+use AntispamBee\Helpers\DataHelper;
+use AntispamBee\Helpers\DebugMode;
+use AntispamBee\Helpers\IpHelper;
+use AntispamBee\Helpers\SpamReasonTextHelper;
+use ReflectionException;
+
+/**
+ * Public entry point for third-party spam checks.
+ *
+ * Plugins that handle their own content — contact forms, registrations, custom
+ * post types — can use this class to have Antispam Bee’s rules classify that
+ * content, without depending on the plugin’s internal handlers.
+ *
+ * Everything outside `AntispamBee\Api` and the documented hooks is internal and
+ * may change in any release.
+ *
+ * Typical use:
+ *
+ *     if ( class_exists( '\AntispamBee\Api\SpamCheck' ) ) {
+ *         $result = \AntispamBee\Api\SpamCheck::check(
+ *             [
+ *                 'author' => $name,
+ *                 'body'   => $message,
+ *                 'email'  => $email,
+ *             ],
+ *             'my_plugin_form'
+ *         );
+ *
+ *         if ( $result->is_spam() ) {
+ *             // Store the reason slugs for later display.
+ *             $reasons = $result->get_reasons();
+ *         }
+ *     }
+ *
+ * @since 3.0.0
+ */
+final class SpamCheck {
+
+	/**
+	 * Version of this API.
+	 *
+	 * Incremented only for breaking changes, so integrations can adapt.
+	 *
+	 * @var int
+	 */
+	const API_VERSION = 1;
+
+	/**
+	 * Check an item for spam.
+	 *
+	 * The item is normalized before the rules see it, so callers only need to
+	 * provide the attributes their content actually has. Missing attributes
+	 * default to an empty value; `host` is derived from `url`, and `ip` and
+	 * `useragent` fall back to the current request.
+	 *
+	 * @param array<string, mixed> $item          Item attributes. Recognized keys are
+	 *                                            `author`, `body`, `email`, `url`, `host`,
+	 *                                            `ip`, `useragent` and `post_id`.
+	 * @param string               $reaction_type The reaction type to check against. Register
+	 *                                            a custom one via `antispam_bee_reaction_types`
+	 *                                            and opt rules into it via
+	 *                                            `antispam_bee_rule_supported_types`.
+	 *
+	 * @return CheckResult The outcome of the check.
+	 */
+	public static function check( array $item, string $reaction_type ): CheckResult {
+		$payload = self::normalize( $item, $reaction_type );
+
+		try {
+			$active_rules = Rules::get( $reaction_type, true );
+		} catch ( ReflectionException $exception ) {
+			DebugMode::log( "SpamCheck: could not collect rules for reaction type {$reaction_type}: " . $exception->getMessage() );
+
+			return CheckResult::not_evaluated( $payload );
+		}
+
+		if ( [] === $active_rules ) {
+			DebugMode::log( "SpamCheck: no active rule for reaction type {$reaction_type}, item was not evaluated." );
+
+			return CheckResult::not_evaluated( $payload );
+		}
+
+		$rules = new Rules( $reaction_type );
+
+		try {
+			$is_spam = $rules->apply( $payload );
+		} catch ( ReflectionException $exception ) {
+			DebugMode::log( "SpamCheck: could not apply rules for reaction type {$reaction_type}: " . $exception->getMessage() );
+
+			return CheckResult::not_evaluated( $payload );
+		}
+
+		return new CheckResult(
+			$is_spam,
+			$is_spam ? $rules->get_spam_reasons() : [],
+			$payload
+		);
+	}
+
+	/**
+	 * Whether at least one rule is active for a reaction type.
+	 *
+	 * Useful to warn administrators that a custom reaction type has no rule
+	 * enabled yet, which would let every item pass.
+	 *
+	 * @param string $reaction_type The reaction type.
+	 *
+	 * @return bool Whether at least one rule is active.
+	 */
+	public static function has_active_rules( string $reaction_type ): bool {
+		try {
+			return [] !== Rules::get( $reaction_type, true );
+		} catch ( ReflectionException $exception ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Get human-readable texts for a list of spam reason slugs.
+	 *
+	 * Use this to resolve slugs that were stored earlier, for example when
+	 * rendering them in an admin table. Only useful once the `init` action has
+	 * run, because the underlying slug map is populated on `init`.
+	 *
+	 * @param string[] $slugs A list of rule slugs.
+	 *
+	 * @return string[] A list of reason texts.
+	 */
+	public static function get_reason_texts( array $slugs ): array {
+		if ( [] === $slugs ) {
+			return [];
+		}
+
+		return SpamReasonTextHelper::get_texts_by_slugs( $slugs );
+	}
+
+	/**
+	 * Run the post-processors for an item that was classified as spam.
+	 *
+	 * Optional second half of the flow. Call this to have Antispam Bee react to
+	 * the spam the way it reacts to its own — updating the spam counter and
+	 * statistics, sending notifications, and so on. Skip it if the calling
+	 * plugin handles storage and notification itself.
+	 *
+	 * Post-processors must opt into the reaction type via
+	 * `antispam_bee_post_processor_supported_types`.
+	 *
+	 * @param CheckResult          $result        The result returned by {@see self::check()}.
+	 * @param array<string, mixed> $reaction      The caller’s own representation of the item.
+	 * @param string               $reaction_type The reaction type.
+	 *
+	 * @return array<string, mixed> The processed item. A set `asb_marked_as_delete`
+	 *                              key means the post-processors decided the item
+	 *                              should be discarded rather than stored.
+	 */
+	public static function post_process( CheckResult $result, array $reaction, string $reaction_type ): array {
+		if ( ! $result->is_spam() ) {
+			return $reaction;
+		}
+
+		return PostProcessors::apply( $reaction_type, $reaction, $result->get_reasons() );
+	}
+
+	/**
+	 * Normalize a caller-supplied item into the payload the rules expect.
+	 *
+	 * @param array<string, mixed> $item          Item attributes.
+	 * @param string               $reaction_type The reaction type.
+	 *
+	 * @return array<string, mixed> The normalized payload.
+	 */
+	private static function normalize( array $item, string $reaction_type ): array {
+		$payload = [
+			'reaction_type' => $reaction_type,
+			'author'        => (string) ( $item['author'] ?? '' ),
+			'body'          => (string) ( $item['body'] ?? '' ),
+			'email'         => (string) ( $item['email'] ?? '' ),
+			'url'           => (string) ( $item['url'] ?? '' ),
+			'ip'            => (string) ( $item['ip'] ?? IpHelper::get_client_ip() ),
+			'useragent'     => (string) ( $item['useragent'] ?? self::get_client_useragent() ),
+			'post_id'       => (int) ( $item['post_id'] ?? 0 ),
+		];
+
+		$payload['host'] = (string) ( $item['host'] ?? '' );
+
+		if ( '' === $payload['host'] && '' !== $payload['url'] ) {
+			$payload['host'] = DataHelper::parse_url( $payload['url'] );
+		}
+
+		/**
+		 * Filters the normalized payload before the rules are applied.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array  $payload       The normalized payload.
+		 * @param array  $item          The item as passed to the API.
+		 * @param string $reaction_type The reaction type.
+		 */
+		return (array) apply_filters( 'antispam_bee_api_payload', $payload, $item, $reaction_type );
+	}
+
+	/**
+	 * Get the user agent of the current request.
+	 *
+	 * @return string The user agent, or an empty string.
+	 */
+	private static function get_client_useragent(): string {
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+	}
+}

--- a/src/Handlers/PostProcessors.php
+++ b/src/Handlers/PostProcessors.php
@@ -14,6 +14,9 @@ use ReflectionException;
 
 /**
  * Post-processors.
+ *
+ * @internal Third-party code should use {@see \AntispamBee\Api\SpamCheck::post_process()}
+ *           instead. This class is an implementation detail and may change in any release.
  */
 class PostProcessors {
 	/**

--- a/src/Handlers/Rules.php
+++ b/src/Handlers/Rules.php
@@ -16,6 +16,9 @@ use ReflectionException;
 
 /**
  * Rules.
+ *
+ * @internal Third-party code should use {@see \AntispamBee\Api\SpamCheck} instead.
+ *           This class is an implementation detail and may change in any release.
  */
 class Rules {
 
@@ -126,6 +129,10 @@ class Rules {
 	 */
 	public function apply( array $item ): bool {
 		$rules = self::get( $this->reaction_type, true );
+
+		if ( empty( $rules ) ) {
+			DebugMode::log( "No active rule for reaction type {$this->reaction_type}, the item was not checked." );
+		}
 
 		/**
 		 * Filters the score threshold below which a reaction is considered no spam.

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -95,13 +95,58 @@ class Settings {
 	 */
 	public static function get_options(): array {
 		PluginUpdate::maybe_run_plugin_updated_logic();
-		$options = wp_cache_get( self::OPTION_NAME );
-		if ( $options ) {
-			return $options;
+		$defaults = self::get_defaults();
+		$options  = wp_cache_get( self::OPTION_NAME );
+
+		if ( ! $options ) {
+			$options = get_option( self::OPTION_NAME, $defaults );
+			wp_cache_set( self::OPTION_NAME, $options );
 		}
 
-		$options = get_option( self::OPTION_NAME, self::$defaults );
-		wp_cache_set( self::OPTION_NAME, $options );
+		return self::add_missing_defaults( is_array( $options ) ? $options : [], $defaults );
+	}
+
+	/**
+	 * Get the default options.
+	 *
+	 * @return array<string, array<string, mixed>> The default options, keyed by reaction type.
+	 */
+	public static function get_defaults(): array {
+		/**
+		 * Filters the default options, keyed by reaction type.
+		 *
+		 * Plugins that register a custom reaction type can use this filter to
+		 * declare which rules and post-processors should be active for it out of
+		 * the box. Without defaults, every controllable rule starts inactive for
+		 * a custom reaction type, so nothing is checked until an administrator
+		 * enables rules on its settings tab.
+		 *
+		 * Defaults only apply to reaction types that are absent from the stored
+		 * options. As soon as a reaction type has been saved, the stored state
+		 * wins — otherwise a rule an administrator deliberately disabled would be
+		 * re-enabled on the next request.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array $defaults The default options, keyed by reaction type.
+		 */
+		return (array) apply_filters( 'antispam_bee_default_options', self::$defaults );
+	}
+
+	/**
+	 * Fill in the defaults of reaction types that are absent from the stored options.
+	 *
+	 * @param array<string, mixed>                $options  The stored options.
+	 * @param array<string, array<string, mixed>> $defaults The default options.
+	 *
+	 * @return array<string, mixed> The options, with missing reaction types defaulted.
+	 */
+	private static function add_missing_defaults( array $options, array $defaults ): array {
+		foreach ( $defaults as $reaction_type => $default_options ) {
+			if ( ! isset( $options[ $reaction_type ] ) && is_array( $default_options ) ) {
+				$options[ $reaction_type ] = $default_options;
+			}
+		}
 
 		return $options;
 	}

--- a/src/PostProcessors/SaveReason.php
+++ b/src/PostProcessors/SaveReason.php
@@ -32,6 +32,13 @@ class SaveReason extends ControllableBase {
 			return $item;
 		}
 
+		// The reason is stored as comment meta, so the item has to become a comment.
+		if ( ! isset( $item['comment_post_ID'] ) ) {
+			$item['asb_post_processors_failed'][] = self::get_slug();
+
+			return $item;
+		}
+
 		if ( ! isset( $item['asb_reasons'] ) ) {
 			$item['asb_post_processors_failed'][] = self::get_slug();
 

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -36,6 +36,13 @@ class SendEmail extends ControllableBase {
 			return $item;
 		}
 
+		// The notification is built from the stored comment, so the item has to become one.
+		if ( ! isset( $item['comment_post_ID'] ) ) {
+			$item['asb_post_processors_failed'][] = self::get_slug();
+
+			return $item;
+		}
+
 		add_action(
 			'comment_post',
 			function ( $id ) use ( $item ) {

--- a/tests/Unit/Api/CheckResultTest.php
+++ b/tests/Unit/Api/CheckResultTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Api;
+
+use AntispamBee\Api\CheckResult;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see CheckResult}.
+ */
+class CheckResultTest extends TestCase {
+
+	public function test_exposes_the_check_outcome(): void {
+		$payload = [
+			'reaction_type' => 'test_reaction',
+			'body'          => 'Spam',
+		];
+		$result  = new CheckResult( true, [ 'asb-bbcode' ], $payload );
+
+		self::assertTrue( $result->is_spam(), 'the item should be reported as spam' );
+		self::assertTrue( $result->was_evaluated(), 'a constructed result should be evaluated by default' );
+		self::assertSame( [ 'asb-bbcode' ], $result->get_reasons(), 'the reason slugs should be exposed' );
+		self::assertSame( $payload, $result->get_payload(), 'the payload should be exposed unchanged' );
+	}
+
+	public function test_not_evaluated_reports_no_spam_and_no_evaluation(): void {
+		$payload = [ 'reaction_type' => 'test_reaction' ];
+		$result  = CheckResult::not_evaluated( $payload );
+
+		self::assertFalse( $result->is_spam(), 'an unevaluated item should not be spam' );
+		self::assertFalse( $result->was_evaluated(), 'the result should report that nothing was evaluated' );
+		self::assertSame( [], $result->get_reasons(), 'an unevaluated item should carry no reasons' );
+		self::assertSame( $payload, $result->get_payload(), 'the payload should still be exposed' );
+	}
+
+	/**
+	 * Without reasons there is nothing to resolve, so the helper — which is only
+	 * populated on `init` — must not be consulted at all.
+	 */
+	public function test_reason_texts_are_empty_without_reasons(): void {
+		$result = new CheckResult( false, [], [] );
+
+		self::assertSame( [], $result->get_reason_texts(), 'no reasons should resolve to no texts' );
+	}
+
+	public function test_reason_texts_are_resolved_via_the_helper(): void {
+		when( 'esc_html' )->returnArg();
+		when( 'esc_html_x' )->returnArg();
+
+		$result = new CheckResult( true, [ 'unregistered-rule' ], [] );
+
+		self::assertSame(
+			[ 'Unknown rule: unregistered-rule' ],
+			$result->get_reason_texts(),
+			'reason texts should be resolved through SpamReasonTextHelper'
+		);
+	}
+}

--- a/tests/Unit/Api/SpamCheckTest.php
+++ b/tests/Unit/Api/SpamCheckTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Api;
+
+use AntispamBee\Api\SpamCheck;
+use AntispamBee\Rules\Base;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'AntispamBee\PLUGIN_PATH' ) ) {
+	define( 'AntispamBee\PLUGIN_PATH', dirname( __DIR__, 3 ) . DIRECTORY_SEPARATOR );
+}
+
+/**
+ * Test rule that records the payload it was given.
+ */
+class SpamCheckTestRule extends Base {
+	protected static $slug            = 'test-spam-check';
+	protected static $supported_types = [ 'test_reaction' ];
+
+	public static $score = 0;
+
+	/**
+	 * The payload of the last verification.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public static $item = [];
+
+	public static function verify( array $item ): int {
+		self::$item = $item;
+
+		return self::$score;
+	}
+
+	public static function get_name(): string {
+		return 'Spam check test rule';
+	}
+}
+
+/**
+ * Unit tests for {@see SpamCheck}.
+ *
+ * @backupGlobals enabled
+ */
+class SpamCheckTest extends TestCase {
+
+	protected function set_up(): void {
+		parent::set_up();
+
+		SpamCheckTestRule::$score = 0;
+		SpamCheckTestRule::$item  = [];
+
+		when( 'wp_unslash' )->returnArg();
+		when( 'sanitize_text_field' )->returnArg();
+		when( 'wp_parse_url' )->alias(
+			static function ( $url ) {
+				return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+			}
+		);
+	}
+
+	/**
+	 * Register the test rule as the only rule.
+	 */
+	private function register_test_rule(): void {
+		expectApplied( 'antispam_bee_rules' )
+			->andReturn( [ SpamCheckTestRule::class ] );
+	}
+
+	public function test_derives_host_from_url_and_defaults_request_attributes(): void {
+		global $_SERVER;
+
+		$this->register_test_rule();
+
+		$_SERVER['REMOTE_ADDR']     = '192.0.2.5';
+		$_SERVER['HTTP_USER_AGENT'] = 'Test user agent';
+
+		SpamCheck::check(
+			[
+				'author' => 'Spammy McSpam',
+				'body'   => 'Buy all the things',
+				'email'  => 'spam@example.com',
+				'url'    => 'https://spam.example.com/landing-page',
+			],
+			'test_reaction'
+		);
+
+		$item = SpamCheckTestRule::$item;
+
+		self::assertSame( 'spam.example.com', $item['host'], 'host should be derived from the url' );
+		self::assertSame( '192.0.2.5', $item['ip'], 'ip should default to the current request' );
+		self::assertSame( 'Test user agent', $item['useragent'], 'useragent should default to the current request' );
+		self::assertSame( 'test_reaction', $item['reaction_type'], 'reaction type should be part of the payload' );
+		self::assertSame( 'Spammy McSpam', $item['author'], 'author should be passed through' );
+		self::assertSame( 0, $item['post_id'], 'post_id should default to 0' );
+	}
+
+	public function test_explicit_host_is_not_overwritten(): void {
+		$this->register_test_rule();
+
+		SpamCheck::check(
+			[
+				'url'  => 'https://spam.example.com/landing-page',
+				'host' => 'explicit.example.com',
+			],
+			'test_reaction'
+		);
+
+		self::assertSame( 'explicit.example.com', SpamCheckTestRule::$item['host'], 'an explicit host should win over the derived one' );
+	}
+
+	public function test_missing_attributes_default_to_empty_strings(): void {
+		$this->register_test_rule();
+
+		SpamCheck::check( [ 'body' => 'Just a body' ], 'test_reaction' );
+
+		$item = SpamCheckTestRule::$item;
+
+		self::assertSame( '', $item['author'], 'missing author should default to an empty string' );
+		self::assertSame( '', $item['email'], 'missing email should default to an empty string' );
+		self::assertSame( '', $item['url'], 'missing url should default to an empty string' );
+		self::assertSame( '', $item['host'], 'host should stay empty without a url' );
+	}
+
+	public function test_reports_spam_with_reasons(): void {
+		$this->register_test_rule();
+		SpamCheckTestRule::$score = 1;
+
+		$result = SpamCheck::check( [ 'body' => 'Spam' ], 'test_reaction' );
+
+		self::assertTrue( $result->is_spam(), 'a positive score should be reported as spam' );
+		self::assertTrue( $result->was_evaluated(), 'the item should be reported as evaluated' );
+		self::assertSame( [ 'test-spam-check' ], $result->get_reasons(), 'the rule slug should be reported as reason' );
+	}
+
+	public function test_reports_ham_without_reasons(): void {
+		$this->register_test_rule();
+		SpamCheckTestRule::$score = -1;
+
+		$result = SpamCheck::check( [ 'body' => 'Ham' ], 'test_reaction' );
+
+		self::assertFalse( $result->is_spam(), 'a negative score should not be reported as spam' );
+		self::assertTrue( $result->was_evaluated(), 'the item should be reported as evaluated' );
+		self::assertSame( [], $result->get_reasons(), 'ham should not carry spam reasons' );
+	}
+
+	public function test_reports_not_evaluated_without_active_rule(): void {
+		expectApplied( 'antispam_bee_rules' )->andReturn( [] );
+
+		$result = SpamCheck::check( [ 'body' => 'Anything' ], 'test_reaction' );
+
+		self::assertFalse( $result->is_spam(), 'an unevaluated item should not be reported as spam' );
+		self::assertFalse( $result->was_evaluated(), 'an item is not evaluated when no rule is active' );
+		self::assertSame( [], $result->get_reasons(), 'an unevaluated item should not carry reasons' );
+		self::assertSame( 'test_reaction', $result->get_payload()['reaction_type'], 'the payload should be available even without evaluation' );
+	}
+
+	public function test_rules_of_other_reaction_types_are_not_applied(): void {
+		$this->register_test_rule();
+
+		$result = SpamCheck::check( [ 'body' => 'Anything' ], 'another_reaction' );
+
+		self::assertFalse( $result->was_evaluated(), 'a rule that does not support the reaction type should not be applied' );
+		self::assertSame( [], SpamCheckTestRule::$item, 'the rule should not have been called at all' );
+	}
+
+	public function test_has_active_rules(): void {
+		$this->register_test_rule();
+
+		self::assertTrue( SpamCheck::has_active_rules( 'test_reaction' ), 'the supported reaction type should report an active rule' );
+		self::assertFalse( SpamCheck::has_active_rules( 'another_reaction' ), 'an unsupported reaction type should report no active rule' );
+	}
+
+	public function test_payload_can_be_filtered(): void {
+		$this->register_test_rule();
+
+		expectApplied( 'antispam_bee_api_payload' )
+			->once()
+			->andReturn(
+				[
+					'reaction_type' => 'test_reaction',
+					'body'          => 'Replaced body',
+				]
+			);
+
+		SpamCheck::check( [ 'body' => 'Original body' ], 'test_reaction' );
+
+		self::assertSame( 'Replaced body', SpamCheckTestRule::$item['body'], 'the filter should be able to replace the payload' );
+	}
+}

--- a/tests/Unit/Helpers/SettingsTest.php
+++ b/tests/Unit/Helpers/SettingsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Settings;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'AntispamBee\MAIN_PLUGIN_FILE' ) ) {
+	define( 'AntispamBee\MAIN_PLUGIN_FILE', dirname( __DIR__, 3 ) . '/antispam_bee.php' );
+}
+
+/**
+ * Unit tests for the default handling in {@see Settings}.
+ */
+class SettingsTest extends TestCase {
+
+	/**
+	 * Stub the stored options.
+	 *
+	 * The object cache functions are already stubbed globally in
+	 * `tests/_stubs/includes.php`, where `wp_cache_get()` always misses.
+	 * `Settings::get_options()` also runs the plugin update check, which needs the
+	 * plugin version and the stored database version to match so it stays a no-op.
+	 *
+	 * @param array<string, mixed> $stored The stored options.
+	 */
+	private function stub_stored_options( array $stored ): void {
+		when( 'get_file_data' )->justReturn( [ 'Version' => '1.0' ] );
+		when( 'get_option' )->alias(
+			static function ( $name, $default_value = false ) use ( $stored ) {
+				return Settings::OPTION_NAME === $name ? $stored : $default_value;
+			}
+		);
+	}
+
+	public function test_defaults_apply_to_reaction_types_that_were_never_saved(): void {
+		$this->stub_stored_options(
+			[
+				'comment' => [ 'rule_asb_bbcode_active' => 'on' ],
+			]
+		);
+
+		expectApplied( 'antispam_bee_default_options' )
+			->andReturn(
+				[
+					'my_form' => [ 'rule_asb_regexp_active' => 'on' ],
+				]
+			);
+
+		self::assertSame(
+			'on',
+			Settings::get_option( 'rule_asb_regexp_active', 'my_form' ),
+			'a reaction type absent from the stored options should fall back to its defaults'
+		);
+	}
+
+	/**
+	 * An unticked checkbox is removed from the stored options, so a saved reaction
+	 * type must win over the defaults — otherwise a rule an administrator disabled
+	 * would come back on the next request.
+	 */
+	public function test_stored_reaction_type_wins_over_defaults(): void {
+		$this->stub_stored_options(
+			[
+				'my_form' => [ 'rule_asb_bbcode_active' => 'on' ],
+			]
+		);
+
+		expectApplied( 'antispam_bee_default_options' )
+			->andReturn(
+				[
+					'my_form' => [
+						'rule_asb_bbcode_active' => 'on',
+						'rule_asb_regexp_active' => 'on',
+					],
+				]
+			);
+
+		self::assertSame(
+			'on',
+			Settings::get_option( 'rule_asb_bbcode_active', 'my_form' ),
+			'the stored value should still be returned'
+		);
+		self::assertNull(
+			Settings::get_option( 'rule_asb_regexp_active', 'my_form' ),
+			'a rule missing from a saved reaction type must stay inactive'
+		);
+	}
+
+	public function test_built_in_defaults_are_exposed_through_the_filter(): void {
+		when( 'apply_filters' )->returnArg( 2 );
+
+		$defaults = Settings::get_defaults();
+
+		self::assertArrayHasKey( 'comment', $defaults, 'the comment defaults should be exposed' );
+		self::assertArrayHasKey( 'linkback', $defaults, 'the linkback defaults should be exposed' );
+		self::assertSame( 'on', $defaults['comment']['rule_asb_bbcode_active'], 'unexpected comment default' );
+	}
+}

--- a/tests/Unit/PostProcessors/CommentOnlyPostProcessorsTest.php
+++ b/tests/Unit/PostProcessors/CommentOnlyPostProcessorsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\PostProcessors;
+
+use AntispamBee\PostProcessors\SaveReason;
+use AntispamBee\PostProcessors\SendEmail;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * `SaveReason` and `SendEmail` defer their work to the `comment_post` action, which
+ * only fires for items that are stored as comments. For anything else the callback
+ * would never run — and worse, stay attached, so an unrelated comment inserted later
+ * in the same request would be stamped with this item’s data.
+ */
+class CommentOnlyPostProcessorsTest extends TestCase {
+
+	/**
+	 * @return array<string, array{0: class-string, 1: string}>
+	 */
+	public function comment_only_post_processors(): array {
+		return [
+			'save reason' => [ SaveReason::class, 'asb-save-reason' ],
+			'send email'  => [ SendEmail::class, 'asb-send-email' ],
+		];
+	}
+
+	/**
+	 * @dataProvider comment_only_post_processors
+	 *
+	 * @param class-string $post_processor The post-processor under test.
+	 * @param string       $slug           Its slug.
+	 */
+	public function test_does_nothing_for_an_item_that_is_not_a_comment( string $post_processor, string $slug ): void {
+		$item = [
+			'reaction_type' => 'my_plugin_form',
+			'body'          => 'Spam',
+			'asb_reasons'   => [ 'asb-bbcode' ],
+		];
+
+		$processed = $post_processor::process( $item );
+
+		self::assertFalse(
+			has_action( 'comment_post' ),
+			'no comment_post callback should be attached for a non-comment item'
+		);
+		self::assertSame(
+			[ $slug ],
+			$processed['asb_post_processors_failed'],
+			'the post-processor should report that it could not process the item'
+		);
+	}
+
+	/**
+	 * @dataProvider comment_only_post_processors
+	 *
+	 * @param class-string $post_processor The post-processor under test.
+	 */
+	public function test_still_processes_a_comment( string $post_processor ): void {
+		$item = [
+			'reaction_type'    => 'comment',
+			'comment_post_ID'  => 12,
+			'comment_content'  => 'Spam',
+			'asb_reasons'      => [ 'asb-bbcode' ],
+		];
+
+		$processed = $post_processor::process( $item );
+
+		self::assertTrue(
+			has_action( 'comment_post' ),
+			'a comment_post callback should be attached for a comment'
+		);
+		self::assertArrayNotHasKey(
+			'asb_post_processors_failed',
+			$processed,
+			'a comment should be processed without failure'
+		);
+	}
+}


### PR DESCRIPTION
Closes #507.

Adds a documented, stable entry point for plugins that want their own content checked, so `AntispamBee\Handlers\Rules` can stay internal.

The trigger was the first real-world integration, [epiphyt/form-block on its `antispam-bee` branch](https://github.com/epiphyt/form-block/tree/antispam-bee). Reviewing it surfaced three things worth settling *before* writing documentation, because the docs freeze whatever we describe.

## 1. `new Rules( $reaction_type )` was the only way in

`Rules` is an internal handler that `Reaction::process()` instantiates. Documenting it would have made its constructor permanent third-party API.

`AntispamBee\Api\SpamCheck` is now the entry point, and `Handlers\Rules` and `Handlers\PostProcessors` are marked `@internal`:

```php
$result = \AntispamBee\Api\SpamCheck::check(
    [ 'author' => $name, 'body' => $message, 'email' => $email ],
    'my_plugin_form'
);

if ( $result->is_spam() ) {
    $reasons = $result->get_reasons();
}
```

`CheckResult` carries the verdict, the reason slugs and the payload. It is an object rather than a boolean mainly because of `was_evaluated()`: a result can report "no spam" simply because no rule was active, and that is the most common reason an integration appears to do nothing. `has_active_rules()` lets an integration warn an administrator before any submission arrives, and `get_reason_texts()` resolves stored slugs so integrators need a single import.

## 2. The payload contract was easy to get wrong

form-block hand-built the item and left `host` empty. `RegexpSpam` reads `host` separately from `rawurl`, so a good number of our own patterns could never match. Nobody should have to know that `host` is `wp_parse_url( $url, PHP_URL_HOST )`.

`SpamCheck::check()` normalizes: it derives `host` from `url` via `DataHelper::parse_url()` and defaults `ip` and `useragent` from the current request, so a form plugin passes only what it actually has. The new `antispam_bee_api_payload` filter is the escape hatch.

## 3. Nothing was checked until an administrator ticked a box

`Settings::$defaults` only covered `comment`, `linkback` and `general`, so every `ControllableBase` rule started inactive for a reaction type registered by another plugin — including rules the integration had explicitly opted in. Verified on a local install: form-block's integration worked, but only because its settings tab had been visited and BBCode ticked. `rule_asb_regexp_active` was still unset there, so `RegexpSpam` silently never ran.

`Settings::get_defaults()` applies a new `antispam_bee_default_options` filter, and `get_options()` fills in the defaults of reaction types absent from the stored options.

**Defaults deliberately apply only to reaction types that were never saved.** An unticked checkbox is *removed* from the stored options by `Sanitize::sanitize_controllables()`, so merging defaults underneath the stored state would re-enable a rule an administrator had deliberately disabled — for `comment` and `linkback` too. There is a unit test for exactly this.

`Rules::apply()` now logs when no rule is active, so the "nothing ran" case leaves a trace instead of silently reporting no spam.

## Also: comment-only post-processors

`SaveReason` and `SendEmail` defer their work to `comment_post`. For an item that never becomes a comment the callback not only never runs, it stays attached for the rest of the request — so an unrelated comment inserted later would be stamped with that item's spam reasons, or trigger its notification email. Both now bail unless `comment_post_ID` is set, mirroring what `UpdateSpamLog::process()` already does.

The check is structural on purpose: `comment_type` is legitimately empty for a regular comment, and gating on `reaction_type` would only re-block what an integration explicitly opted in via `antispam_bee_post_processor_supported_types`.

## Documentation

New `docs/integrating-own-content.md` covers the API, the payload attributes, registering a custom reaction type, and registering your own post-processor via `antispam_bee_post_processors` (already supported, previously undocumented). Two traps are called out explicitly:

* Rules register during module initialization, which is skipped for Ajax requests, so a plugin submitting over Ajax must allow it via `antispam_bee_disallow_ajax_calls` **and register that filter early**. REST requests are unaffected, because `wp_doing_ajax()` is false for them.
* Our own post-processors support comments and linkbacks *by design*: they write comment meta, build notifications from a stored comment, and feed a spam counter rendered next to the comment counts in the At a Glance widget. They should not be opted into a custom reaction type. The documentation says so rather than advertising them.

`docs/adding-rules.md` gains the registration step, the reserved `asb-` slug prefix and a note on the payload. `docs/program-flow.md` no longer leaves `Handlers\Rules` looking like the way in.

## Testing

`composer test:unit` — 56 tests pass, 20 of them new. `phpstan` and `phpcs` clean.

Verified end to end against a local install with form-block ported to the new API, submitting real forms over HTTP:

| Check | Result |
|---|---|
| BBCode submission | stored as spam, reason `asb-bbcode` |
| `host` derived from `url` | `spam.example.com` |
| Reaction type with stored options | only the ticked rule active; a new default does **not** re-enable a disabled rule |
| Same reaction type with its stored options removed | all four opted-in rules active from defaults, nothing written to the database |
| Submission only `RegexpSpam` can catch, on defaults alone | stored as spam, reason `asb-regexp` |
| `spam_count` throughout | unchanged at `0` — no post-processor ran, the comment counter is untouched |

## Notes for review

* `SpamCheck::check()` fails open, matching current behaviour for an empty rule set: it catches the `ReflectionException` that `Rules::get()`/`apply()` declare, logs, and returns a not-evaluated result rather than surfacing a Reflection error to integrators.
* `API_VERSION` is there so integrations can adapt to a breaking change; everything outside `AntispamBee\Api` and the documented hooks is stated to be internal.
* The counter stays comment-scoped. A per-reaction-type counter would need new user-facing strings, i18n and a migration for the flat `spam_count`, and nothing requires it yet.
