### PR TITLE
feat: log the spam reasons in the spam log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
     * The built-in patterns of the regular expression rule now have stable identifiers as array keys,
       so single patterns can be removed or modified via the `antispam_bee_patterns` filter
-    * The spam log now records the reasons an item was detected and supports reactions other than
-      comments
+    * The spam log now uses a `key=value` format with an ISO 8601 timestamp, records the reasons an
+      item was detected and supports reactions other than comments. Fail2Ban filters written for the
+      previous format need to be updated to match `ip=<HOST>`
     * Fix: The language rule now also checks comments written in a script that does not delimit
       its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be
@@ -38,8 +39,9 @@
     * Die eingebauten Patterns der Regular-Expression-Regel haben nun feste Bezeichner als Array-Keys,
       sodass einzelne Patterns über den Filter `antispam_bee_patterns` entfernt oder angepasst werden
       können
-    * Das Spam-Log enthält jetzt die Gründe der Erkennung und unterstützt auch andere Reaktionen als
-      Kommentare
+    * Das Spam-Log verwendet jetzt ein `key=value`-Format mit einem ISO-8601-Zeitstempel, enthält die
+      Gründe der Erkennung und unterstützt auch andere Reaktionen als Kommentare. Fail2Ban-Filter für
+      das bisherige Format müssen auf `ip=<HOST>` umgestellt werden
     * Fix: Die Sprach-Regel prüft nun auch Kommentare in einer Schrift, die ihre Wörter nicht
       durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
     * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
     * The built-in patterns of the regular expression rule now have stable identifiers as array keys,
       so single patterns can be removed or modified via the `antispam_bee_patterns` filter
+    * The spam log now records the reasons an item was detected and supports reactions other than
+      comments
     * Fix: The language rule now also checks comments written in a script that does not delimit
       its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be
@@ -36,6 +38,8 @@
     * Die eingebauten Patterns der Regular-Expression-Regel haben nun feste Bezeichner als Array-Keys,
       sodass einzelne Patterns über den Filter `antispam_bee_patterns` entfernt oder angepasst werden
       können
+    * Das Spam-Log enthält jetzt die Gründe der Erkennung und unterstützt auch andere Reaktionen als
+      Kommentare
     * Fix: Die Sprach-Regel prüft nun auch Kommentare in einer Schrift, die ihre Wörter nicht
       durch Leerzeichen trennt, beispielsweise Chinesisch, Japanisch, Koreanisch oder Thai
     * Fix: Die Sprach-Regel markiert einen Kommentar nicht mehr als Spam, wenn die Sprache

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,17 @@ Yes. Define the constant `ANTISPAM_BEE_LOG_FILE` in your `wp-config.php` with th
 
 The fields are space-separated `key=value` pairs, and every value is free of spaces, so the line can be parsed without quoting. A field that does not apply to a reaction is written as `-`; a form submission, for example, has no post to refer to. `reasons` lists the slugs of the rules that caught the item, so a Fail2Ban jail can ban honeypot hits longer than other detections.
 
-Match the IP with `ip=<HOST>` rather than by position: that field is the one Fail2Ban needs, and it will keep its name and shape in future versions of the format.
+Match the IP with `ip=<HOST>` rather than by position: that field is the one Fail2Ban needs, and it will keep its name and shape in future versions of the format. This filter bans every detected item and keeps working if the rest of the line changes:
+
+`failregex = ^.*?\bip=<HOST>\b`
+
+The `?` matters. Without it the expression is greedy and binds to the *last* `ip=` on the line, so a field added by a plugin whose value happens to contain `ip=` would decide who gets banned.
+
+Because the reasons are logged, a jail can also act on one detection only — banning honeypot hits, which no human ever triggers, for far longer than a content-based match:
+
+`failregex = ^\s*ip=<HOST> .*\breasons=(?:\S+,)?asb-honeypot(?:,\S+)?(?:\s|$)`
+
+Two things to know when writing your own. Fail2Ban removes the timestamp from the line before applying `failregex`, so do not try to match it — anchor on `ip=` instead. And a stricter expression that spells out the whole line, such as `^\s*ip=<HOST> type=\S+ post=\S+ reasons=\S+`, is more precise but will stop matching if the field set ever changes; the short form above is the one to prefer unless you need the precision.
 
 To add a field of your own, use the `antispam_bee_spam_log_fields` filter: it receives the fields as an associative array, and anything you append becomes another `key=value` pair at the end of the line. Keys and values are cleaned up afterwards, so an added field cannot break the format.
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,13 @@ No, Antispam Bee is free forever, for both private and commercial projects. You 
 
 Complete documentation is available on [pluginkollektiv.org](https://antispambee.pluginkollektiv.org/documentation/).
 
+### Can I log detected spam for Fail2Ban? ###
+Yes. Define the constant `ANTISPAM_BEE_LOG_FILE` in your `wp-config.php` with the path to a writable file. Antispam Bee then appends one line per detected spam item:
+
+> 2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam (asb-honeypot)
+
+The reasons in brackets are the slugs of the rules that caught the item, so a Fail2Ban jail can, for example, ban honeypot hits longer than other detections. Items that are not comments are logged with their reaction type instead of the post reference. Use the `antispam_bee_spam_log_entry` filter to write your own format, or return an empty string from it to skip an item.
+
 ### How can I report security bugs? ###
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)
 
