### PR TITLE
feat: read the IPLocate API key from a constant

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -18,3 +18,4 @@ define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-alpha.15' );
 // PHPStan uses the declared type instead of narrowing to these literal values.
 define( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED', false );
 define( 'ANTISPAM_BEE_LOG_FILE', 'asb.log' );
+define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', '' );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
   dynamicConstantNames:
     - ANTISPAM_BEE_DEBUG_MODE_ENABLED
     - ANTISPAM_BEE_LOG_FILE
+    - ANTISPAM_BEE_IPLOCATE_API_KEY
   treatPhpDocTypesAsCertain: false

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,13 @@ Generally yes. However, running Antispam Bee with truncated or shortened IP addr
 ### How can I submit undetected spam? ###
 If the antispam plugin has let some spam comments through, these comments can be reported for analysis. A [Google Form](http://goo.gl/forms/ITzVHXkLVL) was created for this purpose.
 
+### Can I use my own IPLocate API key for the country rule? ###
+Yes. The country rule looks the visitor's country up at IPLocate, which rate-limits requests that carry no API key. Define the constant `ANTISPAM_BEE_IPLOCATE_API_KEY` in your `wp-config.php` and set it to your key:
+
+> define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', getenv( 'IPLOCATE_API_KEY' ) );
+
+Reading it from the environment like this keeps the key out of your code and out of version control. The `antispam_bee_country_spam_apikey` filter still works and is used when the constant is undefined or empty, so the constant wins wherever both are set.
+
 ### Antispam Bee with Varnish? ###
 If WordPress is operated with Apache + Varnish, the actual IP address of the visitors does not appear in WordPress. Accordingly, Antispam Bee lacks the basis it needs to function correctly. An adaptation in the Varnish configuration file /etc/varnish/default.vcl provides a remedy and forwards the original (not from Apache) IP address in the HTTP header X-Forwarded-For:
 

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ Yes. The country rule looks the visitor's country up at IPLocate, which rate-lim
 
 > define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', getenv( 'IPLOCATE_API_KEY' ) );
 
-Reading it from the environment like this keeps the key out of your code and out of version control. The `antispam_bee_country_spam_apikey` filter still works and is used when the constant is undefined or empty, so the constant wins wherever both are set.
+Reading it from the environment like this keeps the key out of your code and out of version control. The `antispam_bee_country_spam_apikey` filter still works and now receives the value of the constant, so a filter can still override it.
 
 ### Antispam Bee with Varnish? ###
 If WordPress is operated with Apache + Varnish, the actual IP address of the visitors does not appear in WordPress. Accordingly, Antispam Bee lacks the basis it needs to function correctly. An adaptation in the Varnish configuration file /etc/varnish/default.vcl provides a remedy and forwards the original (not from Apache) IP address in the HTTP header X-Forwarded-For:

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,9 @@ Yes. The country rule looks the visitor's country up at IPLocate, which rate-lim
 
 > define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', getenv( 'IPLOCATE_API_KEY' ) );
 
-Reading it from the environment like this keeps the key out of your code and out of version control. The `antispam_bee_country_spam_apikey` filter still works and now receives the value of the constant, so a filter can still override it.
+Reading it from the environment like this keeps the key out of your code and out of version control. The value is passed to the `antispam_bee_iplocate_api_key` filter, so a filter can still override it.
+
+That filter was called `antispam_bee_country_spam_apikey` before 3.0.0. The old name still works, but it is deprecated and will be removed in 4.0.
 
 ### Antispam Bee with Varnish? ###
 If WordPress is operated with Apache + Varnish, the actual IP address of the visitors does not appear in WordPress. Accordingly, Antispam Bee lacks the basis it needs to function correctly. An adaptation in the Varnish configuration file /etc/varnish/default.vcl provides a remedy and forwards the original (not from Apache) IP address in the HTTP header X-Forwarded-For:

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -308,19 +308,33 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	 * @return string The API key, or an empty string when none is configured.
 	 */
 	private static function get_api_key(): string {
+		$apikey = defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) ? (string) ANTISPAM_BEE_IPLOCATE_API_KEY : '';
+
+		/**
+		 * Filters the IPLocate API key.
+		 *
+		 * @since      2.10.0
+		 * @deprecated 3.0.0 Use `antispam_bee_iplocate_api_key` instead.
+		 *
+		 * @param string $apikey The current IPLocate API key.
+		 */
+		$apikey = apply_filters_deprecated(
+			'antispam_bee_country_spam_apikey',
+			[ $apikey ],
+			'3.0.0',
+			'antispam_bee_iplocate_api_key'
+		);
+
 		/**
 		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
 		 *
-		 * @since 2.10.0
+		 * @since 3.0.0
 		 *
 		 * @param string $apikey The current IPLocate API key. Defaults to the
 		 *                       `ANTISPAM_BEE_IPLOCATE_API_KEY` constant when it is
 		 *                       defined, an empty string otherwise.
 		 */
-		return (string) apply_filters(
-			'antispam_bee_country_spam_apikey',
-			defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) ? (string) ANTISPAM_BEE_IPLOCATE_API_KEY : ''
-		);
+		return (string) apply_filters( 'antispam_bee_iplocate_api_key', $apikey );
 	}
 
 	/**

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -107,14 +107,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			return 0;
 		}
 
-		/**
-		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
-		 *
-		 * @since 2.10.0
-		 *
-		 * @param string $apikey The current IPLocate API key. Default is empty string.
-		 */
-		$apikey = trim( (string) apply_filters( 'antispam_bee_country_spam_apikey', '' ) );
+		$apikey = trim( self::get_api_key() );
 
 		/*
 		 * The service answers anonymous lookups within its free tier, but rejects
@@ -300,6 +293,35 @@ class CountrySpam extends ControllableBase implements SpamReason {
 		$values = Sanitize::iso_codes( $values );
 
 		return implode( ',', $values );
+	}
+
+	/**
+	 * Get the IPLocate API key.
+	 *
+	 * The `ANTISPAM_BEE_IPLOCATE_API_KEY` constant takes precedence over the filter, so
+	 * the key can be deployed with the environment instead of with code. An empty or
+	 * undefined constant falls through to the filter, and without either the lookup is
+	 * made against IPLocate's free rate limit.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string The API key, or an empty string when none is configured.
+	 */
+	private static function get_api_key(): string {
+		if ( defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) && ANTISPAM_BEE_IPLOCATE_API_KEY ) {
+			return (string) ANTISPAM_BEE_IPLOCATE_API_KEY;
+		}
+
+		/**
+		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
+		 *
+		 * The `ANTISPAM_BEE_IPLOCATE_API_KEY` constant takes precedence over this filter.
+		 *
+		 * @since 2.10.0
+		 *
+		 * @param string $apikey The current IPLocate API key. Default is empty string.
+		 */
+		return (string) apply_filters( 'antispam_bee_country_spam_apikey', '' );
 	}
 
 	/**

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -298,30 +298,29 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	/**
 	 * Get the IPLocate API key.
 	 *
-	 * The `ANTISPAM_BEE_IPLOCATE_API_KEY` constant takes precedence over the filter, so
-	 * the key can be deployed with the environment instead of with code. An empty or
-	 * undefined constant falls through to the filter, and without either the lookup is
-	 * made against IPLocate's free rate limit.
+	 * The `ANTISPAM_BEE_IPLOCATE_API_KEY` constant provides the key, so it can be
+	 * deployed with the environment instead of with code. It is passed as the default
+	 * to the filter, which keeps the last word. Without either, the lookup is made
+	 * against IPLocate's free rate limit.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @return string The API key, or an empty string when none is configured.
 	 */
 	private static function get_api_key(): string {
-		if ( defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) && ANTISPAM_BEE_IPLOCATE_API_KEY ) {
-			return (string) ANTISPAM_BEE_IPLOCATE_API_KEY;
-		}
-
 		/**
 		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
 		 *
-		 * The `ANTISPAM_BEE_IPLOCATE_API_KEY` constant takes precedence over this filter.
-		 *
 		 * @since 2.10.0
 		 *
-		 * @param string $apikey The current IPLocate API key. Default is empty string.
+		 * @param string $apikey The current IPLocate API key. Defaults to the
+		 *                       `ANTISPAM_BEE_IPLOCATE_API_KEY` constant when it is
+		 *                       defined, an empty string otherwise.
 		 */
