### PR TITLE
feat: rename the language filter to `antispam_bee_allowed_languages`

### DIFF
--- a/src/Rules/LangSpam.php
+++ b/src/Rules/LangSpam.php
@@ -226,11 +226,26 @@ class LangSpam extends ControllableBase implements SpamReason {
 		/**
 		 * Filter the possible languages for the language spam test.
 		 *
-		 * @since 2.7.1
+		 * @since      2.7.1
+		 * @deprecated 3.0.0 Use `antispam_bee_allowed_languages` instead.
 		 *
-		 * @param (array) $languages The languages.
+		 * @param array<string, string> $languages The languages.
 		 */
-		$languages = (array) apply_filters( 'antispam_bee_get_allowed_translate_languages', $languages );
+		$languages = apply_filters_deprecated(
+			'antispam_bee_get_allowed_translate_languages',
+			[ $languages ],
+			'3.0.0',
+			'antispam_bee_allowed_languages'
+		);
+
+		/**
+		 * Filter the possible languages for the language spam test.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array<string, string> $languages The languages.
+		 */
+		$languages = (array) apply_filters( 'antispam_bee_allowed_languages', $languages );
 
 		return [
 			[

--- a/tests/Unit/Rules/LangSpamTest.php
+++ b/tests/Unit/Rules/LangSpamTest.php
@@ -226,4 +226,65 @@ class LangSpamTest extends AbstractRuleTestCase {
 	private function expect_no_request(): void {
 		expect( 'wp_safe_remote_post' )->never();
 	}
+
+	/**
+	 * Pull the language list out of the checkbox group the rule builds.
+	 *
+	 * @return array<string, string> The offered languages.
+	 */
+	private static function get_offered_languages(): array {
+		foreach ( LangSpam::get_options() as $option ) {
+			if ( 'allowed' === ( $option['option_name'] ?? '' ) ) {
+				return $option['options'];
+			}
+		}
+
+		self::fail( 'The rule did not offer an "allowed" checkbox group' );
+	}
+
+	public function test_allowed_languages_filter_can_change_the_offered_languages(): void {
+		expectApplied( 'antispam_bee_allowed_languages' )
+			->once()
+			->andReturn( [ 'nl' => 'Dutch' ] );
+
+		self::assertSame(
+			[ 'nl' => 'Dutch' ],
+			self::get_offered_languages(),
+			'The filter should replace the offered languages'
+		);
+	}
+
+	/**
+	 * The pre-3.0.0 name still works and its value is handed on to the new filter.
+	 *
+	 * Core only runs the deprecated hook, and only emits the notice, when something is
+	 * hooked to it; that guard lives in `apply_filters_deprecated()`, which Brain
+	 * Monkey models as a plain `apply_filters()`.
+	 */
+	public function test_deprecated_filter_still_applies(): void {
+		expectApplied( 'antispam_bee_get_allowed_translate_languages' )
+			->once()
+			->andReturn( [ 'nl' => 'Dutch' ] );
+
+		expectApplied( 'antispam_bee_allowed_languages' )
+			->once()
+			->with( [ 'nl' => 'Dutch' ] )
+			->andReturnFirstArg();
+
+		self::assertSame(
+			[ 'nl' => 'Dutch' ],
+			self::get_offered_languages(),
+			'The deprecated filter should still be honoured'
+		);
+	}
+
+	public function test_default_languages_are_offered_without_a_filter(): void {
+		expectApplied( 'antispam_bee_allowed_languages' )->once()->andReturnFirstArg();
+
+		self::assertSame(
+			[ 'de', 'en', 'fr', 'it', 'es' ],
+			array_keys( self::get_offered_languages() ),
+			'The five bundled languages should be offered by default'
+		);
+	}
 }


### PR DESCRIPTION
## Description

`antispam_bee_get_allowed_translate_languages` filters the languages the language rule offers in its settings. Two things are wrong with that name:

- It has nothing to do with **translation** any more. The name looks like a leftover from when the rule used a translation service; today the list feeds the "Allowed languages" checkbox group, and detection goes to `api.pluginkollektiv.org/language/v1/`.
- The **`get_`** prefix is unusual for a filter, and no other hook in the plugin uses one.

This renames it to **`antispam_bee_allowed_languages`**, which says what it filters.

The old name keeps working:

```php
$languages = apply_filters_deprecated(
	'antispam_bee_get_allowed_translate_languages',
	[ $languages ],
	'3.0.0',
	'antispam_bee_allowed_languages'
);

$languages = (array) apply_filters( 'antispam_bee_allowed_languages', $languages );
```

`apply_filters_deprecated()` only runs the old hook, and only emits the deprecation notice, when something is actually hooked to it — a site that never used the filter pays nothing and sees nothing. A site that did keeps working, and its value is handed on to the new filter. The function is available since WP 4.6.0 and the plugin requires 4.7, which `wp-since` verifies.

3.0.0 is the right window for this, and the deprecation can be dropped in 4.0.

The `@param` docblocks are tightened to `array<string, string>` while they are being touched.

## Testing

`get_options()` had no test at all. Three were added to `LangSpamTest`, reading the language list back out of the checkbox group the rule builds:

- the five bundled languages are offered by default
- `antispam_bee_allowed_languages` can replace the list
- a value from the deprecated filter is handed on to the new one

The deprecation test was mutation-checked: dropping the `apply_filters_deprecated()` call makes it fail with the default five languages instead of the filtered list.

One limit worth naming: Brain Monkey models `apply_filters_deprecated()` as a plain `apply_filters()`, so the "only runs when hooked" guard is core's contract and is not asserted here.

`composer test:unit` — 74 tests, 180 assertions, all pass. `phpcs`, `phpstan` (level 8) and `wp-since` clean.

## Related

Same treatment as the filter rename in #814, which renames `antispam_bee_country_spam_apikey` to `antispam_bee_iplocate_api_key`. The two are independent and can land in either order.