@@ -124,6 +131,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Complete code rewrite and backend UI overhaul
     * Allows extending Antispam Bee with your own rules
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
+    * The spam log now records the reasons an item was detected and supports reactions other than comments
     * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups

--- a/readme.txt
+++ b/readme.txt
@@ -124,7 +124,9 @@ The fields are space-separated `key=value` pairs, and every value is free of spa
 
 Match the IP with `ip=<HOST>` rather than by position: that field is the one Fail2Ban needs, and it will keep its name and shape in future versions of the format.
 
-Use the `antispam_bee_spam_log_entry` filter to write your own format, or return an empty string from it to skip an item.
+To add a field of your own, use the `antispam_bee_spam_log_fields` filter: it receives the fields as an associative array, and anything you append becomes another `key=value` pair at the end of the line. Keys and values are cleaned up afterwards, so an added field cannot break the format.
+
+To replace the line wholesale — with CSV, JSON or anything else — use the `antispam_bee_spam_log_entry` filter, or return an empty string from it to skip an item.
 
 ### How can I report security bugs? ###
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)

--- a/readme.txt
+++ b/readme.txt
@@ -118,9 +118,13 @@ Complete documentation is available on [pluginkollektiv.org](https://antispambee
 ### Can I log detected spam for Fail2Ban? ###
 Yes. Define the constant `ANTISPAM_BEE_LOG_FILE` in your `wp-config.php` with the path to a writable file. Antispam Bee then appends one line per detected spam item:
 
-> 2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam (asb-honeypot)
+> 2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot
 
-The reasons in brackets are the slugs of the rules that caught the item, so a Fail2Ban jail can, for example, ban honeypot hits longer than other detections. Items that are not comments are logged with their reaction type instead of the post reference. Use the `antispam_bee_spam_log_entry` filter to write your own format, or return an empty string from it to skip an item.
+The fields are space-separated `key=value` pairs, and every value is free of spaces, so the line can be parsed without quoting. A field that does not apply to a reaction is written as `-`; a form submission, for example, has no post to refer to. `reasons` lists the slugs of the rules that caught the item, so a Fail2Ban jail can ban honeypot hits longer than other detections.
+
+Match the IP with `ip=<HOST>` rather than by position: that field is the one Fail2Ban needs, and it will keep its name and shape in future versions of the format.
+
+Use the `antispam_bee_spam_log_entry` filter to write your own format, or return an empty string from it to skip an item.
 
 ### How can I report security bugs? ###
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)
@@ -131,7 +135,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Complete code rewrite and backend UI overhaul
     * Allows extending Antispam Bee with your own rules
     * Allows using Antispam Bee rules for other reactions than comments, for example, forms
