### PR TITLE
ci: add back a working plugin check workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,9 @@
 # Directories
+/.aider
+/.claude
 /.cursor
 /.github
+/.idea
 /.wordpress-org
 /bin
 /docs
@@ -10,24 +13,36 @@
 !/vendor/composer/
 
 # Files
+#
+# `composer.json` is deliberately *not* excluded: the archive ships
+# `vendor/autoload.php`, and a `vendor` directory without an accompanying
+# `composer.json` is flagged by the WordPress.org plugin check.
+/.aider.conf.yml
 /.distignore
 /.editorconfig
 /.gitattributes
 /.gitignore
+# In a git worktree `.git` is a file, which `dist-archive` does not skip on its own.
+/.git
+/.phpunit.result.cache
 /.sonarcloud.properties
 /.windsurfrules
 /.wp-env.json
+/.wp-env.override.json
+/AGENTS.local.md
 /AGENTS.md
+/CLAUDE.local.md
 /CLAUDE.md
+/CONVENTIONS.local.md
 /CONVENTIONS.md
 /README.md
-/composer.json
 /composer.lock
 /docker-compose.yml
 /package-lock.json
 /package.json
 /phpcs.xml
 /phpstan-bootstrap.php
+/phpstan.neon
 /phpunit.xml.dist
 /playwright.config.ts
 /typos.toml

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,68 @@
+# Runs the official WordPress Plugin Check against the archive we would actually
+# publish, not against the repository.
+#
+# That distinction matters: the repository carries tooling, tests and dev
+# dependencies that never reach wordpress.org, and several plugin-check rules
+# (hidden files, a `/vendor` directory without `composer.json`, direct file
+# access protection) only make sense for the shipped set of files. So the job
+# builds the release zip with `wp dist-archive` — the same `.distignore`-driven
+# build the deploy workflow uses — unpacks it, and points the check at that.
+
+name: Plugin Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - v3
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+  pull-requests: write # the action reports its findings as a pull request comment
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+          tools: wp-cli
+
+      - name: Install production dependencies
+        # The archive ships `vendor/autoload.php` and `vendor/composer/`, so the
+        # autoloader inside it has to be the production one.
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Install the dist-archive command
+        # `setup-php` seeds Composer's auth with a github-oauth token that
+        # Composer itself rejects as malformed, and `wp package install`
+        # registers the package as a GitHub VCS repository, which forces that
+        # token to be used. Isolate Composer from the ambient auth: a fresh
+        # COMPOSER_HOME (no seeded auth.json), an empty COMPOSER_AUTH and no
+        # GITHUB_TOKEN. The package is public, so anonymous access suffices.
+        env:
+          COMPOSER_HOME: ${{ runner.temp }}/composer-home
+          COMPOSER_AUTH: '{}'
+        run: |
+          unset GITHUB_TOKEN
+          wp package install wp-cli/dist-archive-command:^3.1
+
+      - name: Build the plugin archive
+        run: |
+          wp dist-archive . ./${{ github.event.repository.name }}.zip
+          mkdir tmp-build
+          unzip -q ${{ github.event.repository.name }}.zip -d tmp-build
+
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./tmp-build/${{ github.event.repository.name }}

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -14,12 +14,15 @@
  * Author: pluginkollektiv
  * Author URI: https://pluginkollektiv.org
  * Text Domain: antispam-bee
- * Domain Path: /lang
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 namespace AntispamBee;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 define( __NAMESPACE__ . '\MAIN_PLUGIN_FILE', __FILE__ );
 define( __NAMESPACE__ . '\PLUGIN_PATH', plugin_dir_path( MAIN_PLUGIN_FILE ) );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -48,7 +48,8 @@
 
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="4.6"/>
+	<!-- Keep in sync with "Requires at least" in readme.txt. -->
+	<config name="minimum_supported_wp_version" value="4.7"/>
 
 	<rule ref="WordPress">
 		<!-- As we use PHP 5.4+ now, we can use the short array syntax -->

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -111,10 +111,13 @@ class PluginUpdate {
 			// Therefore, we need to delete this unused data.
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery
 			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			// The statement is a constant string; the only interpolated value is the table name from $wpdb.
+			// phpcs:disable PluginCheck.Security.DirectDB.UnescapedDBParameter
 			$sql = 'DELETE FROM `' . $wpdb->commentmeta . '` WHERE `meta_key` IN ("antispam_bee_iphash")';
 			$wpdb->query( $sql );
 			// phpcs:enable WordPress.DB.DirectDatabaseQuery
 			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:enable PluginCheck.Security.DirectDB.UnescapedDBParameter
 		}
 
 		// DB version was raised in ASB 2.10.0 to 1.02.