-		return (string) apply_filters( 'antispam_bee_country_spam_apikey', '' );
+		return (string) apply_filters(
+			'antispam_bee_country_spam_apikey',
+			defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) ? (string) ANTISPAM_BEE_IPLOCATE_API_KEY : ''
+		);
 	}
 
 	/**

--- a/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
+++ b/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Rules;
+
+use AntispamBee\Rules\CountrySpam;
+use ReflectionMethod;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Filters\expectApplied;
+
+/**
+ * Covers the `ANTISPAM_BEE_IPLOCATE_API_KEY` constant.
+ *
+ * A constant cannot be undefined once it is set, so each case needs its own
+ * process. That rules out `AbstractRuleTestCase`, whose constructor signature
+ * PHPUnit cannot reproduce in a separate process.
+ */
+class CountrySpamApiKeyConstantTest extends TestCase {
+
+	/**
+	 * Call the private `get_api_key` method.
+	 *
+	 * @return string The resolved API key.
+	 */
+	private static function get_api_key(): string {
+		$method = new ReflectionMethod( CountrySpam::class, 'get_api_key' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_constant_takes_precedence_over_the_filter() {
+		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', 'from-constant' );
+
+		expectApplied( 'antispam_bee_country_spam_apikey' )->never();
+
+		self::assertSame( 'from-constant', self::get_api_key(), 'The constant should win over the filter' );
+	}
+
+	/**
+	 * An empty constant is treated as unset, so a filtered key still applies.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_empty_constant_falls_through_to_the_filter() {
+		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', '' );
+
+		expectApplied( 'antispam_bee_country_spam_apikey' )
+			->once()
+			->andReturn( 'from-filter' );
+
+		self::assertSame( 'from-filter', self::get_api_key(), 'An empty constant should fall through to the filter' );
+	}
+}

--- a/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
+++ b/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
@@ -32,27 +32,31 @@ class CountrySpamApiKeyConstantTest extends TestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_constant_takes_precedence_over_the_filter() {
+	public function test_constant_is_used_as_the_key() {
 		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', 'from-constant' );
 
-		expectApplied( 'antispam_bee_country_spam_apikey' )->never();
+		expectApplied( 'antispam_bee_country_spam_apikey' )
+			->once()
+			->with( 'from-constant' )
+			->andReturnFirstArg();
 
-		self::assertSame( 'from-constant', self::get_api_key(), 'The constant should win over the filter' );
+		self::assertSame( 'from-constant', self::get_api_key(), 'The constant should provide the key' );
 	}
 
 	/**
-	 * An empty constant is treated as unset, so a filtered key still applies.
+	 * The constant is only the default handed to the filter, so a filter still wins.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_empty_constant_falls_through_to_the_filter() {
-		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', '' );
+	public function test_filter_overrides_the_constant() {
+		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', 'from-constant' );
 
 		expectApplied( 'antispam_bee_country_spam_apikey' )
 			->once()
+			->with( 'from-constant' )
 			->andReturn( 'from-filter' );
 
-		self::assertSame( 'from-filter', self::get_api_key(), 'An empty constant should fall through to the filter' );
+		self::assertSame( 'from-filter', self::get_api_key(), 'The filter should win over the constant' );
 	}
 }

--- a/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
+++ b/tests/Unit/Rules/CountrySpamApiKeyConstantTest.php
@@ -35,7 +35,7 @@ class CountrySpamApiKeyConstantTest extends TestCase {
 	public function test_constant_is_used_as_the_key() {
 		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', 'from-constant' );
 
-		expectApplied( 'antispam_bee_country_spam_apikey' )
+		expectApplied( 'antispam_bee_iplocate_api_key' )
 			->once()
 			->with( 'from-constant' )
 			->andReturnFirstArg();
@@ -52,7 +52,7 @@ class CountrySpamApiKeyConstantTest extends TestCase {
 	public function test_filter_overrides_the_constant() {
 		define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', 'from-constant' );
 
-		expectApplied( 'antispam_bee_country_spam_apikey' )
+		expectApplied( 'antispam_bee_iplocate_api_key' )
 			->once()
 			->with( 'from-constant' )
 			->andReturn( 'from-filter' );

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -3,6 +3,7 @@
 namespace AntispamBee\Tests\Unit\Rules;
 
 use AntispamBee\Rules\CountrySpam;
+use ReflectionMethod;
 use function Brain\Monkey\Filters\expectApplied;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
@@ -274,6 +275,23 @@ class CountrySpamTest extends AbstractRuleTestCase {
 		);
 	}
 
+	public function test_api_key_defaults_to_empty_string() {
+		expectApplied( 'antispam_bee_country_spam_apikey' )
+			->once()
+			->with( '' )
+			->andReturnFirstArg();
+
+		self::assertSame( '', self::get_api_key(), 'Without a key configured the result should be an empty string' );
+	}
+
+	public function test_api_key_falls_back_to_the_filter() {
+		expectApplied( 'antispam_bee_country_spam_apikey' )
+			->once()
+			->andReturn( 'from-filter' );
+
+		self::assertSame( 'from-filter', self::get_api_key(), 'The filtered key should be used when no constant is set' );
+	}
+
 	/**
 	 * The `sanitize` callbacks are handed the posted value as it arrived. The two
 	 * country lists are textareas, but a request can post an array for them, and
@@ -379,5 +397,17 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	 */
 	private function expect_no_request(): void {
 		expect( 'wp_safe_remote_get' )->never();
+	}
+
+	/**
+	 * Call the private `get_api_key` method.
+	 *
+	 * @return string The resolved API key.
+	 */
+	private static function get_api_key(): string {
+		$method = new ReflectionMethod( CountrySpam::class, 'get_api_key' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
 	}
 }

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -257,7 +257,7 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	}
 
 	public function test_verify_sends_a_configured_api_key_as_a_header(): void {
-		expectApplied( 'antispam_bee_country_spam_apikey' )->once()->andReturn( ' secret-key ' );
+		expectApplied( 'antispam_bee_iplocate_api_key' )->once()->andReturn( ' secret-key ' );
 
 		$this->expect_request( '{"country_code":"DE"}' );
 
@@ -276,7 +276,7 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	}
 
 	public function test_api_key_defaults_to_empty_string() {
-		expectApplied( 'antispam_bee_country_spam_apikey' )
+		expectApplied( 'antispam_bee_iplocate_api_key' )
 			->once()
 			->with( '' )
 			->andReturnFirstArg();
@@ -284,12 +284,35 @@ class CountrySpamTest extends AbstractRuleTestCase {
 		self::assertSame( '', self::get_api_key(), 'Without a key configured the result should be an empty string' );
 	}
 
-	public function test_api_key_falls_back_to_the_filter() {
-		expectApplied( 'antispam_bee_country_spam_apikey' )
+	public function test_api_key_comes_from_the_filter() {
+		expectApplied( 'antispam_bee_iplocate_api_key' )
 			->once()
 			->andReturn( 'from-filter' );
 
-		self::assertSame( 'from-filter', self::get_api_key(), 'The filtered key should be used when no constant is set' );
+		self::assertSame( 'from-filter', self::get_api_key(), 'The filtered key should be used' );
+	}
+
+	/**
+	 * A site still using the old hook keeps working, and its value is handed on to
+	 * the new one.
+	 *
+	 * Core only runs the deprecated hook, and only emits the notice, when something
+	 * is actually hooked to it. That guard lives in `apply_filters_deprecated()`
+	 * itself, which Brain Monkey models as a plain `apply_filters()`, so it is core's
+	 * contract rather than something asserted here.
+	 */
+	public function test_deprecated_filter_still_applies() {
+		expectApplied( 'antispam_bee_country_spam_apikey' )
+			->once()
+			->with( '' )
+			->andReturn( 'from-deprecated' );
+
+		expectApplied( 'antispam_bee_iplocate_api_key' )
+			->once()
+			->with( 'from-deprecated' )
+			->andReturnFirstArg();
+
+		self::assertSame( 'from-deprecated', self::get_api_key(), 'The deprecated filter should still be honoured' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The IPLocate API key used by `CountrySpam` could only be set through the `antispam_bee_country_spam_apikey` filter, which means it has to live in PHP — a `functions.php`, an mu-plugin or a small custom plugin. That is awkward to deploy: the key is a per-environment secret, so it wants to come from the environment, not from code that gets committed.

This adds the constant `ANTISPAM_BEE_IPLOCATE_API_KEY`:

```php
// wp-config.php
define( 'ANTISPAM_BEE_IPLOCATE_API_KEY', getenv( 'IPLOCATE_API_KEY' ) );
```

The constant is passed to the filter as its default value, following the shape of `Akismet::get_api_key()` and core's `wp_doing_cron()`:

```php
return (string) apply_filters(
	'antispam_bee_country_spam_apikey',
	defined( 'ANTISPAM_BEE_IPLOCATE_API_KEY' ) ? (string) ANTISPAM_BEE_IPLOCATE_API_KEY : ''
);
```

So the filter keeps the last word, and it now receives the deployed key rather than an empty string — a filter that wants to adapt the key per site or per environment can see what was configured. Sites already using the filter are unaffected, and without either the request is made against IPLocate's free rate limit.

The lookup itself is unchanged apart from one fix: the key is now passed through `rawurlencode()`. IPLocate keys are hex today, but a key containing a URL-reserved character would previously have been interpolated into the query string raw.

## Filter rename

The filter is renamed from `antispam_bee_country_spam_apikey` to **`antispam_bee_iplocate_api_key`**. The old name named neither the service it belongs to nor what it configures, and `apikey` was the only hook in the plugin not in `snake_case` throughout.

The old name keeps working:

```php
$apikey = apply_filters_deprecated(
	'antispam_bee_country_spam_apikey',
	[ $apikey ],
	'3.0.0',
	'antispam_bee_iplocate_api_key'
);

return (string) apply_filters( 'antispam_bee_iplocate_api_key', $apikey );
```

`apply_filters_deprecated()` only runs the old hook, and only emits the deprecation notice, when something is actually hooked to it — a site that never used the filter pays nothing and sees nothing. A site that did keeps working, and its value is handed on to the new filter. The function is available since WP 4.6.0 and the plugin requires 4.7, which `wp-since` verifies.

3.0.0 is the right window for this: it is a major with a full rewrite, and the deprecation can be dropped in 4.0.

## Testing

New `CountrySpamTest` covers the rule's slug and init (it had no test at all before), the filter path, the empty default, and that a value from the deprecated filter is handed on to the new one. `CountrySpamApiKeyConstantTest` covers the constant, in separate processes since a constant cannot be undefined once set — which is also why it does not extend `AbstractRuleTestCase`, whose constructor signature PHPUnit cannot reproduce in a separate process. It asserts both that the constant reaches the filter as its default and that a filter still overrides it.

The constant tests were mutation-checked: replacing the constant default with `''` makes them fail, so the assertions have teeth.

One limit worth naming: Brain Monkey models `apply_filters_deprecated()` as a plain `apply_filters()`, so the "only runs when hooked" guard is core's contract and is not asserted here.

`composer test:unit` — 78 tests, 186 assertions, all pass. `phpcs`, `phpstan` (level 8) and `wp-since` clean.

`ANTISPAM_BEE_IPLOCATE_API_KEY` is registered in `phpstan-bootstrap.php` and `dynamicConstantNames`, alongside the other user-defined constants.

## Documentation

New FAQ entry in `readme.txt` showing the `getenv()` form, noting that the filter receives the constant's value, and recording the old filter name as deprecated since 3.0.0 and slated for removal in 4.0.