-    * The spam log now records the reasons an item was detected and supports reactions other than comments
+    * The spam log now uses a `key=value` format with an ISO 8601 timestamp, records the reasons an item was detected and supports reactions other than comments. Fail2Ban filters written for the previous format need to be updated to match `ip=<HOST>`
     * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -90,11 +90,11 @@ class UpdateSpamLog extends Base {
 	 * Space-separated `key=value` pairs, the shape `filter.d/dovecot.conf` already
 	 * matches on a great many servers, so it is not exotic in Fail2Ban terms. Every
 	 * value is space-free by construction, which is what makes the line parseable
-	 * without quoting. A field that does not apply to a reaction is written as `-`
+	 * without quoting. A field that has no value for a reaction is written as `-`
 	 * rather than omitted, so the field set is the same on every line.
 	 *
-	 * The timestamp comes first because Fail2Ban looks for it near the start of the
-	 * line to apply `findtime`.
+	 * The timestamp is not one of the fields: it has no key, and Fail2Ban looks for
+	 * it near the start of the line to apply `findtime`, so it must not be movable.
 	 *
 	 * @param array<string, mixed> $item Item that was marked as spam.
 	 * @param string               $ip   IP address the item was submitted from.
@@ -102,24 +102,99 @@ class UpdateSpamLog extends Base {
 	 * @return string The log entry, without a trailing newline.
 	 */
 	private static function get_entry( array $item, string $ip ): string {
-		$post = '-';
-		if ( isset( $item['comment_post_ID'] ) ) {
-			$post = (string) (int) $item['comment_post_ID'];
-		}
-
-		$reasons = '-';
+		$reasons = '';
 		if ( ! empty( $item['asb_reasons'] ) ) {
 			$reasons = implode( ',', array_map( [ self::class, 'sanitize_token' ], (array) $item['asb_reasons'] ) );
 		}
 
-		return sprintf(
-			'%s ip=%s type=%s post=%s reasons=%s',
-			self::get_timestamp(),
-			$ip,
-			self::sanitize_token( $item['reaction_type'] ?? '' ),
-			$post,
-			$reasons
-		);
+		$fields = [
+			'ip'      => $ip,
+			'type'    => self::sanitize_token( $item['reaction_type'] ?? '' ),
+			'post'    => isset( $item['comment_post_ID'] ) ? (int) $item['comment_post_ID'] : '',
+			'reasons' => $reasons,
+		];
+
+		/**
+		 * Filter the fields that make up a spam log line.
+		 *
+		 * Keys become the `key=` part and are written in the order of the array, so
+		 * appending to it adds a field at the end of the line. Keys are reduced to
+		 * `[a-zA-Z0-9_-]` and a key left empty by that is dropped; values have their
+		 * whitespace replaced and an empty value is written as `-`, so a filter
+		 * cannot break the shape of the line. An array value is joined with commas.
+		 *
+		 * The timestamp is not part of this array — it has no key and has to stay at
+		 * the start of the line for Fail2Ban's date detection.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array<string, mixed> $fields The fields of the log line.
+		 * @param array<string, mixed> $item   The item that was marked as spam.
+		 */
+		$fields = (array) apply_filters( 'antispam_bee_spam_log_fields', $fields, $item );
+
+		// The documented Fail2Ban filter matches `ip=<HOST>`; a line without it would silently stop being banned on.
+		if ( ! isset( $fields['ip'] ) ) {
+			$fields = array_merge( [ 'ip' => $ip ], $fields );
+		}
+
+		$pairs = [];
+
+		foreach ( $fields as $key => $value ) {
+			$key = self::sanitize_key( $key );
+
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$pairs[] = $key . '=' . self::sanitize_value( $value );
+		}
+
+		if ( [] === $pairs ) {
+			return self::get_timestamp();
+		}
+
+		return self::get_timestamp() . ' ' . implode( ' ', $pairs );
+	}
+
+	/**
+	 * Reduce a field name to characters that are safe in a `key=value` line.
+	 *
+	 * @param mixed $key Field name to sanitize.
+	 *
+	 * @return string The sanitized field name, empty if nothing usable was left.
+	 */
+	private static function sanitize_key( $key ): string {
+		return (string) preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $key );
+	}
+
+	/**
+	 * Make a field value safe to write into a `key=value` line.
+	 *
+	 * Only whitespace and control characters actually break the format, so unlike
+	 * {@see self::sanitize_token()} this keeps punctuation: a filter may well add a
+	 * value that needs a dot or a colon, and stripping those would corrupt it
+	 * silently rather than protect anything.
+	 *
+	 * @param mixed $value Field value to sanitize.
+	 *
+	 * @return string The sanitized value, or `-` if it is empty.
+	 */
+	private static function sanitize_value( $value ): string {
+		if ( is_array( $value ) ) {
+			$value = implode( ',', array_map( 'strval', $value ) );
+		}
+
+		if ( is_bool( $value ) ) {
+			$value = $value ? '1' : '0';
+		}
+
+		// Whitespace first: a newline is also a control character, and deleting it
+		// outright would run two words together instead of keeping them apart.
+		$value = (string) preg_replace( '/\s+/', '_', trim( (string) $value ) );
+		$value = (string) preg_replace( '/[[:cntrl:]]/', '', $value );
+
+		return '' === $value ? '-' : $value;
 	}
 
 	/**

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -123,6 +123,13 @@ class UpdateSpamLog extends Base {
 		 * whitespace replaced and an empty value is written as `-`, so a filter
 		 * cannot break the shape of the line. An array value is joined with commas.
 		 *
+		 * Keep `ip` present and first unless you know you do not need it. The Fail2Ban
+		 * filter in the readme matches the first `ip=` on the line, so removing the
+		 * field stops it matching, and moving it behind a field whose value contains
+		 * `ip=` makes it match that value instead. Both are legitimate choices — a log
+		 * kept for statistics rather than for banning has good reason to drop the
+		 * address entirely — but neither reports an error.
+		 *
 		 * The timestamp is not part of this array — it has no key and has to stay at
 		 * the start of the line for Fail2Ban's date detection.
 		 *
@@ -132,11 +139,6 @@ class UpdateSpamLog extends Base {
 		 * @param array<string, mixed> $item   The item that was marked as spam.
 		 */
 		$fields = (array) apply_filters( 'antispam_bee_spam_log_fields', $fields, $item );
-
-		// The documented Fail2Ban filter matches `ip=<HOST>`; a line without it would silently stop being banned on.
-		if ( ! isset( $fields['ip'] ) ) {
-			$fields = array_merge( [ 'ip' => $ip ], $fields );
-		}
 
 		$pairs = [];
 

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -28,7 +28,10 @@ class UpdateSpamLog extends Base {
 	 * @return array<string, mixed> Processed item.
 	 */
 	public static function process( array $item ): array {
-		if ( ! isset( $item['comment_post_ID'] ) || ! isset( $item['comment_author_IP'] ) ) {
+		// The IP is the only field a Fail2Ban filter really needs, everything else is contextual.
+		$ip = self::get_ip( $item );
+
+		if ( '' === $ip ) {
 			$item['asb_post_processors_failed'][] = self::get_slug();
 
 			return $item;
@@ -44,21 +47,114 @@ class UpdateSpamLog extends Base {
 			return $item;
 		}
 
-		$entry = sprintf(
-			'%s comment for post=%d from host=%s marked as spam%s',
-			current_time( 'mysql' ),
-			$item['comment_post_ID'],
-			$item['comment_author_IP'],
-			PHP_EOL
-		);
+		$entry = self::get_entry( $item, $ip );
+
+		/**
+		 * Filter the line that is appended to the spam log file.
+		 *
+		 * Return an empty string to skip the item, for example to log honeypot hits only.
+		 * The line is written as-is, followed by a single newline; do not add one yourself.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $entry The log entry, without a trailing newline.
+		 * @param array  $item  The item that was marked as spam.
+		 */
+		$entry = apply_filters( 'antispam_bee_spam_log_entry', $entry, $item );
+
+		if ( ! is_string( $entry ) ) {
+			return $item;
+		}
+
+		// A filtered entry must stay a single line, otherwise it breaks every log parser reading the file.
+		$single_line = preg_replace( '/\s+/', ' ', $entry );
+		$entry       = null === $single_line ? '' : trim( $single_line );
+
+		if ( '' === $entry ) {
+			return $item;
+		}
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- WP_Filesystem cannot perform an atomic FILE_APPEND | LOCK_EX write to the log file.
 		file_put_contents(
 			ANTISPAM_BEE_LOG_FILE,
-			$entry,
+			$entry . PHP_EOL,
 			FILE_APPEND | LOCK_EX
 		);
 
 		return $item;
+	}
+
+	/**
+	 * Build the log entry for an item.
+	 *
+	 * Comments keep the wording the log has used since 2.5.7, so existing Fail2Ban
+	 * filters keep matching. Any other reaction is logged with its type instead of
+	 * the post reference it does not have.
+	 *
+	 * @param array<string, mixed> $item Item that was marked as spam.
+	 * @param string               $ip   IP address the item was submitted from.
+	 *
+	 * @return string The log entry, without a trailing newline.
+	 */
+	private static function get_entry( array $item, string $ip ): string {
+		if ( isset( $item['comment_post_ID'] ) ) {
+			$subject = sprintf( 'comment for post=%d', $item['comment_post_ID'] );
+		} else {
+			$subject = self::sanitize_token( $item['reaction_type'] ?? 'item' );
+		}
+
+		$reasons = '';
+		if ( ! empty( $item['asb_reasons'] ) ) {
+			$reasons = sprintf(
+				' (%s)',
+				implode( ',', array_map( [ self::class, 'sanitize_token' ], (array) $item['asb_reasons'] ) )
+			);
+		}
+
+		return sprintf(
+			'%s %s from host=%s marked as spam%s',
+			current_time( 'mysql' ),
+			$subject,
+			$ip,
+			$reasons
+		);
+	}
+
+	/**
+	 * Get the IP address an item was submitted from.
+	 *
+	 * Comments and linkbacks carry it as `comment_author_IP`. Items that reach the
+	 * post-processors through {@see \AntispamBee\Api\SpamCheck::post_process()} are
+	 * passed on unchanged, so they may instead use `ip`, the attribute name the
+	 * spam check itself expects.
+	 *
+	 * @param array<string, mixed> $item Item that was marked as spam.
+	 *
+	 * @return string The IP address, or an empty string if the item has none.
+	 */
+	private static function get_ip( array $item ): string {
+		$ip = $item['comment_author_IP'] ?? $item['ip'] ?? '';
+
+		if ( ! is_string( $ip ) ) {
+			return '';
+		}
+
+		return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
+	}
+
+	/**
+	 * Reduce a slug to characters that are safe to write into a log line.
+	 *
+	 * Reaction types and rule slugs can come from third-party integrations, which
+	 * are not guaranteed to stick to slug characters.
+	 *
+	 * @param mixed $token Slug to sanitize.
+	 *
+	 * @return string The sanitized slug.
+	 */
+	private static function sanitize_token( $token ): string {
+		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $token );
+
+		return empty( $sanitized ) ? 'unknown' : $sanitized;
 	}
 }

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -87,9 +87,14 @@ class UpdateSpamLog extends Base {
 	/**
 	 * Build the log entry for an item.
 	 *
-	 * Comments keep the wording the log has used since 2.5.7, so existing Fail2Ban
-	 * filters keep matching. Any other reaction is logged with its type instead of
-	 * the post reference it does not have.
+	 * Space-separated `key=value` pairs, the shape `filter.d/dovecot.conf` already
+	 * matches on a great many servers, so it is not exotic in Fail2Ban terms. Every
+	 * value is space-free by construction, which is what makes the line parseable
+	 * without quoting. A field that does not apply to a reaction is written as `-`
+	 * rather than omitted, so the field set is the same on every line.
+	 *
+	 * The timestamp comes first because Fail2Ban looks for it near the start of the
+	 * line to apply `findtime`.
 	 *
 	 * @param array<string, mixed> $item Item that was marked as spam.
 	 * @param string               $ip   IP address the item was submitted from.
@@ -97,26 +102,55 @@ class UpdateSpamLog extends Base {
 	 * @return string The log entry, without a trailing newline.
 	 */
 	private static function get_entry( array $item, string $ip ): string {
+		$post = '-';
 		if ( isset( $item['comment_post_ID'] ) ) {
-			$subject = sprintf( 'comment for post=%d', $item['comment_post_ID'] );
-		} else {
-			$subject = self::sanitize_token( $item['reaction_type'] ?? 'item' );
+			$post = (string) (int) $item['comment_post_ID'];
 		}
 
-		$reasons = '';
+		$reasons = '-';
 		if ( ! empty( $item['asb_reasons'] ) ) {
-			$reasons = sprintf(
-				' (%s)',
-				implode( ',', array_map( [ self::class, 'sanitize_token' ], (array) $item['asb_reasons'] ) )
-			);
+			$reasons = implode( ',', array_map( [ self::class, 'sanitize_token' ], (array) $item['asb_reasons'] ) );
 		}
 
 		return sprintf(
-			'%s %s from host=%s marked as spam%s',
-			current_time( 'mysql' ),
-			$subject,
+			'%s ip=%s type=%s post=%s reasons=%s',
+			self::get_timestamp(),
 			$ip,
+			self::sanitize_token( $item['reaction_type'] ?? '' ),
+			$post,
 			$reasons
+		);
+	}
+
+	/**
+	 * Get the current time as an ISO 8601 timestamp with a UTC offset.
+	 *
+	 * `current_time( 'mysql' )` writes WordPress-local time without an offset, so on
+	 * a site whose timezone differs from the server's, Fail2Ban reads entries as
+	 * outside `findtime` and silently never bans. The offset is derived from the
+	 * difference between local and UTC time at this very instant rather than from
+	 * the `gmt_offset` option, so it stays correct across daylight saving changes
+	 * and cannot disagree with the wall clock it is appended to.
+	 *
+	 * @return string The timestamp, for example `2026-01-15T10:23:45+01:00`.
+	 */
+	private static function get_timestamp(): string {
+		$local = (string) current_time( 'mysql' );
+		$utc   = (string) current_time( 'mysql', true );
+
+		$offset = strtotime( $local ) - strtotime( $utc );
+
+		$sign    = $offset < 0 ? '-' : '+';
+		$offset  = abs( $offset );
+		$hours   = (int) floor( $offset / 3600 );
+		$minutes = (int) floor( ( $offset % 3600 ) / 60 );
+
+		return sprintf(
+			'%s%s%02d:%02d',
+			str_replace( ' ', 'T', $local ),
+			$sign,
+			$hours,
+			$minutes
 		);
 	}
 

--- a/tests/Unit/PostProcessors/UpdateSpamLogTest.php
+++ b/tests/Unit/PostProcessors/UpdateSpamLogTest.php
@@ -55,7 +55,7 @@ class UpdateSpamLogTest extends TestCase {
 		);
 
 		self::assertSame(
-			'2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam (asb-honeypot)' . PHP_EOL,
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot' . PHP_EOL,
 			$this->get_log()
 		);
 	}
@@ -70,14 +70,15 @@ class UpdateSpamLogTest extends TestCase {
 			]
 		);
 
-		self::assertStringContainsString( '(asb-honeypot,asb-too-fast-submit)', $this->get_log() );
+		self::assertStringContainsString( 'reasons=asb-honeypot,asb-too-fast-submit', $this->get_log() );
 	}
 
 	/**
-	 * Without reasons the line has to stay byte-identical to the one the log has
-	 * used since 2.5.7, so existing Fail2Ban filters keep matching.
+	 * A field that does not apply is written as `-` rather than left out, so every
+	 * line carries the same field set and a parser never has to cope with a missing
+	 * key.
 	 */
