### PR TITLE
ci: pin every external action to a commit hash

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -33,7 +33,14 @@ runs:
   using: composite
   steps:
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      # Pinned to a commit rather than to `v2`, because a tag can be moved: whoever
+      # controls the upstream repository can point `v2` at different code, and this action
+      # runs with access to the job. The trailing comment records which release the hash
+      # is, since a bare hash says nothing about how old the pin is.
+      #
+      # Note there is no Dependabot coverage for GitHub Actions in this repository yet, so
+      # this pin has to be advanced by hand until there is.
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.extensions }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  # The workflows pin every action to a commit hash, which stops a moved tag from
+  # changing what we run — but it also means a pin stays where it is until someone
+  # moves it. Dependabot advances the hash and the release comment for us. Weekly,
+  # because actions release far less often than the Composer and npm dependencies.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # A floating major tag like `@v7` only produces a pull request for `v7` -> `v8`,
+    # but a commit pin produces one for every patch release — and `actions/checkout`
+    # alone is referenced ten times. Group them so all action updates arrive in a
+    # single weekly pull request instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/attach-snapshot.yml
+++ b/.github/workflows/attach-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
         corpus: [ full, small ]
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/attach-snapshot.yml
+++ b/.github/workflows/attach-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
         corpus: [ full, small ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,9 +73,9 @@ jobs:
           - php: '7.4'
             wordpress: '5.6'
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: '22'
         cache: 'npm'
@@ -102,7 +102,7 @@ jobs:
       run: npm run test:e2e
     - name: Upload test report on failure
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: playwright-report-php${{ matrix.php }}-wp${{ matrix.wordpress }}
         path: tests/e2e/report/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,9 +49,9 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -126,7 +126,7 @@ jobs:
           --health-retries=30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0        # full history/tags for baseline resolution
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Compare spam detection
         id: compare
-        uses: 2ndkauboy/asb-detection-compare@v1
+        uses: 2ndkauboy/asb-detection-compare@05975dd833642599d023bdce5136fbc90399e411 # v1.8.0
         with:
           # PR -> the PR's base branch. Manual -> the chosen baseline. Prepare
           # push -> empty, so the baseline is resolved from the branch name.
@@ -207,7 +207,7 @@ jobs:
       # ever match it.
       - name: Upload the verdict snapshot
         if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.snapshot-file != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: asb-detection-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.snapshot-file }}
@@ -219,7 +219,7 @@ jobs:
       # next comparison against it needs only a single pass.
       - name: Upload the baseline verdict snapshot
         if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.baseline-snapshot-file != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: asb-detection-baseline-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.baseline-snapshot-file }}

--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -126,7 +126,7 @@ jobs:
           --health-retries=30
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0        # full history/tags for baseline resolution
 
@@ -207,7 +207,7 @@ jobs:
       # ever match it.
       - name: Upload the verdict snapshot
         if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.snapshot-file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: asb-detection-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.snapshot-file }}