--- a/src/PostProcessors/SendEmail.php
+++ b/src/PostProcessors/SendEmail.php
@@ -170,28 +170,34 @@ class SendEmail extends ControllableBase {
 		$asb_message = esc_html__( 'Notify message by Antispam Bee', 'antispam-bee' );
 		$asb_url     = esc_html__( 'https://antispambee.pluginkollektiv.org/', 'antispam-bee' );
 
-		$body = <<<EOF
-$new_spam_comment
-
-$author: {{comment_author}}
-$url: {{comment_author_url}}
-$type: {{reaction_type}}
-Whois: https://whois.arin.net/rest/ip/{{comment_author_IP}}
-$spam_reasons: {{spam_reasons}}
-
-{{content}}
-
-
-$remove_label: $remove_url
-
-$approve_label: $approve_url
-
-$spam_list_label: $spam_list_url
-
-$asb_message
-$asb_url
-
-EOF;
+		// Heredoc syntax is not allowed by the WordPress.org plugin review, so the
+		// template is assembled line by line. The trailing empty element keeps the
+		// closing newline the template has always ended with.
+		$body = implode(
+			PHP_EOL,
+			[
+				$new_spam_comment,
+				'',
+				"$author: {{comment_author}}",
+				"$url: {{comment_author_url}}",
+				"$type: {{reaction_type}}",
+				'Whois: https://whois.arin.net/rest/ip/{{comment_author_IP}}',
+				"$spam_reasons: {{spam_reasons}}",
+				'',
+				'{{content}}',
+				'',
+				'',
+				"$remove_label: $remove_url",
+				'',
+				"$approve_label: $approve_url",
+				'',
+				"$spam_list_label: $spam_list_url",
+				'',
+				$asb_message,
+				$asb_url,
+				'',
+			]
+		);
 
 		return str_replace( PHP_EOL, "\r\n", $body );
 	}

--- a/src/Rules/DbSpam.php
+++ b/src/Rules/DbSpam.php
@@ -62,6 +62,9 @@ class DbSpam extends ControllableBase implements SpamReason {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// $filter_sql is assembled from the hard-coded fragments above only; every
+		// value reaches the query as a %s placeholder handled by $wpdb->prepare().
+		// phpcs:disable PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$filter_sql = implode( ' OR ', $filter );
 
 		global $wpdb;
@@ -78,6 +81,7 @@ class DbSpam extends ControllableBase implements SpamReason {
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:enable PluginCheck.Security.DirectDB.UnescapedDBParameter
 
 		return (int) ! empty( $result );
 	}

--- a/src/load.php
+++ b/src/load.php
@@ -41,6 +41,10 @@ use AntispamBee\Rules\RegexpSpam;
 use AntispamBee\Rules\TooFastSubmit;
 use AntispamBee\Rules\ValidGravatar;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Init function of the plugin.
  */


### PR DESCRIPTION
Brings back `.github/workflows/wordpress-plugin-check.yml`, which was removed in 2a61805 because it failed on every run, and fixes everything that made it fail.

Replaces #758, whose branch has since gone stale and conflicts with `v3`.

## Why it was failing

Two independent causes:

1. The check reported real findings — 15 of them, errors and warnings.
2. The action could not post its report: `Resource not accessible by integration`, because the job had no `pull-requests: write` permission.

## What the workflow does

It checks the archive we would actually publish, not the repository. That distinction matters, because the repository carries tooling, tests and dev dependencies that never reach wordpress.org, and several rules (hidden files, a `/vendor` directory without `composer.json`, direct file access protection) only make sense for the shipped set of files. So the job builds the release zip with `wp dist-archive` — the same `.distignore`-driven build the deploy workflow uses — unpacks it, and points the check at that.

The build steps are the ones that were proven to work on `fix/repair-plugin-check-workflow`: `setup-php` provides `wp-cli`, the production autoloader is installed with `--no-dev`, and `wp package install` runs with an isolated `COMPOSER_HOME` so the malformed github-oauth token `setup-php` seeds cannot break the download of `dist-archive-command`.

## Findings that were fixed

**Errors**

* `missing_direct_file_access_protection` — `antispam_bee.php` and `src/load.php` are the only two shipped files with top-level side effects, so both now carry the `ABSPATH` guard. (`phpstan-bootstrap.php` was the third one and is no longer shipped.)
* `PluginCheck.CodeAnalysis.Heredoc.NotAllowed` — the email body template in `SendEmail::get_body_template()` used heredoc syntax, which the plugin review does not allow. It is assembled with `implode()` now and produces a byte-identical string.
* `hidden_files` — covered by the `.distignore` changes below.

**Warnings**

* `plugin_header_nonexistent_domain_path` — the `Domain Path: /lang` header pointed at a folder that does not exist. No translations are bundled (they come from translate.wordpress.org and are loaded from `WP_LANG_DIR`) and `load_plugin_textdomain()` is never called, so the header has no effect and is dropped.
* `missing_composer_json_file` — the archive ships `vendor/autoload.php` and `vendor/composer/`, so `composer.json` is no longer excluded from it.
* `PluginCheck.Security.DirectDB.UnescapedDBParameter` in `PluginUpdate` and `DbSpam` — both are false positives. The statements are assembled from hard-coded fragments only, and every value reaches the query through a `$wpdb->prepare()` placeholder. Annotated with the reason.

The remaining findings from the last run of #758 (`stable_tag_mismatch`, the `wp_function_not_compatible_with_requires_wp` errors, `strip_tags()`, the nonce and direct-DB warnings) were already resolved on `v3` in the meantime.

## Other changes

`.distignore` no longer lets local tooling leftovers into the archive: `.claude`, `.idea`, `.aider` and the `*.local.md` agent files would otherwise be published, and `.phpunit.result.cache` would trip the hidden-files check on a local build. It also drops `phpstan.neon`, which was shipped while `phpstan-bootstrap.php` was already excluded, and `.git`, which is a file rather than a directory in a git worktree and therefore not skipped by `dist-archive` on its own.

`minimum_supported_wp_version` in `phpcs.xml` still said 4.6 while `readme.txt` requires 4.7.

## Verification

Run locally against the built archive with plugin-check 2.0.0 via `wp-env`:

```
$ wp plugin check antispam-bee --include-experimental
Success: Checks complete. No errors found.
```

`composer cs`, `composer phpstan` and `composer test:unit` (71 tests) all pass.

Refs #534
