### PR TITLE
feat: resolve both log files from `WP_DEBUG_LOG`-shaped constants

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,7 @@ No, Antispam Bee is free forever, for both private and commercial projects. You 
 Complete documentation is available on [pluginkollektiv.org](https://antispambee.pluginkollektiv.org/documentation/).
 
 ### Can I log detected spam for Fail2Ban? ###
-Yes. Define the constant `ANTISPAM_BEE_LOG_FILE` in your `wp-config.php` with the path to a writable file. Antispam Bee then appends one line per detected spam item:
+Yes. Define the constant `ANTISPAM_BEE_SPAM_LOG` in your `wp-config.php`. Set it to the path of a writable file to choose the name yourself, which is what a Fail2Ban jail needs, or to `true` to let Antispam Bee pick one. Antispam Bee then appends one line per detected spam item:
 
 > 2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot
 
@@ -137,6 +137,10 @@ Two things to know when writing your own. Fail2Ban removes the timestamp from th
 To add a field of your own, use the `antispam_bee_spam_log_fields` filter: it receives the fields as an associative array, and anything you append becomes another `key=value` pair at the end of the line. Keys and values are cleaned up afterwards, so an added field cannot break the format.
 
 To replace the line wholesale — with CSV, JSON or anything else — use the `antispam_bee_spam_log_entry` filter, or return an empty string from it to skip an item.
+
+With `true`, the file is written to the directory in `ANTISPAM_BEE_SPAM_LOG_DIR`, or to `wp-content` when that is unset, under a name ending in a site-specific suffix — the log holds IP addresses, and `wp-content` is usually reachable from the web, so the name must not be guessable. The suffix does not change, so a Fail2Ban `logpath` keeps matching it.
+
+The older `ANTISPAM_BEE_LOG_FILE` still works and is read as a file path. It will be removed in 4.0.
 
 ### How can I report security bugs? ###
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -7,13 +7,17 @@
 
 namespace AntispamBee\Helpers;
 
-use const ANTISPAM_BEE_DEBUG_MODE_ENABLED;
-use const WP_CONTENT_DIR;
-
 /**
  * Debug Mode.
  */
 class DebugMode {
+	/**
+	 * File name prefix of the debug log.
+	 *
+	 * @var string
+	 */
+	const LOG_PREFIX = 'asb-debug';
+
 	/**
 	 * Is debug mode enabled?
 	 *
@@ -33,44 +37,46 @@ class DebugMode {
 			return;
 		}
 
-		$date        = date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-		$time        = date( 'H-i-s' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-		$content_dir = WP_CONTENT_DIR;
-		$suffix      = self::get_log_file_suffix();
+		$log_file = static::get_log_file();
 
-		if ( null === $suffix ) {
+		if ( null === $log_file ) {
 			return;
 		}
+
+		$date = date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$time = date( 'H-i-s' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 
 		// Comment data reaches the log, so a line break in the message would let
 		// an attacker forge additional log entries.
 		$message = (string) preg_replace( '/[\r\n]+/', ' ', $message );
 
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug use.
-		error_log( "[{$date} {$time}] {$message}\n", 3, "{$content_dir}/asb-debug.{$date}.{$suffix}.log" );
+		error_log( "[{$date} {$time}] {$message}\n", 3, $log_file );
 	}
 
 	/**
-	 * Get the salted log file suffix.
+	 * Get the debug log file path.
 	 *
-	 * The log contains comment data and `WP_CONTENT_DIR` is usually served
-	 * publicly, so the file name must not be guessable.
+	 * A generated name carries a salted suffix, because the log contains comment
+	 * data and `WP_CONTENT_DIR` is usually served publicly. {@see LogPath::suffix()}
+	 * yields nothing when no secret salt is available, in which case this returns
+	 * `null` and logging is skipped rather than writing to a guessable file name.
 	 *
-	 * {@see Salt::get()} prefers a configured `NONCE_SALT` and otherwise falls
-	 * back to `wp_salt()`, so a secret is normally always available. Should it
-	 * ever yield nothing, this returns `null` and logging is skipped rather than
-	 * falling back to a predictable value.
-	 *
-	 * @return string|null Suffix, or null if no secret salt is available.
+	 * @return string|null Path, or null when debug logging is off.
 	 */
-	private static function get_log_file_suffix(): ?string {
-		$salt = Salt::get();
+	public static function get_log_file(): ?string {
+		$log_file = LogPath::resolve( 'ANTISPAM_BEE_DEBUG_LOG', 'ANTISPAM_BEE_DEBUG_LOG_DIR', self::LOG_PREFIX, true );
 
-		if ( '' === $salt ) {
-			return null;
+		if ( null !== $log_file ) {
+			return $log_file;
 		}
 
-		return substr( sha1( 'asb-debug' . $salt ), 0, 12 );
+		// Deprecated since 3.0.0, use `ANTISPAM_BEE_DEBUG_LOG` instead.
+		if ( defined( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED' ) && \ANTISPAM_BEE_DEBUG_MODE_ENABLED ) {
+			return LogPath::generate( 'ANTISPAM_BEE_DEBUG_LOG_DIR', self::LOG_PREFIX, true );
+		}
+
+		return null;
 	}
 
 	/**
@@ -80,7 +86,7 @@ class DebugMode {
 	 */
 	public static function enabled(): bool {
 		if ( null === static::$debug_mode_enabled ) {
-			static::$debug_mode_enabled = defined( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED' ) ? ANTISPAM_BEE_DEBUG_MODE_ENABLED : false;
+			static::$debug_mode_enabled = null !== static::get_log_file();
 		}
 
 		return static::$debug_mode_enabled;

--- a/src/Helpers/LogPath.php
+++ b/src/Helpers/LogPath.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Log file path resolution.
+ *
+ * @package AntispamBee\Helpers
+ */
+
+namespace AntispamBee\Helpers;
+
+/**
+ * Resolves the log file paths from their `wp-config.php` constants.
+ */
+class LogPath {
+
+	/**
+	 * Resolve a log file path from its constants.
+	 *
+	 * The log constant doubles as the switch that turns the log on, following the shape of
+	 * `WP_DEBUG_LOG`:
+	 *
+	 * - undefined, `false` or an empty string — the log is off
+	 * - `true` — on, written to a generated file name inside the directory constant, or
+	 *   `WP_CONTENT_DIR` when that is unset
+	 * - a string — on, written to exactly that path
+	 *
+	 * A generated name carries a salted suffix, because the default directory is usually
+	 * served publicly and both logs contain personal data. An explicit path is used verbatim
+	 * and never salted: a Fail2Ban jail has to be told the name in advance.
+	 *
+	 * @param string $log_constant Name of the constant that enables the log.
+	 * @param string $dir_constant Name of the constant holding the target directory.
+	 * @param string $prefix       File name prefix, also salted into the suffix.
+	 * @param bool   $dated        Whether a generated name carries the current date.
+	 *
+	 * @return string|null Absolute path, or null when the log is off.
+	 */
+	public static function resolve( string $log_constant, string $dir_constant, string $prefix, bool $dated = false ): ?string {
+		if ( ! defined( $log_constant ) ) {
+			return null;
+		}
+
+		$value = constant( $log_constant );
+
+		if ( is_string( $value ) ) {
+			return '' === $value ? null : $value;
+		}
+
+		if ( true !== $value ) {
+			return null;
+		}
+
+		return self::generate( $dir_constant, $prefix, $dated );
+	}
+
+	/**
+	 * Build a generated log file path.
+	 *
+	 * @param string $dir_constant Name of the constant holding the target directory.
+	 * @param string $prefix       File name prefix, also salted into the suffix.
+	 * @param bool   $dated        Whether the name carries the current date.
+	 *
+	 * @return string Absolute path.
+	 */
+	public static function generate( string $dir_constant, string $prefix, bool $dated = false ): ?string {
+		$suffix = self::suffix( $prefix );
+
+		if ( null === $suffix ) {
+			return null;
+		}
+
+		$name = $prefix;
+
+		if ( $dated ) {
+			$name .= '.' . date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- File name, matches the timestamps written inside.
+		}
+
+		$name .= '.' . $suffix . '.log';
+
+		return self::directory( $dir_constant ) . '/' . $name;
+	}
+
+	/**
+	 * Get the directory a generated log file is written to.
+	 *
+	 * @param string $dir_constant Name of the constant holding the target directory.
+	 *
+	 * @return string Directory without a trailing separator.
+	 */
+	private static function directory( string $dir_constant ): string {
+		$dir = defined( $dir_constant ) ? constant( $dir_constant ) : null;
+
+		if ( ! is_string( $dir ) || '' === $dir ) {
+			$dir = WP_CONTENT_DIR;
+		}
+
+		return rtrim( $dir, '/\\' );
+	}
+
+	/**
+	 * Get the salted file name suffix.
+	 *
+	 * The logs contain personal data and `WP_CONTENT_DIR` is usually served publicly, so a
+	 * generated file name must not be guessable.
+	 *
+	 * {@see Salt::get()} prefers a configured `NONCE_SALT` and otherwise falls back to
+	 * `wp_salt()`, so a secret is normally always available. Should it ever yield nothing,
+	 * this returns `null` and the caller skips logging rather than writing to a file name
+	 * derived from a predictable value.
+	 *
+	 * @param string $prefix File name prefix.
+	 *
+	 * @return string|null Twelve hexadecimal characters, or null if no secret salt is available.
+	 */
+	public static function suffix( string $prefix ): ?string {
+		$salt = Salt::get();
+
+		if ( '' === $salt ) {
+			return null;
+		}
+
+		return substr( sha1( $prefix . $salt ), 0, 12 );
+	}
+
+	/**
+	 * Whether a log file can be written to.
+	 *
+	 * A generated file does not exist before the first write, so an absent file is writable
+	 * when its directory is.
+	 *
+	 * @param string $path Log file path.
+	 *
+	 * @return bool Whether the path can be written to.
+	 */
+	public static function is_writable( string $path ): bool {
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- WP_Filesystem cannot perform an atomic FILE_APPEND | LOCK_EX write to the log file.
+		if ( file_exists( $path ) ) {
+			return is_writable( $path );
+		}
+
+		return is_writable( dirname( $path ) );
+		// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+	}
+}

--- a/src/PostProcessors/UpdateSpamLog.php
+++ b/src/PostProcessors/UpdateSpamLog.php
@@ -7,10 +7,19 @@
 
 namespace AntispamBee\PostProcessors;
 
+use AntispamBee\Helpers\LogPath;
+
 /**
  * Post-processor that is responsible for updating the spam log file.
  */
 class UpdateSpamLog extends Base {
+	/**
+	 * File name prefix of the spam log.
+	 *
+	 * @var string
+	 */
+	const LOG_PREFIX = 'asb-spam';
+
 
 	/**
 	 * Post-processor slug.
@@ -37,12 +46,12 @@ class UpdateSpamLog extends Base {
 			return $item;
 		}
 
+		$log_file = self::get_log_file();
+
 		if (
-			! defined( 'ANTISPAM_BEE_LOG_FILE' )
-			|| ! ANTISPAM_BEE_LOG_FILE
-			|| validate_file( ANTISPAM_BEE_LOG_FILE ) !== 0
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- WP_Filesystem cannot perform an atomic FILE_APPEND | LOCK_EX write to the log file.
-			|| ! is_writable( ANTISPAM_BEE_LOG_FILE )
+			null === $log_file
+			|| validate_file( $log_file ) !== 0
+			|| ! LogPath::is_writable( $log_file )
 		) {
 			return $item;
 		}
@@ -76,7 +85,7 @@ class UpdateSpamLog extends Base {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- WP_Filesystem cannot perform an atomic FILE_APPEND | LOCK_EX write to the log file.
 		file_put_contents(
-			ANTISPAM_BEE_LOG_FILE,
+			$log_file,
 			$entry . PHP_EOL,
 			FILE_APPEND | LOCK_EX
 		);
@@ -267,5 +276,28 @@ class UpdateSpamLog extends Base {
 		$sanitized = preg_replace( '/[^a-zA-Z0-9_\-]/', '', (string) $token );
 
 		return empty( $sanitized ) ? 'unknown' : $sanitized;
+	}
+	/**
+	 * Get the spam log file path.
+	 *
+	 * Unlike the debug log the generated name carries no date. A Fail2Ban jail expands
+	 * `logpath` globs when it starts, so a file name that changes daily would stop being
+	 * matched until the jail is reloaded.
+	 *
+	 * @return string|null Path, or null when spam logging is off.
+	 */
+	public static function get_log_file(): ?string {
+		$log_file = LogPath::resolve( 'ANTISPAM_BEE_SPAM_LOG', 'ANTISPAM_BEE_SPAM_LOG_DIR', self::LOG_PREFIX );
+
+		if ( null !== $log_file ) {
+			return $log_file;
+		}
+
+		// Deprecated since 3.0.0, use `ANTISPAM_BEE_SPAM_LOG` instead.
+		if ( defined( 'ANTISPAM_BEE_LOG_FILE' ) && \ANTISPAM_BEE_LOG_FILE ) {
+			return (string) \ANTISPAM_BEE_LOG_FILE;
+		}
+
+		return null;
 	}
 }

--- a/tests/Unit/Helpers/DebugModeTest.php
+++ b/tests/Unit/Helpers/DebugModeTest.php
@@ -5,10 +5,32 @@ namespace AntispamBee\Tests\Unit\Helpers;
 use AntispamBee\Helpers\DebugMode;
 use ReflectionProperty;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
-use function Brain\Monkey\Functions\when;
 
-if ( ! defined( 'WP_CONTENT_DIR' ) ) {
-	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/asb-debug-mode-test' );
+/**
+ * A {@see DebugMode} whose log path is injected rather than resolved from a constant.
+ *
+ * The real resolution goes through constants, which cannot be undefined again and would
+ * therefore leak into every other test file in the run — enabling debug logging for tests
+ * that never asked for it. Where the path comes from is {@see LogPathTest}'s subject; what
+ * gets written to it is this one's.
+ */
+class InjectedDebugMode extends DebugMode {
+
+	/**
+	 * Path returned instead of resolving one, or null for "no log configured".
+	 *
+	 * @var string|null
+	 */
+	public static $path = null;
+
+	/**
+	 * Get the debug log file path.
+	 *
+	 * @return string|null The injected path.
+	 */
+	public static function get_log_file(): ?string {
+		return self::$path;
+	}
 }
 
 /**
@@ -17,18 +39,18 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 class DebugModeTest extends TestCase {
 
 	/**
-	 * The salt `wp_salt()` returns.
+	 * Path the injected log writes to.
 	 *
 	 * @var string
 	 */
-	private $salt = 'test-salt';
+	private $log_file;
 
 	public function test_log_writes_a_single_line_per_entry(): void {
 		self::force_debug_mode( true );
 
-		DebugMode::log( "first\nsecond\r\nthird" );
+		InjectedDebugMode::log( "first\nsecond\r\nthird" );
 
-		$contents = self::read_log();
+		$contents = (string) file_get_contents( $this->log_file );
 
 		self::assertCount(
 			1,
@@ -45,50 +67,28 @@ class DebugModeTest extends TestCase {
 	public function test_log_writes_nothing_when_debug_mode_is_disabled(): void {
 		self::force_debug_mode( false );
 
-		DebugMode::log( 'should not be written' );
+		InjectedDebugMode::log( 'should not be written' );
 
-		self::assertSame(
-			[],
-			self::log_files(),
+		self::assertFileDoesNotExist(
+			$this->log_file,
 			'Nothing should be logged while debug mode is off'
 		);
 	}
 
 	/**
-	 * The file name is derived from the salt, so without one there is nothing to
-	 * make the name unguessable and nothing may be written. `wp_salt()` normally
-	 * always returns a secret, so this is a safety net rather than a case that is
-	 * expected to occur.
+	 * Without a resolvable path there is nothing to write to, so logging is skipped. That
+	 * happens when no log constant is defined, and also when no secret salt is available to
+	 * make a generated file name unguessable — see {@see LogPathTest}.
 	 */
-	public function test_log_writes_nothing_without_a_secret_salt(): void {
-		$this->salt = '';
+	public function test_log_writes_nothing_without_a_log_file(): void {
 		self::force_debug_mode( true );
+		InjectedDebugMode::$path = null;
 
-		DebugMode::log( 'should not be written' );
+		InjectedDebugMode::log( 'should not be written' );
 
-		self::assertSame(
-			[],
-			self::log_files(),
-			'Without a salt the file name would be guessable, so nothing may be logged'
-		);
-	}
-
-	public function test_log_file_name_is_derived_from_the_salt(): void {
-		self::force_debug_mode( true );
-
-		DebugMode::log( 'first entry' );
-		$first = self::log_files();
-
-		self::remove_log_files();
-		$this->salt = 'another-salt';
-
-		DebugMode::log( 'second entry' );
-		$second = self::log_files();
-
-		self::assertNotSame(
-			$first,
-			$second,
-			'A different salt must produce a different, unguessable file name'
+		self::assertFileDoesNotExist(
+			$this->log_file,
+			'Without a log file path nothing may be written'
 		);
 	}
 
@@ -100,17 +100,8 @@ class DebugModeTest extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		when( 'wp_salt' )->alias(
-			function () {
-				return $this->salt;
-			}
-		);
-
-		if ( ! is_dir( WP_CONTENT_DIR ) ) {
-			mkdir( WP_CONTENT_DIR, 0777, true );
-		}
-
-		self::remove_log_files();
+		$this->log_file          = sys_get_temp_dir() . '/asb-debug-mode-test-' . uniqid() . '.log';
+		InjectedDebugMode::$path = $this->log_file;
 	}
 
 	/**
@@ -119,14 +110,18 @@ class DebugModeTest extends TestCase {
 	 * @return void
 	 */
 	protected function tear_down() {
-		self::remove_log_files();
+		if ( file_exists( $this->log_file ) ) {
+			unlink( $this->log_file );
+		}
+
+		InjectedDebugMode::$path = null;
 		self::force_debug_mode( null );
 
 		parent::tear_down();
 	}
 
 	/**
-	 * Override the cached debug mode state, which is otherwise read from a constant.
+	 * Override the cached debug mode state, which is otherwise derived from the log path.
 	 *
 	 * @param bool|null $enabled Whether debug mode is enabled, or null to reset.
 	 *
@@ -136,38 +131,5 @@ class DebugModeTest extends TestCase {
 		$property = new ReflectionProperty( DebugMode::class, 'debug_mode_enabled' );
 		$property->setAccessible( true );
 		$property->setValue( null, $enabled );
-	}
-
-	/**
-	 * All log files the helper may have written.
-	 *
-	 * @return string[] List of file paths.
-	 */
-	private static function log_files(): array {
-		return glob( WP_CONTENT_DIR . '/asb-debug.*.log' ) ?: [];
-	}
-
-	/**
-	 * Read the single log file that was written.
-	 *
-	 * @return string The log file contents.
-	 */
-	private static function read_log(): string {
-		$files = self::log_files();
-
-		self::assertCount( 1, $files, 'Exactly one log file should have been written' );
-
-		return (string) file_get_contents( $files[0] );
-	}
-
-	/**
-	 * Remove any log files left behind.
-	 *
-	 * @return void
-	 */
-	private static function remove_log_files(): void {
-		foreach ( self::log_files() as $file ) {
-			unlink( $file );
-		}
 	}
 }

--- a/tests/Unit/Helpers/LogPathTest.php
+++ b/tests/Unit/Helpers/LogPathTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\LogPath;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', '/var/www/wp-content' );
+}
+/*
+ * The salt deliberately comes from a mocked `wp_salt()` rather than a defined `NONCE_SALT`.
+ * A constant cannot be undefined again, and `Salt::get()` prefers it over `wp_salt()`, so
+ * defining one here would leak into every other test file in the run — including
+ * {@see DebugModeTest}, which asserts that changing the salt changes the log file name.
+ */
+
+// The resolver reads constants by name, and a constant cannot be undefined again, so each
+// case gets its own constant rather than redefining a shared one.
+define( 'ASB_TEST_LOG_TRUE', true );
+define( 'ASB_TEST_LOG_FALSE', false );
+define( 'ASB_TEST_LOG_EMPTY', '' );
+define( 'ASB_TEST_LOG_PATH', '/var/log/antispam-bee.log' );
+define( 'ASB_TEST_DIR', '/srv/logs' );
+define( 'ASB_TEST_DIR_TRAILING', '/srv/logs/' );
+define( 'ASB_TEST_DIR_EMPTY', '' );
+
+/**
+ * Unit tests for {@see LogPath}.
+ */
+class LogPathTest extends TestCase {
+
+	/**
+	 * The salt every generated name in these tests is derived from.
+	 *
+	 * Long enough and free of whitespace, so `Salt` treats it as a real salt rather than an
+	 * unconfigured placeholder.
+	 *
+	 * @var string
+	 */
+	private const SALT = 'aFixedSaltForTestsLongEnoughToCountAsGenerated0123456789';
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		when( 'wp_salt' )->justReturn( self::SALT );
+	}
+
+	/**
+	 * An undefined log constant means the log is off.
+	 *
+	 * @return void
+	 */
+	public function test_undefined_constant_disables_the_log(): void {
+		$this->assertNull(
+			LogPath::resolve( 'ASB_TEST_LOG_NOT_DEFINED', 'ASB_TEST_DIR', 'asb-spam' )
+		);
+	}
+
+	/**
+	 * `false` and an empty string mean the log is off.
+	 *
+	 * @return void
+	 */
+	public function test_falsey_constant_disables_the_log(): void {
+		$this->assertNull( LogPath::resolve( 'ASB_TEST_LOG_FALSE', 'ASB_TEST_DIR', 'asb-spam' ) );
+		$this->assertNull( LogPath::resolve( 'ASB_TEST_LOG_EMPTY', 'ASB_TEST_DIR', 'asb-spam' ) );
+	}
+
+	/**
+	 * A string is used verbatim, without a salted suffix — a Fail2Ban jail has to be told
+	 * the file name in advance.
+	 *
+	 * @return void
+	 */
+	public function test_string_constant_is_used_verbatim(): void {
+		$this->assertSame(
+			'/var/log/antispam-bee.log',
+			LogPath::resolve( 'ASB_TEST_LOG_PATH', 'ASB_TEST_DIR', 'asb-spam' )
+		);
+	}
+
+	/**
+	 * `true` generates a salted name inside the directory constant.
+	 *
+	 * @return void
+	 */
+	public function test_true_generates_a_salted_name_in_the_directory(): void {
+		$path = LogPath::resolve( 'ASB_TEST_LOG_TRUE', 'ASB_TEST_DIR', 'asb-spam' );
+
+		$this->assertSame( '/srv/logs/asb-spam.' . LogPath::suffix( 'asb-spam' ) . '.log', $path );
+		$this->assertMatchesRegularExpression( '#/asb-spam\.[0-9a-f]{12}\.log$#', (string) $path );
+	}
+
+	/**
+	 * The spam log name carries no date, so a Fail2Ban `logpath` keeps matching it.
+	 *
+	 * @return void
+	 */
+	public function test_undated_name_has_no_date_component(): void {
+		$path = LogPath::resolve( 'ASB_TEST_LOG_TRUE', 'ASB_TEST_DIR', 'asb-spam' );
+
+		$this->assertDoesNotMatchRegularExpression( '#\d{4}-\d{2}-\d{2}#', (string) $path );
+	}
+
+	/**
+	 * The debug log name carries the date, as it did before.
+	 *
+	 * @return void
+	 */
+	public function test_dated_name_carries_the_date(): void {
+		$path = LogPath::generate( 'ASB_TEST_DIR', 'asb-debug', true );
+
+		$this->assertSame(
+			'/srv/logs/asb-debug.' . date( 'Y-m-d' ) . '.' . LogPath::suffix( 'asb-debug' ) . '.log',
+			$path
+		);
+	}
+
+	/**
+	 * The generated debug name matches what 3.0.0-beta.2 wrote, so an existing debug log
+	 * keeps its file name across the constant rename.
+	 *
+	 * @return void
+	 */
+	public function test_debug_suffix_is_unchanged_from_the_previous_implementation(): void {
+		$this->assertSame(
+			substr( sha1( 'asb-debug' . self::SALT ), 0, 12 ),
+			LogPath::suffix( 'asb-debug' )
+		);
+	}
+
+	/**
+	 * Each log gets its own suffix, so one file name cannot be derived from the other.
+	 *
+	 * @return void
+	 */
+	public function test_suffix_differs_per_prefix(): void {
+		$this->assertNotSame( LogPath::suffix( 'asb-debug' ), LogPath::suffix( 'asb-spam' ) );
+	}
+
+	/**
+	 * The file name is derived from the salt, so two sites cannot be guessed from one
+	 * another's.
+	 *
+	 * @return void
+	 */
+	public function test_name_is_derived_from_the_salt(): void {
+		$first = LogPath::generate( 'ASB_TEST_DIR', 'asb-debug', true );
+
+		when( 'wp_salt' )->justReturn( 'a-completely-different-salt-that-is-long-enough' );
+
+		$this->assertNotSame(
+			$first,
+			LogPath::generate( 'ASB_TEST_DIR', 'asb-debug', true ),
+			'A different salt must produce a different, unguessable file name'
+		);
+	}
+
+	/**
+	 * Without a secret there is nothing to make a generated name unguessable, so no path
+	 * is produced at all and the caller skips logging. `Salt::get()` normally always
+	 * returns a secret, so this is a safety net rather than an expected case.
+	 *
+	 * @return void
+	 */
+	public function test_no_generated_path_without_a_secret_salt(): void {
+		when( 'wp_salt' )->justReturn( '' );
+
+		$this->assertNull( LogPath::suffix( 'asb-spam' ) );
+		$this->assertNull( LogPath::generate( 'ASB_TEST_DIR', 'asb-spam' ) );
+		$this->assertNull( LogPath::resolve( 'ASB_TEST_LOG_TRUE', 'ASB_TEST_DIR', 'asb-spam' ) );
+	}
+
+	/**
+	 * An unset or empty directory constant falls back to `WP_CONTENT_DIR`, and a trailing
+	 * separator does not produce a doubled one.
+	 *
+	 * @return void
+	 */
+	public function test_directory_fallback_and_trailing_separator(): void {
+		$this->assertStringStartsWith(
+			WP_CONTENT_DIR . '/',
+			(string) LogPath::resolve( 'ASB_TEST_LOG_TRUE', 'ASB_TEST_DIR_NOT_DEFINED', 'asb-spam' )
+		);
+		$this->assertStringStartsWith(
+			WP_CONTENT_DIR . '/',
+			(string) LogPath::resolve( 'ASB_TEST_LOG_TRUE', 'ASB_TEST_DIR_EMPTY', 'asb-spam' )
+		);
+		$this->assertStringStartsWith(
+			'/srv/logs/asb-spam.',
+			LogPath::generate( 'ASB_TEST_DIR_TRAILING', 'asb-spam' )
+		);
+	}
+
+	/**
+	 * A file that does not exist yet is writable when its directory is, since a generated
+	 * log is only created on the first write.
+	 *
+	 * @return void
+	 */
+	public function test_absent_file_is_writable_when_its_directory_is(): void {
+		$dir = sys_get_temp_dir() . '/asb-logpath-' . uniqid();
+		mkdir( $dir );
+
+		$this->assertTrue( LogPath::is_writable( $dir . '/does-not-exist.log' ) );
+		$this->assertFalse( LogPath::is_writable( $dir . '/missing-dir/nope.log' ) );
+
+		rmdir( $dir );
+	}
+}


### PR DESCRIPTION
Still a draft, but for a different reason than when it was opened: the constant scheme below is settled, and what is left is one decision about backward compatibility — see *The open question* at the end.

> **No longer stacked.** #797 has merged and this is now based on `v3`, rebased onto the merged commit rather than merged with it. Its remaining conflict-resolution decisions are described under *Rebased onto the merged #797*.

## What this does

Configures both logs the same way, following the shape of `WP_DEBUG_LOG`:

| Constant | Meaning |
| --- | --- |
| `ANTISPAM_BEE_SPAM_LOG` | `true` to enable with a generated name, or a string path |
| `ANTISPAM_BEE_SPAM_LOG_DIR` | where a generated file goes, default `WP_CONTENT_DIR` |
| `ANTISPAM_BEE_DEBUG_LOG` | as above, for the debug log |
| `ANTISPAM_BEE_DEBUG_LOG_DIR` | as above |

`ANTISPAM_BEE_LOG_FILE` and `ANTISPAM_BEE_DEBUG_MODE_ENABLED` keep working.

## Two decisions worth reviewing

**A generated name is salted; an explicit path never is.** The default directory is usually served publicly and both logs contain personal data, so a generated name must not be guessable. But a Fail2Ban jail has to be told the file name in advance, which is exactly what the string form is for. `LogPath::suffix()` reproduces the previous `asb-debug` suffix bit for bit, so an existing debug log keeps its file name across the rename — covered by a test.

**The generated spam log name carries no date; the debug log's still does.** Fail2Ban expands `logpath` globs when a jail starts or reloads, so a file name that changes daily silently stops being matched until someone reloads. The debug log is read by humans and keeps its date.

That asymmetry is the main thing I would like a second opinion on.

## Rebased onto the merged #797

Three things `v3` changed while this branch waited had to be carried in rather than resolved away.

**The salted suffix now comes from `Salt::get()`.** `LogPath::suffix()` was written before `v3` gained the `Salt` helper and fell back to `ABSPATH` when `NONCE_SALT` was undefined — precisely the predictable fallback `v3` then removed in *do not log when no secret salt is available*. Resolving the conflict in this branch's favour would have quietly reinstated a guessable log file name. `suffix()` now returns `null` when no secret is available, `generate()` and both callers propagate that, and logging is skipped rather than writing to a guessable name. `DebugMode` also keeps the line-break collapsing it gained in the meantime, which this branch predates.

**`DebugMode::log()` and `enabled()` call `static::get_log_file()`.** One word, so a subclass can supply the path in tests. The path is resolved from constants, and a constant defined in a test file cannot be undefined again — defining one leaked into the whole suite and switched debug logging on for tests that never asked for it, which surfaced as `RulesTest` reaching an unmocked `wp_salt()`. The tests inject a path instead of defining a constant.

**`LogPathTest` mocks `wp_salt()` rather than defining `NONCE_SALT`,** for the same reason in the other direction: the constant takes precedence over the salt `DebugModeTest` mocks, and would have broken its assertion that a different salt yields a different file name. That assertion moved here, where the name is actually generated.

## The open question

**Should `ANTISPAM_BEE_LOG_FILE` write the pre-3.0 line?**

When this PR was opened the format was still undecided, so both constants deliberately wrote the same thing. #797 has now settled it — space-separated `key=value` with an ISO 8601 timestamp — and that means the deferral has turned into the one piece of unfinished business:

```
ANTISPAM_BEE_LOG_FILE  → 2026-01-15 10:23:45 comment for post=474 from host=192.0.2.42 marked as spam
ANTISPAM_BEE_SPAM_LOG  → 2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot
```

**Today both write the second line.** The new-constant idea was justified in #797 on the grounds that backward compatibility becomes structural — a new constant means a new log, and the old one keeps writing exactly what it wrote before, so a jail with `marked as spam$` survives the upgrade untouched. `get_log_file()` already knows *which* constant supplied the path, so the switch is cheap to implement here.

It is a real decision rather than an oversight, because keeping the old line alive means keeping the old builder alive too, with tests, for a format we have told people to migrate off. The alternatives:

1. **Implement it here.** #797's promise is kept in the same beta, and nobody's jail breaks.
2. **A third PR.** Keeps this one about constants only, at the cost of a window where the promise is unkept.
3. **Do not do it at all.** 3.0 is a major release, the changelog carries the warning in both languages, and #797 already tells people what to change. Simpler, but it drops a commitment made in that thread.

I lean towards 1, since the promise was made publicly in #797 and the implementation is small. Worth deciding before this leaves draft.

## Also still out of scope

**The deprecation notice** for the old constants — `_doing_it_wrong()` plus an admin notice, weighted towards the notice because `_doing_it_wrong()` only surfaces with `WP_DEBUG`, which a production server running Fail2Ban will not have. Discussed in #797; a follow-up, not an omission.

## Relationship to #595

This supersedes the constant introduced there, and carries over @florianbrinkmann's idea of making the directory configurable. I did not build on that branch: it is 178 commits behind `v3` and already conflicting, and its `ANTISPAM_BEE_DEBUG_MODE_LOG_DIR` would be renamed by this scheme immediately. Cherry-picking the commit to preserve authorship conflicted heavily, hence the credit in the commit message instead.

Worth noting that branch also predates the salted debug file name — it still writes `asb-debug.{$date}.log`, so a straight replay would have dropped that protection.

## Test steps

1. `define( 'ANTISPAM_BEE_SPAM_LOG', true );` — trip the honeypot; a file appears in `wp-content` named `asb-spam.<suffix>.log`, with no date in the name.
2. Add `define( 'ANTISPAM_BEE_SPAM_LOG_DIR', '/some/dir' );` — the file appears there instead.
3. Set `ANTISPAM_BEE_SPAM_LOG` to a path string — that exact file is written, unsalted.
4. Same three for `ANTISPAM_BEE_DEBUG_LOG`, whose generated name additionally carries the date.
5. With only `ANTISPAM_BEE_LOG_FILE` defined, logging behaves as before.

Verified locally on a DDEV install: `ANTISPAM_BEE_LOG_FILE` still writes, and `ANTISPAM_BEE_SPAM_LOG = true` produced `asb-spam.46509eb87c8b.log`, whose suffix equals `sha1( 'asb-spam' . NONCE_SALT )` truncated to twelve characters — confirming a configured salt is preferred over the managed one.

`composer test:unit` (171 passing), `composer phpstan` and `composer cs` all pass.