-	public function test_keeps_the_legacy_line_when_there_are_no_reasons(): void {
+	public function test_writes_a_placeholder_when_there_are_no_reasons(): void {
 		UpdateSpamLog::process(
 			[
 				'reaction_type'     => 'comment',
@@ -88,7 +89,7 @@ class UpdateSpamLogTest extends TestCase {
 		);
 
 		self::assertSame(
-			'2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam' . PHP_EOL,
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=comment post=474 reasons=-' . PHP_EOL,
 			$this->get_log()
 		);
 	}
@@ -103,7 +104,72 @@ class UpdateSpamLogTest extends TestCase {
 		);
 
 		self::assertSame(
-			'2026-01-15 10:23:45 my_plugin_form from host=192.0.2.42 marked as spam (asb-honeypot)' . PHP_EOL,
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=my_plugin_form post=- reasons=asb-honeypot' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	/**
+	 * The offset is what makes the timestamp usable for `findtime` on a site whose
+	 * timezone differs from the server's.
+	 */
+	public function test_appends_the_utc_offset_of_the_site(): void {
+		stubs(
+			[
+				'current_time' => static function ( $type, $gmt = false ) {
+					return $gmt ? '2026-01-15 09:23:45' : '2026-01-15 10:23:45';
+				},
+			]
+		);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertStringStartsWith( '2026-01-15T10:23:45+01:00 ', $this->get_log() );
+	}
+
+	public function test_appends_a_negative_utc_offset(): void {
+		stubs(
+			[
+				'current_time' => static function ( $type, $gmt = false ) {
+					return $gmt ? '2026-01-15 10:23:45' : '2026-01-15 05:53:45';
+				},
+			]
+		);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertStringStartsWith( '2026-01-15T05:53:45-04:30 ', $this->get_log() );
+	}
+
+	/**
+	 * A reaction type and rule slugs can come from a third-party integration, and a
+	 * value containing a space would break the `key=value` shape for every parser.
+	 */
+	public function test_strips_characters_that_would_break_the_line(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type' => 'my plugin/form!',
+				'ip'            => '192.0.2.42',
+				'asb_reasons'   => [ 'weird slug()', '' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=mypluginform post=- reasons=weirdslug,unknown' . PHP_EOL,
 			$this->get_log()
 		);
 	}

--- a/tests/Unit/PostProcessors/UpdateSpamLogTest.php
+++ b/tests/Unit/PostProcessors/UpdateSpamLogTest.php
@@ -328,10 +328,11 @@ class UpdateSpamLogTest extends TestCase {
 	}
 
 	/**
-	 * `ip=<HOST>` is the field the documented Fail2Ban filter matches on, so a line
-	 * without it would silently stop producing bans.
+	 * Dropping the IP breaks the Fail2Ban filter in the readme, but a log kept for
+	 * statistics rather than for banning has good reason not to retain addresses,
+	 * and the filter has to be able to say so.
 	 */
-	public function test_the_ip_survives_a_filter_that_drops_it(): void {
+	public function test_a_filter_can_drop_the_ip(): void {
 		expectApplied( 'antispam_bee_spam_log_fields' )
 			->once()
 			->andReturnUsing(
@@ -351,7 +352,10 @@ class UpdateSpamLogTest extends TestCase {
 			]
 		);
 
-		self::assertStringContainsString( 'ip=192.0.2.42', $this->get_log() );
+		self::assertSame(
+			'2026-01-15T10:23:45+00:00 type=comment post=474 reasons=asb-honeypot' . PHP_EOL,
+			$this->get_log()
+		);
 	}
 
 	public function test_appends_to_an_existing_log(): void {

--- a/tests/Unit/PostProcessors/UpdateSpamLogTest.php
+++ b/tests/Unit/PostProcessors/UpdateSpamLogTest.php
@@ -237,6 +237,123 @@ class UpdateSpamLogTest extends TestCase {
 		self::assertSame( 'first second' . PHP_EOL, $this->get_log() );
 	}
 
+	/**
+	 * The point of the fields filter: adding a field should not mean rebuilding the
+	 * whole line and re-implementing its shape.
+	 */
+	public function test_a_filter_can_append_a_field(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					$fields['score'] = 7.5;
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot score=7.5' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	public function test_a_filter_can_remove_a_field(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					unset( $fields['post'] );
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=comment reasons=asb-honeypot' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	/**
+	 * A value with a space in it would split into two fields and quietly corrupt
+	 * every line the filter touches.
+	 */
+	public function test_a_filtered_value_cannot_break_the_line(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					$fields['note']      = "two words\nand a newline";
+					$fields['bad key!']  = 'dropped';
+					$fields['tags']      = [ 'one', 'two' ];
+					$fields['empty']     = '';
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15T10:23:45+00:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot'
+			. ' note=two_words_and_a_newline badkey=dropped tags=one,two empty=-' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	/**
+	 * `ip=<HOST>` is the field the documented Fail2Ban filter matches on, so a line
+	 * without it would silently stop producing bans.
+	 */
+	public function test_the_ip_survives_a_filter_that_drops_it(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					unset( $fields['ip'] );
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertStringContainsString( 'ip=192.0.2.42', $this->get_log() );
+	}
+
 	public function test_appends_to_an_existing_log(): void {
 		$item = [
 			'reaction_type'     => 'comment',

--- a/tests/Unit/PostProcessors/UpdateSpamLogTest.php
+++ b/tests/Unit/PostProcessors/UpdateSpamLogTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\PostProcessors;
+
+use AntispamBee\PostProcessors\UpdateSpamLog;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\stubs;
+
+if ( ! defined( 'ANTISPAM_BEE_LOG_FILE' ) ) {
+	define( 'ANTISPAM_BEE_LOG_FILE', sys_get_temp_dir() . '/asb-spam-log-test.log' );
+}
+
+/**
+ * Unit tests for {@see UpdateSpamLog}.
+ */
+class UpdateSpamLogTest extends TestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		file_put_contents( ANTISPAM_BEE_LOG_FILE, '' );
+
+		stubs(
+			[
+				'current_time'  => '2026-01-15 10:23:45',
+				'validate_file' => 0,
+			]
+		);
+	}
+
+	public function tear_down(): void {
+		if ( file_exists( ANTISPAM_BEE_LOG_FILE ) ) {
+			unlink( ANTISPAM_BEE_LOG_FILE );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @return string The contents of the log file.
+	 */
+	private function get_log(): string {
+		return (string) file_get_contents( ANTISPAM_BEE_LOG_FILE );
+	}
+
+	public function test_logs_a_comment_with_its_spam_reason(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam (asb-honeypot)' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	public function test_logs_every_reason_it_was_given(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot', 'asb-too-fast-submit' ],
+			]
+		);
+
+		self::assertStringContainsString( '(asb-honeypot,asb-too-fast-submit)', $this->get_log() );
+	}
+
+	/**
+	 * Without reasons the line has to stay byte-identical to the one the log has
+	 * used since 2.5.7, so existing Fail2Ban filters keep matching.
+	 */
+	public function test_keeps_the_legacy_line_when_there_are_no_reasons(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	public function test_logs_a_reaction_that_is_not_a_comment(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type' => 'my_plugin_form',
+				'ip'            => '192.0.2.42',
+				'asb_reasons'   => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'2026-01-15 10:23:45 my_plugin_form from host=192.0.2.42 marked as spam (asb-honeypot)' . PHP_EOL,
+			$this->get_log()
+		);
+	}
+
+	public function test_reports_a_failure_for_an_item_without_a_usable_ip(): void {
+		$processed = UpdateSpamLog::process(
+			[
+				'reaction_type' => 'my_plugin_form',
+				'ip'            => 'not-an-ip',
+				'asb_reasons'   => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( [ 'asb-update-spam-log' ], $processed['asb_post_processors_failed'] );
+		self::assertSame( '', $this->get_log() );
+	}
+
+	public function test_writes_what_the_filter_returns(): void {
+		expectApplied( 'antispam_bee_spam_log_entry' )
+			->once()
+			->andReturn( '192.0.2.42,asb-honeypot' );
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( '192.0.2.42,asb-honeypot' . PHP_EOL, $this->get_log() );
+	}
+
+	public function test_skips_the_item_when_the_filter_returns_an_empty_string(): void {
+		expectApplied( 'antispam_bee_spam_log_entry' )->andReturn( '' );
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( '', $this->get_log() );
+	}
+
+	/**
+	 * A multi-line entry would break every parser reading the file line by line.
+	 */
+	public function test_forces_a_filtered_entry_onto_a_single_line(): void {
+		expectApplied( 'antispam_bee_spam_log_entry' )->andReturn( "first\nsecond\n" );
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( 'first second' . PHP_EOL, $this->get_log() );
+	}
+
+	public function test_appends_to_an_existing_log(): void {
+		$item = [
+			'reaction_type'     => 'comment',
+			'comment_post_ID'   => 474,
+			'comment_author_IP' => '192.0.2.42',
+			'asb_reasons'       => [ 'asb-honeypot' ],
+		];
+
+		UpdateSpamLog::process( $item );
+		UpdateSpamLog::process( $item );
+
+		self::assertCount( 2, array_filter( explode( PHP_EOL, $this->get_log() ) ) );
+	}
+}


### PR DESCRIPTION
Reported in [this support topic](https://wordpress.org/support/topic/slightly-extended-fail2ban-integration/#post-18987671): the spam log records only *that* something was spam, never *why*, so a Fail2Ban jail cannot ban a honeypot hit longer than a content-based detection.

The log line has been unchanged since 2.5.7 — and, contrary to what the topic reply suggests, `v3` did not make it any more verbose: `UpdateSpamLog::process()` wrote exactly what `_update_spam_log()` writes on `master`.

## What changed

**1. A `key=value` line.** After the discussion below, the format is space-separated pairs rather than the reasons appended to the old sentence:

```
2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot
```

Space-separated `key=value` has real precedent in Fail2Ban-land: `filter.d/dovecot.conf` matches `rip=<HOST>` on a very large number of servers. JSONL was considered and rejected for this particular log — Fail2Ban parses with regexes only, a leading `{` forces every operator to configure a custom `datepattern`, and escaped values are a hazard for regex extraction. `antispam_bee_spam_log_entry` makes JSONL about three lines of userland code for anyone who wants it.

Every value is space-free by construction, so nothing needs quoting. Reaction types and rule slugs can come from third-party integrations, so they are reduced to `[a-zA-Z0-9_-]` before being written.

**2. A field that does not apply is written as `-`.** Not omitted — so the field set is identical on every line and a parser never has to cope with a missing key:

```
2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=my_plugin_form post=- reasons=asb-honeypot
```

**3. Reactions other than comments are logged.** Only the IP is essential for a Fail2Ban filter, so an item without `comment_post_ID` is logged with its reaction type and `post=-`. Unlike `SaveReason`/`SendEmail` (see b51a1ed) nothing here is comment-specific — the processor just appends a line. The default `$supported_types` is untouched; this only stops the processor from doing nothing when an integration opts in via `antispam_bee_post_processor_supported_types`.

The IP is read from `comment_author_IP` or, as a fallback, from the normalized `ip` attribute. That fallback is a wart — #796 tracks removing it by handing the normalized payload to post-processors.

**4. The timestamp is ISO 8601 with a UTC offset.** `current_time( 'mysql' )` wrote WordPress-local time without an offset, so on a site whose timezone differs from the server's, Fail2Ban read entries as outside `findtime` and silently never banned. The offset is derived from the difference between local and UTC time at the same instant rather than from the `gmt_offset` option, so it follows daylight saving and cannot disagree with the wall clock it is appended to. The timestamp stays first, because Fail2Ban looks for it near the start of the line.

**5. Two filters: one to extend the line, one to replace it.**

The line is not assembled with a single `sprintf()`. `get_entry()` builds an associative array of fields, filters it, and joins it afterwards — so adding one field does not mean reimplementing the format in userland and keeping it in step with ours by hand:

```php
add_filter(
	'antispam_bee_spam_log_fields',
	function ( array $fields, array $item ): array {
		$fields['score'] = 7.5;

		return $fields;
	},
	10,
	2
);
```

```
2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot score=7.5
```

Joining *after* the filter is what makes that safe. Keys are reduced to `[a-zA-Z0-9_-]` and dropped if nothing is left; values have their whitespace replaced and empty ones become `-`; an array value is joined with commas. So an added field cannot split into two fields or corrupt the file.

Values deliberately do **not** go through the slug sanitizer. Only whitespace and control characters break the format, and stripping punctuation would quietly turn a `score=7.5` into `score=75`. Whitespace is also collapsed *before* control characters are stripped — a newline is both, and deleting it outright would run two words together.

The timestamp is not in the array at all: it has no key, and Fail2Ban looks for it near the start of the line.

`ip` *can* be removed. An earlier revision put it back, on the grounds that the documented filter matches on it — but that was the wrong call. Everywhere else this PR guards against *us* breaking someone's setup without telling them; a callback unsetting a field is the site owner instructing us in their own code, and silently ignoring that is worse than the failure it was avoiding. Dropping the address is also a legitimate thing to want: the log sits in `wp-content`, an IP is personal data, and a log kept for statistics rather than for banning has no need of one. The filter documents the consequence instead.

`antispam_bee_spam_log_entry` keeps its meaning — the finished line, for anyone who wants CSV, TSV or JSONL instead of extending ours. Returning an empty string skips the item, e.g. to log honeypot hits only. The entry is filtered without its newline and collapsed to a single line before writing.

## Backward compatibility

**This breaks filters anchored on `marked as spam$`.** That is deliberate, and it is the outcome of the discussion in the comments: 3.0 is where a major release is allowed to break, and a versioned format constant would have meant a value matrix to document and test.

Preserving the old line is **#807's** job, not this PR's. That branch resolves *which* constant supplied the log path, so it can keep `ANTISPAM_BEE_LOG_FILE` writing the byte-identical 2.5.7 line while `ANTISPAM_BEE_SPAM_LOG` gets this format. #807 is stacked directly on this branch, so both land in the same beta and no released version ever breaks a jail.

The changelog carries the warning in English and German.

## Matching the IP

The readme documents `ip=<HOST>` as the field to match on, and promises it keeps its name and shape in future versions of the format. That is the useful guarantee — a version marker like `ASB_SPAM_V1` would not help, because a filter written for V1 meeting a V2 line simply stops matching and Fail2Ban says nothing either way.

```ini
[Definition]
failregex = ^.*?\bip=<HOST>\b
ignoreregex =
```

**The `?` is load-bearing.** Greedy `^.*\bip=<HOST>\b` binds to the *last* `ip=` on the line, so a field added through `antispam_bee_spam_log_fields` whose value contains `ip=` would decide who gets banned — most likely exactly where that value carries attacker-influenced content. The lazy form takes the first, which is ours.

Because the reasons are logged, a jail can also act on one detection only — which is what the original report asked for:

```ini
failregex = ^\s*ip=<HOST> .*\breasons=(?:\S+,)?asb-honeypot(?:,\S+)?(?:\s|$)
```

Worth knowing when writing one: **Fail2Ban strips the timestamp from the line before applying `failregex`**, so an expression anchored on it never matches. The readme says so, and warns that a stricter form spelling out the whole field set is more precise but stops matching if that set changes.

Every expression above was checked with the real `fail2ban-regex` against a log containing multi-reason lines, a non-comment reaction and a line with a hijacking `ip=` in a trailing field: the short filter matches 6/6 with `0 missed`, the honeypot filter matches exactly the three honeypot lines, and the date template is auto-detected **including the zone offset**, so no custom `datepattern` is needed. Shipping a filter as a file in the repo is left to a follow-up — it is a packaging question of its own.

## Deliberately not included

**The score.** `Rules::apply()` does compute one, but it is a local variable that never leaves the method, and today's rule values (`-100`, `-1`, `0`, `1`, `999` with `$weight` always `1`) are a boolean OR with vetoes rather than a calibrated scale. Making the score a real control — configurable weights, a threshold that decides — is planned for 3.1 or later and tracked in #837.

## Test steps

1. Define `ANTISPAM_BEE_LOG_FILE` in `wp-config.php`, pointing at a writable file.
2. Submit a comment that trips the honeypot; the line ends in `reasons=asb-honeypot`.
3. Submit one that trips several rules; the reasons are comma-separated.
4. Submit one through a non-comment integration; it is logged with `type=<reaction type> post=-`.
5. Add a filter on `antispam_bee_spam_log_fields` appending a field; it appears at the end of the line.
6. Add a filter on `antispam_bee_spam_log_entry` returning `''`; nothing is logged.

`composer cs`, `composer phpstan` and `composer test:unit` pass; the post-processor got a unit test suite, it had none before.
