### PR TITLE
docs: note that issues merged into `v3` must be closed by hand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,9 @@ Excludes tracked files from `git archive` exports via `export-ignore`.
 - Include a short summary of what changed and why
 - Add test steps when the change affects user-facing behavior; pure code style fixes do not need
   them
+- **Close the issue manually.** GitHub only acts on closing keywords such as `Fixes #123` when a
+  pull request is merged into the repository's *default* branch, which is currently `master`. A
+  pull request merged into `v3` leaves its issue open, however the description is worded — close
+  it by hand with a short comment naming the pull request that fixed it. Still write the keyword,
+  so the issue and the pull request stay linked. This stops applying once `v3` becomes the default
+  branch.


### PR DESCRIPTION
## Problem

GitHub only acts on closing keywords such as `Fixes #123` when a pull request is merged into the repository's **default** branch. That is `master`, so every pull request merged into `v3` leaves its issue open no matter how the description is worded.

This is easy to miss precisely because the description *looks* right — the keyword is there, the timeline shows the link, and nothing signals that the close never happened.

It already caught four issues in 3.0.0-beta.2. #790, #792, #801 and #802 each had a closing keyword in the merging pull request, and all four were still open afterwards and had to be closed by hand.

## Solution

A bullet under **Pull requests** in `AGENTS.md`.

Two deliberate details:

* It says to **keep writing the keyword**. It still creates the visible issue ↔ pull request link in the timeline, even when it does not close anything.
* It states when the rule expires — once `v3` becomes the default branch, this stops applying. Better than leaving a rule nobody knows to delete.

## Test steps

None; documentation only.
