### PR TITLE
fix: tolerate a partial legacy option array in the v2 to v3 migration

### DIFF
--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -149,53 +149,65 @@ class PluginUpdate {
 		) ) {
 			// Update options (we migrate to a new option name `antispam_bee_options` in this release).
 			$options = get_option( 'antispam_bee', [] );
+			if ( ! is_array( $options ) ) {
+				$options = [];
+			}
 
 			$allowed_languages = self::convert_multiselect_values( $options['translate_lang'] ?? [] );
 
 			$delete_reasons = self::convert_multiselect_values( $options['ignore_reasons'] ?? [], self::$spam_reasons_mapping );
 
+			/*
+			 * Every legacy flag is read through `empty()`, because the legacy option array grew
+			 * over the lifetime of Antispam Bee 2.x and a site that never re-saved its settings
+			 * after an upgrade can hold an array that predates any given key. Reading such a key
+			 * directly emits an `Undefined array key` warning, which aborts the whole migration on
+			 * installs that promote warnings to exceptions — and since the database version is
+			 * raised before the migration runs, it is then never retried. A missing key means the
+			 * feature did not exist yet, so it is migrated as disabled.
+			 */
 			$new_options = [
 				'comment'    => [
 					'post_processor_asb_delete_spam_active' => isset( $options['flag_spam'] ) && ! $options['flag_spam'] ? 'on' : '',
-					'post_processor_asb_send_email_active' => $options['email_notify'] ? 'on' : '',
+					'post_processor_asb_send_email_active' => empty( $options['email_notify'] ) ? '' : 'on',
 					'post_processor_asb_save_reason_active' => isset( $options['no_notice'] ) && ! $options['no_notice'] ? 'on' : '',
-					'rule_asb_regexp_active'               => $options['regexp_check'] ? 'on' : '',
+					'rule_asb_regexp_active'               => empty( $options['regexp_check'] ) ? '' : 'on',
 					'rule_asb_honeypot_active'             => 'on',
-					'rule_asb_db_spam_active'              => $options['spam_ip'] ? 'on' : '',
-					'rule_asb_approved_email_active'       => $options['already_commented'] ? 'on' : '',
-					'rule_asb_too_fast_submit_active'      => $options['time_check'] ? 'on' : '',
-					'post_processor_asb_delete_for_reasons_active' => $options['reasons_enable'] ? 'on' : '',
+					'rule_asb_db_spam_active'              => empty( $options['spam_ip'] ) ? '' : 'on',
+					'rule_asb_approved_email_active'       => empty( $options['already_commented'] ) ? '' : 'on',
+					'rule_asb_too_fast_submit_active'      => empty( $options['time_check'] ) ? '' : 'on',
+					'post_processor_asb_delete_for_reasons_active' => empty( $options['reasons_enable'] ) ? '' : 'on',
 					'post_processor_asb_delete_for_reasons_reasons' => $delete_reasons,
-					'rule_asb_bbcode_active'               => $options['bbcode_check'] ? 'on' : '',
-					'rule_asb_valid_gravatar_active'       => $options['gravatar_check'] ? 'on' : '',
-					'rule_asb_country_spam_active'         => $options['country_code'] ? 'on' : '',
+					'rule_asb_bbcode_active'               => empty( $options['bbcode_check'] ) ? '' : 'on',
+					'rule_asb_valid_gravatar_active'       => empty( $options['gravatar_check'] ) ? '' : 'on',
+					'rule_asb_country_spam_active'         => empty( $options['country_code'] ) ? '' : 'on',
 					'rule_asb_country_spam_denied'         => $options['country_denied'] ?? '',
 					'rule_asb_country_spam_allowed'        => $options['country_allowed'] ?? '',
-					'rule_asb_lang_spam_active'            => $options['translate_api'] ? 'on' : '',
+					'rule_asb_lang_spam_active'            => empty( $options['translate_api'] ) ? '' : 'on',
 					'rule_asb_lang_spam_allowed'           => $allowed_languages,
 				],
 				'linkback'   => [
 					'post_processor_asb_delete_spam_active' => isset( $options['flag_spam'] ) && ! $options['flag_spam'] ? 'on' : '',
-					'post_processor_asb_send_email_active' => $options['email_notify'] ? 'on' : '',
+					'post_processor_asb_send_email_active' => empty( $options['email_notify'] ) ? '' : 'on',
 					'post_processor_asb_save_reason_active' => isset( $options['no_notice'] ) && ! $options['no_notice'] ? 'on' : '',
-					'rule_asb_regexp_active'               => $options['regexp_check'] ? 'on' : '',
-					'rule_asb_db_spam_active'              => $options['spam_ip'] ? 'on' : '',
-					'post_processor_asb_delete_for_reasons_active' => $options['reasons_enable'] ? 'on' : '',
+					'rule_asb_regexp_active'               => empty( $options['regexp_check'] ) ? '' : 'on',
+					'rule_asb_db_spam_active'              => empty( $options['spam_ip'] ) ? '' : 'on',
+					'post_processor_asb_delete_for_reasons_active' => empty( $options['reasons_enable'] ) ? '' : 'on',
 					'post_processor_asb_delete_for_reasons_reasons' => $delete_reasons,
-					'rule_asb_bbcode_active'               => $options['bbcode_check'] ? 'on' : '',
-					'rule_asb_valid_gravatar_active'       => $options['gravatar_check'] ? 'on' : '',
-					'rule_asb_country_spam_active'         => $options['country_code'] ? 'on' : '',
+					'rule_asb_bbcode_active'               => empty( $options['bbcode_check'] ) ? '' : 'on',
+					'rule_asb_valid_gravatar_active'       => empty( $options['gravatar_check'] ) ? '' : 'on',
+					'rule_asb_country_spam_active'         => empty( $options['country_code'] ) ? '' : 'on',
 					'rule_asb_country_spam_denied'         => $options['country_denied'] ?? '',
 					'rule_asb_country_spam_allowed'        => $options['country_allowed'] ?? '',
-					'rule_asb_lang_spam_active'            => $options['translate_api'] ? 'on' : '',
+					'rule_asb_lang_spam_active'            => empty( $options['translate_api'] ) ? '' : 'on',
 					'rule_asb_lang_spam_allowed'           => $allowed_languages,
 				],
 				'general'    => [
-					'general_delete_spam_cronjob_enabled_active' => $options['cronjob_enable'] ? 'on' : '',
+					'general_delete_spam_cronjob_enabled_active' => empty( $options['cronjob_enable'] ) ? '' : 'on',
 					'general_delete_spam_cronjob_enabled_delete_spam_cronjob_days' => $options['cronjob_interval'] ?? 30,
-					'general_statistics_on_dashboard_active' => $options['dashboard_count'] ? 'on' : '',
-					'general_ignore_linkbacks_active' => $options['ignore_pings'] ? 'on' : '',
-					'general_delete_data_on_uninstall_active' => $options['delete_data_on_uninstall'] ? 'on' : '',
+					'general_statistics_on_dashboard_active' => empty( $options['dashboard_count'] ) ? '' : 'on',
+					'general_ignore_linkbacks_active' => empty( $options['ignore_pings'] ) ? '' : 'on',
+					'general_delete_data_on_uninstall_active' => empty( $options['delete_data_on_uninstall'] ) ? '' : 'on',
 				],
 				'spam_count' => $options['spam_count'] ?? 0,
 			];

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\Handlers\PluginUpdate;
+use AntispamBee\Helpers\Settings;
+use ReflectionProperty;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'AntispamBee\MAIN_PLUGIN_FILE' ) ) {
+	define( 'AntispamBee\MAIN_PLUGIN_FILE', dirname( __DIR__, 3 ) . DIRECTORY_SEPARATOR . 'antispam_bee.php' );
+}
+
+/**
+ * Unit tests for the v2 to v3 option migration in {@see PluginUpdate}.
+ */
+class PluginUpdateTest extends TestCase {
+
+	/**
+	 * Options captured from `update_option()` calls, keyed by option name.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $written_options = [];
+
+	/**
+	 * Reset the memoized migration state and stub the option and plugin-file functions.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->reset_static( 'db_update_triggered', false );
+		$this->reset_static( 'db_version_is_current', null );
+
+		$this->written_options = [];
+
+		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0-beta.1' ] );
+		when( 'update_option' )->alias(
+			function ( $name, $value ) {
+				$this->written_options[ $name ] = $value;
+
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Reset a private static property of the handler between tests.
+	 *
+	 * @param string $name  Property name.
+	 * @param mixed  $value Value to reset it to.
+	 *
+	 * @return void
+	 */
+	private function reset_static( string $name, $value ): void {
+		$property = new ReflectionProperty( PluginUpdate::class, $name );
+		$property->setAccessible( true );
+		$property->setValue( null, $value );
+	}
+
+	/**
+	 * Stub `get_option()` with a fixed set of stored options.
+	 *
+	 * @param array<string, mixed> $stored Option values keyed by option name.
+	 *
+	 * @return void
+	 */
+	private function stub_options( array $stored ): void {
+		when( 'get_option' )->alias(
+			function ( $name, $default = false ) use ( $stored ) {
+				return array_key_exists( $name, $stored ) ? $stored[ $name ] : $default;
+			}
+		);
+	}
+
+	/**
+	 * A legacy option array that predates most v2 options must migrate without warnings.
+	 *
+	 * PHPUnit is configured with `convertWarningsToExceptions`, so an `Undefined array key`
+	 * warning raised by the migration fails this test.
+	 *
+	 * @return void
+	 */
+	public function test_partial_legacy_options_migrate_without_warnings(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'          => [
+					'regexp_check' => 1,
+					'spam_ip'      => 1,
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertArrayHasKey( Settings::OPTION_NAME, $this->written_options );
+	}
+
+	/**
+	 * Legacy options that are present and enabled are migrated as enabled, and keys that are
+	 * absent from the legacy array are migrated as disabled rather than raising a warning.
+	 *
+	 * @return void
+	 */
+	public function test_missing_legacy_keys_migrate_as_disabled(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'          => [
+					'regexp_check' => 1,
+					'spam_ip'      => 1,
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$comment = $this->written_options[ Settings::OPTION_NAME ]['comment'];
+
+		$this->assertSame( 'on', $comment['rule_asb_regexp_active'], 'A present, enabled legacy option stays enabled.' );
+		$this->assertSame( 'on', $comment['rule_asb_db_spam_active'], 'A present, enabled legacy option stays enabled.' );
+
+		$this->assertSame( '', $comment['post_processor_asb_send_email_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $comment['rule_asb_bbcode_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $comment['rule_asb_country_spam_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $comment['rule_asb_lang_spam_active'], 'A missing legacy option migrates as disabled.' );
+
+		$general = $this->written_options[ Settings::OPTION_NAME ]['general'];
+
+		$this->assertSame( '', $general['general_delete_spam_cronjob_enabled_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $general['general_statistics_on_dashboard_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $general['general_ignore_linkbacks_active'], 'A missing legacy option migrates as disabled.' );
+		$this->assertSame( '', $general['general_delete_data_on_uninstall_active'], 'A missing legacy option migrates as disabled.' );
+	}
+
+	/**
+	 * A legacy option that is explicitly disabled must not be migrated as enabled.
+	 *
+	 * @return void
+	 */
+	public function test_disabled_legacy_options_stay_disabled(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'          => [
+					'regexp_check'  => 0,
+					'bbcode_check'  => '',
+					'country_code'  => false,
+					'cronjob_enable' => 1,
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$comment = $this->written_options[ Settings::OPTION_NAME ]['comment'];
+
+		$this->assertSame( '', $comment['rule_asb_regexp_active'] );
+		$this->assertSame( '', $comment['rule_asb_bbcode_active'] );
+		$this->assertSame( '', $comment['rule_asb_country_spam_active'] );
+
+		$general = $this->written_options[ Settings::OPTION_NAME ]['general'];
+
+		$this->assertSame( 'on', $general['general_delete_spam_cronjob_enabled_active'] );
+	}
+
+	/**
+	 * A legacy option value that is not an array at all must not abort the migration.
+	 *
+	 * @return void
+	 */
+	public function test_non_array_legacy_options_do_not_abort_the_migration(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'          => 'corrupted',
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$comment = $this->written_options[ Settings::OPTION_NAME ]['comment'];
+
+		$this->assertSame( '', $comment['rule_asb_regexp_active'] );
+		$this->assertSame( 'on', $comment['rule_asb_honeypot_active'], 'The honeypot rule is always migrated as enabled.' );
+	}
+}


### PR DESCRIPTION
Fixes the first half of #793. The retry half is split out as #798.

## Problem

`Handlers\PluginUpdate::maybe_update_database()` read most legacy `antispam_bee` keys directly, without a null coalescing operator. A v2 option array that predates any of those keys — which is what a site holds if it never re-saved its settings after a 2.x upgrade — emits `Undefined array key` warnings.

On installs that promote warnings to exceptions the migration aborts partway. Because `antispambee_db_version` is bumped *before* the migration runs, it is never retried: the legacy options stay in the database, `antispam_bee_options` is never written, and the site silently falls back to `Settings::$defaults`.

## Solution

Every legacy flag read now goes through a new `legacy_flag()` helper that treats a missing key as disabled. A legacy option that is not an array at all is coerced to an empty array.

The helper is deliberately used instead of an inline `?? false`, because `??` binds *looser* than the ternary — `$options['x'] ?? false ? 'on' : ''` parses as `$options['x'] ?? ''` and would have reintroduced the exact bug.

`flag_spam` and `no_notice` were already guarded by `isset()` and are unchanged; the key list in #793 is slightly over-inclusive there.

## Test steps

1. On a v2 install, shrink the legacy option to a partial array:
   `wp option update antispam_bee '{"regexp_check":1,"spam_ip":1}' --format=json`
2. `wp option update antispambee_db_version 1.02`
3. Load any page with `WP_DEBUG` on and warnings promoted to exceptions.
4. Before: `Undefined array key "email_notify"`, and `antispam_bee_options` is never written.
   After: migrates cleanly, missing options land as disabled, `regexp` and `db_spam` as `on`.

## Verification

- 4 new unit tests in `tests/Unit/Handlers/PluginUpdateTest.php`; all 4 fail on `v3` with the reported warning and pass with the fix.
- `composer test:unit` 66/66, `composer phpstan` clean, `phpcs` clean on the changed files.

Refs #793