@@ -219,7 +219,7 @@ jobs:
       # next comparison against it needs only a single pass.
       - name: Upload the baseline verdict snapshot
         if: env.ASB_CORPUS_READY == 'true' && steps.compare.outputs.baseline-snapshot-file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: asb-detection-baseline-snapshot-${{ env.ASB_CORPUS }}
           path: ${{ steps.compare.outputs.baseline-snapshot-file }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -32,5 +32,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -32,5 +32,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
   phpstan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup PHP and install dependencies
         uses: ./.github/actions/setup-php
         with:
@@ -58,7 +58,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup PHP and install dependencies
       uses: ./.github/actions/setup-php
       with:
@@ -72,7 +72,7 @@ jobs:
   wp-since:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup PHP and install dependencies
       uses: ./.github/actions/setup-php
       with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         php-versions: ['8.5', '7.4']
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup PHP and install dependencies
       uses: ./.github/actions/setup-php
       with:

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: '8.5'
         tools: composer
     - name: Build
       run: composer install --ignore-platform-reqs
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
+      uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # 2.2.0
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -10,13 +10,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: '8.5'
-        tools: composer
-    - name: Build
-      run: composer install --ignore-platform-reqs
+        composer-flags: '--ignore-platform-reqs'
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # 2.2.0
       env:

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.5'
           coverage: none
@@ -63,6 +63,6 @@ jobs:
           unzip -q ${{ github.event.repository.name }}.zip -d tmp-build
 
       - name: Run plugin check
-        uses: wordpress/plugin-check-action@v1
+        uses: wordpress/plugin-check-action@10857da14b6c2246d15402b3e69f777edcf8c12e # v1.1.9
         with:
           build-dir: ./tmp-build/${{ github.event.repository.name }}

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -11,13 +11,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+    - name: Setup PHP and install dependencies
+      uses: ./.github/actions/setup-php
       with:
         php-version: '8.3'
-        tools: composer
-    - name: Build
-      run: composer install --ignore-platform-reqs
+        composer-flags: '--ignore-platform-reqs'
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       env:

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: '8.3'
         tools: composer
     - name: Build
       run: composer install --ignore-platform-reqs
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
## Why

A tag and a branch are both movable refs. Whoever controls an action's repository can change what our workflows execute without anything changing on our side, and these actions run inside our jobs — `10up/action-wordpress-plugin-deploy` runs with `SVN_USERNAME` and `SVN_PASSWORD` in its environment.

Three of our refs were the weak kind:

| Ref | Was | Meaning |
| --- | --- | --- |
| `crate-ci/typos` | `@master` | every run executed whatever was on `master` at that moment |
| `10up/action-wordpress-plugin-deploy` | `@stable` | same, and this one holds the SVN credentials |
| `10up/action-wordpress-plugin-asset-update` | `@stable` | same |

The rest were major tags (`@v4`, `@v7`, `@v2`, …) — movable too, just conventionally not moved backwards.

## What

**Pin every external action reference to a commit**, with a trailing comment naming the release:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

Every hash was resolved from the API and verified to be what the previous ref pointed at, so pinning itself changes no behaviour. The comment matters as much as the hash: a bare SHA says nothing about how old a pin is.

**Use one version of each action.** `actions/checkout` was split across v4.4.0 and v7.0.1, and `actions/upload-artifact` across v4.6.2 and v7.0.1 — three major versions of drift, and twice the pins for Dependabot to carry. Both are now on v7.0.1, after checking:

- the only input the v4 `checkout` sites pass is `fetch-depth: 0`, still a v7 input;
- the comparison workflow passes `name`, `path`, `retention-days` and `if-no-files-found` to `upload-artifact`, all four still inputs in v7;
- `attach-snapshot.yml` consumes those artifacts with `gh run download --name`, which reads the same artifact backend for v4 and v7, so the chain carrying a verdict snapshot from a comparison run to a release keeps working;
- every job runs on `ubuntu-latest`, so no runner holds the newer versions back.

**Reuse the shared PHP setup in the release workflows.** `wordpress-plugin-deploy.yml` and `wordpress-plugin-asset-update.yml` opened with the same three steps as every check — checkout, `setup-php` with `tools: composer`, `composer install` — so they now use `./.github/actions/setup-php` too. `shivammathur/setup-php` is consequently pinned once rather than three times.

Final state: 19 external references, 8 distinct pins, each action on exactly one version.

| Action | Refs | Pinned to |
| --- | --- | --- |
| `actions/checkout` | 10 | v7.0.1 |
| `actions/upload-artifact` | 3 | v7.0.1 |
| `shivammathur/setup-php` | 1 | 2.37.2 |
| `crate-ci/typos` | 1 | v1.49.0 |
| `actions/setup-node` | 1 | v6.5.0 |
| `2ndkauboy/asb-detection-compare` | 1 | v1.8.0 |
| `10up/action-wordpress-plugin-deploy` | 1 | 2.3.0 |
| `10up/action-wordpress-plugin-asset-update` | 1 | 2.2.0 |

## Dependabot

Pinning trades one risk for another: a hash cannot be moved under us, but it also sits where it is until somebody advances it, so an upstream security fix never arrives on its own. `dependabot.yml` covered `composer` and `npm` but not `github-actions`, so this adds that ecosystem — Dependabot advances both the hash and the release comment, and it rewrites every occurrence of a pin in one pull request, so ten `checkout` pins cost no more upkeep than one. Weekly, since actions release far less often than the other two.

The updates are **grouped**. A floating tag like `@v7` only produces a pull request for the next major, whereas a commit pin produces one for every patch release — so grouping keeps all action bumps in a single weekly pull request rather than one per action.

## Pin policy

Every external reference is pinned, including the GitHub-owned `actions/*` ones. Not because a compromise of the `actions` org is a realistic worry — if it were, a pin would not help, since the same party provisions the runner and mints `GITHUB_TOKEN` — but because the alternative rule does not survive contact with practice. "Trusted publisher" is a judgement call every contributor has to re-make for every new action, and tags are mutable regardless of who owns them: a maintainer force-moving `v7` during a botched release changes what we run without any malice involved. One rule, "every external reference is a commit hash", needs no deliberation and can be checked with a grep. Grouped Dependabot updates remove the churn that would otherwise argue for exempting them.

⚠️ **To confirm after the first run:** whether the `github-actions` ecosystem picks up the composite action at `.github/actions/setup-php/action.yml` as well as the files under `.github/workflows/`. If it does not, that one pin has to be advanced by hand.

## Why not wrap more actions in `.github/actions/`

`actions/checkout` accounts for 10 of the 19 refs and is the one case that cannot be wrapped at all: a local action at `./.github/actions/…` only exists once the repository has been checked out, and `checkout` is the step that does that. Of the rest, `upload-artifact` is a single step whose three call sites share none of their inputs, so a wrapper would declare four inputs and forward four inputs while removing nothing; every other action is used exactly once. What made `setup-php` worth extracting was five sites sharing *two* steps with near-identical configuration. Keeping the pins maintainable is Dependabot's job, not a wrapper's.

## Base branch

Stacked on `ci/split-workflows` (#809) rather than on `v3`, because `.github/actions/setup-php/action.yml` is introduced there — pinning and reusing it is only possible on top of that PR. GitHub will retarget this to `v3` automatically once #809 merges.

## Testing

All eleven YAML files under `.github/` parse. No reference outside the repo-local `./.github/actions/…` ones is anything other than a 40-character commit hash, verified by grep, and no action appears at two different versions. Each hash was cross-checked against the ref it replaces. All seven jobs that use the local composite action were verified to run `actions/checkout` before it.

⚠️ One commit here cannot be proven green by this PR's CI: the deploy workflow runs only on a stable tag push, so its switch to the shared setup action is unexercised until a release.
