### PR TITLE
ci: split `tests.yml` into per-concern workflows with path filters

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,44 @@
+# Sets up PHP with Composer and installs the Composer dependencies.
+#
+# Every job that touches PHP starts with these two steps, and only three things ever
+# differ: the PHP version, the extensions and ini values the unit suite needs, and the
+# flags for `composer install` (`--ignore-platform-req=php` for the static checks,
+# `--no-dev --optimize-autoloader` for the end-to-end build, nothing for the unit suite).
+# So the steps live here once instead of five times across the workflows.
+#
+# Used with a local path (`uses: ./.github/actions/setup-php`), so the calling job has to
+# check the repository out first.
+
+name: Setup PHP
+description: Set up PHP with Composer and install the Composer dependencies.
+
+inputs:
+  php-version:
+    description: The PHP version to set up.
+    required: true
+  extensions:
+    description: Additional PHP extensions to enable, as a comma-separated list.
+    required: false
+    default: ''
+  ini-values:
+    description: Additional `php.ini` values to set, as a comma-separated list.
+    required: false
+    default: ''
+  composer-flags:
+    description: Extra flags to pass to `composer install`.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.extensions }}
+        ini-values: ${{ inputs.ini-values }}
+        tools: composer
+    - name: Install Composer dependencies
+      shell: bash
+      run: composer install ${{ inputs.composer-flags }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,13 +80,11 @@ jobs:
       run: npm ci
     - name: Install Playwright browsers
       run: npx playwright install chromium --with-deps
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: ${{ matrix.php }}
-        tools: composer
-    - name: Install Composer dependencies
-      run: composer install --no-dev --optimize-autoloader
+        composer-flags: '--no-dev --optimize-autoloader'
     - name: Configure wp-env for matrix
       run: |
         case "${{ matrix.wordpress }}" in

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,32 +1,50 @@
-name: Tests, Coding Standards
+# Split out of the former `tests.yml`. Keep the job name `test-e2e`, since that is what the
+# status checks on existing pull requests are called.
+#
+# This is by far the most expensive workflow — nine matrix entries, each starting a
+# WordPress environment and a browser — so it is the one that benefits most from both the
+# path filter and the concurrency group.
+#
+# Only `pull_request` is filtered — `push` to a major branch deliberately runs everything.
+# A merge carries the same diff the pull request carried, so a filter that is too narrow
+# would skip the check on the pull request *and* on the merge, and the gap would never
+# surface. The push run is also the only one that tests the code as it actually landed:
+# pull request checks run against a merge commit computed when they started, which goes
+# stale once the base branch moves on. Pull requests are where the volume is — many pushes
+# per review — so the filter still saves nearly everything it did before.
+
+name: E2E tests
+
 on:
   push:
     branches:
       - master
       - v3
   pull_request:
-jobs:
-  test-unit:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: ['8.5', '7.4']
-    steps:
-    - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        extensions: mbstring, intl
-        ini-values: post_max_size=256M, short_open_tag=On
-        tools: composer
-    - name: Install
-      run: |
-        composer install
-    - name: Run tests
-      run: |
-        composer test:unit
+    paths:
+      - '**.php'
+      # The unit suite and its stubs cannot affect an end-to-end run, and this workflow is
+      # nine environments wide, so exclude them from the `**.php` match above.
+      - '!tests/Unit/**'
+      - '!tests/_stubs/**'
+      - '**.js'
+      - '**.css'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.ts'
+      - 'tests/e2e/**'
+      - '.wp-env.json'
+      - '.github/workflows/e2e.yml'
+  # Allow forcing a full run by hand, for example before cutting a release.
+  workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
   test-e2e:
     runs-on: ubuntu-latest
     strategy:
@@ -91,54 +109,3 @@ jobs:
     - name: Stop wp-env
       if: always()
       run: npm run env:stop
-
-  phpstan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          tools: composer
-      - name: Install Composer dependencies
-        run: composer install --ignore-platform-req=php
-      - name: Run PHPStan
-        run: composer phpstan
-
-  quality:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        tools: composer
-    - name: Run code style checks for CSS, JavaScript and PHP
-      run: |
-        composer install --ignore-platform-req=php
-        ./vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
-        composer cs
-
-  wp-since:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        tools: composer
-    - name: Check for unavailable WordPress functions
-      run: |
-        composer install --ignore-platform-req=php
-        ./vendor/bin/wp-since check .
-
-  spelling:
-    name: Typos
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,9 @@ on:
       - 'tests/e2e/**'
       - '.wp-env.json'
       - '.github/workflows/e2e.yml'
+      # The shared PHP setup is part of this workflow's setup, so a change to it has to run
+      # this workflow as well.
+      - '.github/actions/setup-php/**'
   # Allow forcing a full run by hand, for example before cutting a release.
   workflow_dispatch:
 

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -47,6 +47,12 @@ name: Spam-detection comparison
 on:
   pull_request:
     branches: [ v3, master ]
+    # Only meaningful when the detection logic itself changes.
+    paths:
+      - 'src/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/spam-detection-comparison.yml'
   push:
     branches:
       - 'prepare-*'

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,30 @@
+# Split out of the former `tests.yml`. Keep the job name `spelling` and its display name
+# `Typos`, since that is what the status checks on existing pull requests are called.
+#
+# Deliberately has no path filter. It is the only check that validates prose, so it is the
+# one that must still run on a documentation-only change — which is exactly the kind of
+# pull request the other workflows now skip.
+
+name: Spelling
+
+on:
+  push:
+    branches:
+      - master
+      - v3
+  pull_request:
+  # Allow forcing a full run by hand, for example before cutting a release.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spelling:
+    name: Typos
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,13 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Setup PHP and install dependencies
+        uses: ./.github/actions/setup-php
         with:
           php-version: '8.5'
-          tools: composer
-      - name: Install Composer dependencies
-        run: composer install --ignore-platform-req=php
+          composer-flags: '--ignore-platform-req=php'
       - name: Run PHPStan
         run: composer phpstan
 
@@ -58,14 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: '8.5'
-        tools: composer
+        composer-flags: '--ignore-platform-req=php'
     - name: Run code style checks for CSS, JavaScript and PHP
       run: |
-        composer install --ignore-platform-req=php
         ./vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
         composer cs
 
@@ -73,12 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: '8.5'
-        tools: composer
+        composer-flags: '--ignore-platform-req=php'
     - name: Check for unavailable WordPress functions
-      run: |
-        composer install --ignore-platform-req=php
-        ./vendor/bin/wp-since check .
+      run: ./vendor/bin/wp-since check .

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,84 @@
+# Split out of the former `tests.yml`. Keep the job names `phpstan`, `quality` and
+# `wp-since`, since that is what the status checks on existing pull requests are called.
+#
+# The jobs share a workflow because they share a trigger: all of them are static checks
+# over the source, none starts an environment. They still report as separate status checks.
+#
+# Only `pull_request` is filtered — `push` to a major branch deliberately runs everything.
+# A merge carries the same diff the pull request carried, so a filter that is too narrow
+# would skip the check on the pull request *and* on the merge, and the gap would never
+# surface. The push run is also the only one that tests the code as it actually landed:
+# pull request checks run against a merge commit computed when they started, which goes
+# stale once the base branch moves on.
+
+name: Static analysis
+
+on:
+  push:
+    branches:
+      - master
+      - v3
+  pull_request:
+    paths:
+      - '**.php'
+      - '**.js'
+      - '**.css'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpstan.neon'
+      # `wp-since` resolves the minimum supported WordPress version from the
+      # `Requires at least` header in `readme.txt`, so lowering it there alone changes
+      # the outcome of the check.
+      - 'readme.txt'
+      - '.github/workflows/static-analysis.yml'
+  # Allow forcing a full run by hand, for example before cutting a release.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer
+      - name: Install Composer dependencies
+        run: composer install --ignore-platform-req=php
+      - name: Run PHPStan
+        run: composer phpstan
+
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer
+    - name: Run code style checks for CSS, JavaScript and PHP
+      run: |
+        composer install --ignore-platform-req=php
+        ./vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
+        composer cs
+
+  wp-since:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'
+        tools: composer
+    - name: Check for unavailable WordPress functions
+      run: |
+        composer install --ignore-platform-req=php
+        ./vendor/bin/wp-since check .

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,6 +32,9 @@ on:
       # the outcome of the check.
       - 'readme.txt'
       - '.github/workflows/static-analysis.yml'
+      # The shared PHP setup is part of this workflow's setup, so a change to it has to run
+      # this workflow as well.
+      - '.github/actions/setup-php/**'
   # Allow forcing a full run by hand, for example before cutting a release.
   workflow_dispatch:
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,16 +41,12 @@ jobs:
         php-versions: ['8.5', '7.4']
     steps:
     - uses: actions/checkout@v7
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, intl
         ini-values: post_max_size=256M, short_open_tag=On
-        tools: composer
-    - name: Install
-      run: |
-        composer install
     - name: Run tests
       run: |
         composer test:unit

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,6 +26,9 @@ on:
       - 'composer.lock'
       - 'phpunit.xml.dist'
       - '.github/workflows/unit.yml'
+      # The shared PHP setup is part of this workflow's setup, so a change to it has to run
+      # this workflow as well.
+      - '.github/actions/setup-php/**'
   # Allow forcing a full run by hand, for example before cutting a release.
   workflow_dispatch:
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,56 @@
+# Split out of the former `tests.yml` so each kind of check has its own workflow, its own
+# path filter and its own concurrency group. Keep the job name `test-unit`, since that is
+# what the status checks on existing pull requests are called.
+#
+# Every filter includes this workflow file, so a change to the setup always runs the thing
+# it is setting up.
+#
+# Only `pull_request` is filtered — `push` to a major branch deliberately runs everything.
+# A merge carries the same diff the pull request carried, so a filter that is too narrow
+# would skip the check on the pull request *and* on the merge, and the gap would never
+# surface. The push run is also the only one that tests the code as it actually landed:
+# pull request checks run against a merge commit computed when they started, which goes
+# stale once the base branch moves on.
+
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+      - v3
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/unit.yml'
+  # Allow forcing a full run by hand, for example before cutting a release.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.5', '7.4']
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mbstring, intl
+        ini-values: post_max_size=256M, short_open_tag=On
+        tools: composer
+    - name: Install
+      run: |
+        composer install
+    - name: Run tests
+      run: |
+        composer test:unit


### PR DESCRIPTION
## Why

`tests.yml` ran every check on every change. A documentation-only pull request started 15 jobs — nine of them full Playwright environments, plus the corpus comparison. #806, a six-line Markdown change, is the example.

## What

Split `tests.yml` into four workflows. Each filters its **`pull_request`** trigger only:

| Workflow | Jobs | `pull_request` runs when |
| --- | --- | --- |
| `unit.yml` | `test-unit` | PHP sources, `composer.*`, `phpunit.xml.dist`, own workflow file, shared setup action |
| `e2e.yml` | `test-e2e` | PHP/JS/CSS, `package*.json`, `playwright.config.ts`, `tests/e2e/**`, `.wp-env.json`, own workflow file, shared setup action |
| `static-analysis.yml` | `phpstan`, `quality`, `wp-since` | PHP/JS/CSS, `composer.*`, `phpcs.xml`, `phpstan.neon`, `readme.txt`, own workflow file, shared setup action |
| `spelling.yml` | `spelling` (`Typos`) | always |

`spam-detection-comparison.yml` also gets a `paths` filter on its `pull_request` trigger, so it only runs when the detection logic actually changes. Its `push` tiers (`prepare-*`) are untouched.

## Triggers

**`push` to `master`/`v3` deliberately runs everything, unfiltered.** Two reasons:

1. A merge carries the same diff the pull request carried. A filter that is too narrow would therefore skip the check on the pull request *and* on the merge — the gap could never surface. The unfiltered push run is the only thing that can catch a filter that is wrong.
2. It is the only run that tests the code as it actually landed. Pull request checks run against a merge commit computed when they started, which goes stale once the base moves on, so two independently green pull requests can still break `v3`. No path filter can catch that.

Pull requests are where the volume is — many pushes per review — so the filters still save nearly all of what they saved before. The cost is roughly one full run per merge (~20/month on `v3` lately).

**Each workflow also gains `workflow_dispatch`**, to force a full run by hand before cutting a release. **No release or tag trigger:** tags here are cut from commits that already sit on a major branch (`3.0.0-beta.1` is an ancestor of `v3`), so those commits have had an unfiltered run already and a tag trigger would only duplicate it.

## Shared PHP setup

Five jobs opened with the same two steps — `shivammathur/setup-php@v2` with `tools: composer`, then `composer install` — varying only in PHP version, the extensions and ini values the unit suite needs, and the `composer install` flags. Those steps now live once in `.github/actions/setup-php`, with `php-version`, `extensions`, `ini-values` and `composer-flags` inputs, and each call site states only what is different about it. In `quality` and `wp-since` the `composer install` had been folded into the same `run` block as the check itself, so those blocks now contain only the check they are named after.

The action is included in all three path filters, for the same reason each workflow includes its own file: a change to the setup has to run the thing it configures.

`wordpress-plugin-deploy.yml` and `wordpress-plugin-asset-update.yml` keep their own inline setup — they pass `--ignore-platform-reqs`, they are release plumbing rather than checks, and neither was part of the split.

## Notes

- **Job names are unchanged** — `test-unit`, `test-e2e`, `phpstan`, `quality`, `wp-since`, `spelling`/`Typos`. Status checks on existing pull requests keep their names.
- The job *bodies* are unchanged in behaviour — same steps, same order, same arguments — but no longer byte-identical to `tests.yml`, since the PHP setup now comes from the shared action.
- ⚠️ **A filtered workflow cannot simply be made a required check.** When a workflow is skipped by its `paths` filter it reports no status at all, so a pull request would wait indefinitely on a check that never arrives. Requiring any of these needs a sentinel job that always runs. (`v3` requires only `Typos`, which is unfiltered and therefore always reports.)
- **`wp-since` (from #772) lives in `static-analysis.yml`.** It is a static check over the source that starts no environment, so it shares the trigger of `phpstan` and `quality`. Its filter also lists `readme.txt`, because `wp-since` resolves the minimum supported WordPress version from the `Requires at least` header there — lowering it in `readme.txt` alone changes what the check reports, and the check would otherwise not re-run.
- **`spelling.yml` is deliberately left unfiltered.** It is the only check that validates prose, so it must still run on exactly the documentation-only changes that every other workflow now skips.
- **`e2e.yml` excludes `tests/Unit/**` and `tests/_stubs/**`** from its `**.php` match. The unit suite cannot affect an end-to-end run, and this is the nine-environment workflow.
- **Each workflow gets a `concurrency` group with `cancel-in-progress`.** There was none before, so three pushes in quick succession ran three full matrices; superseded runs are now cancelled.
- Extracting the shared setup also dropped the `tests.yml`/`e2e.yml` similarity from 52 % to 48 %, below git's rename threshold, so this renders as a delete plus an add rather than a rename — which reads more honestly, since `tests.yml` was dissolved into four files rather than renamed to one of them.

## Testing

All workflow files and the composite action parse as valid YAML. The set of job names across the new workflows matches `tests.yml` exactly, with no duplicates. The resolved triggers were verified to be unfiltered on `push`, filtered on `pull_request`, with `workflow_dispatch` present everywhere, and with the shared action in each of the three filters. No `shivammathur/setup-php` call sites remain in the split workflows, and every job checks the repository out before invoking the local action.

Refs #806
