### PR TITLE
chore: pin the E2E environment to WordPress 7.0

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress",
+	"core": "WordPress/WordPress#7.0",
 	"phpVersion": "8.2",
 	"plugins": [
 		"."

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"env:start": "wp-env start",
 		"env:stop": "wp-env stop",
-		"env:clean": "wp-env clean tests",
+		"env:clean": "wp-env reset tests",
 		"env:destroy": "wp-env destroy",
 		"test:e2e": "wp-scripts test-playwright",
 		"test:e2e:ui": "wp-scripts test-playwright --ui",


### PR DESCRIPTION
Fixes #802.

## Problem

`.wp-env.json` set `"core": "WordPress/WordPress"`, which resolves to the default branch of the WordPress git repository — trunk. Locally this built:

```
$ wp-env run tests-cli wp core version
7.1-alpha-62566
```

So local development ran against an unreleased WordPress alpha, and that version changed silently whenever the environment was rebuilt.

Two concrete consequences, both observed:

1. **Non-reproducible local results.** Two developers on the same commit can be on different WordPress builds, and a failure may or may not reproduce without either of them thinking to check `wp core version`.
2. **The git checkout is not a release build.** It does not carry the bundled default themes, so the environment came up with **no active theme at all** — only `twentyeleven`, inactive. With the `7.0` pin it activates `twentytwentyfive` 1.5, as a real install does.

## Scope — CI was not affected

This is worth stating explicitly, because an earlier version of this description got it wrong.

`tests.yml` writes a per-matrix `.wp-env.override.json` before starting the environment:

```bash
case "${{ matrix.wordpress }}" in
  nightly) CORE="WordPress/WordPress" ;;
  latest)  CORE="https://wordpress.org/latest.zip" ;;
  *)       CORE="https://wordpress.org/wordpress-${{ matrix.wordpress }}.zip" ;;
esac
```

The override takes precedence, so **CI never used the committed `core` value** and its matrix (`nightly`, `latest`, `7.0`, `6.9`, `6.8`, `6.7`, `6.6`, `6.0`, `5.6`) was already correct. This pin governs local development only — which is exactly where the problem showed up.

## Solution

Pin `core` to the `7.0` tag, matching the `Tested up to` line in `readme.txt`.

Also switch `env:clean` from `wp-env clean` to `wp-env reset`, since the former now warns:

```
⚠ The `clean` command is deprecated. Use `reset` instead.
```

## Note on the exact pin

This pins `7.0`, not `7.0.3`. Patch releases up to `7.0.3` exist, and pinning the bare `.0` tag means local environments never pick up 7.0.x fixes. Deliberate for now, and cheap to change later.

`wp-env` does not support semver ranges such as `^7`: `core` accepts only a path, a `<owner>/<repo>[#<ref>]` git ref, an SSH repo, a ZIP URL, or `null` for the latest production release.

## Test steps

```bash
npm run env:destroy
npm run env:start
npx wp-env run tests-cli wp core version   # 7.0
npm run test:e2e
```

## Verification

- Environment rebuilds as **WordPress 7.0** and activates `twentytwentyfive` 1.5, as a release build does.
- Full E2E suite on the pinned version: **37 passed, 2 skipped** — unchanged from trunk, so the pin regresses nothing.

---

*Description corrected: the original claimed this affected CI reproducibility. It did not — `tests.yml` overrides `core` per matrix entry, so the impact was limited to local development.*
