### PR TITLE
fix: skip the country lookup for addresses that have no country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for
       IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6
       instead of only its first two groups
+    * Fix: The country rule no longer asks the geolocation service about loopback, link-local and
+      private addresses, which have no country anyway — a local installation and a site behind a
+      reverse proxy without a `pre_comment_user_ip` filter stop sending requests altogether
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
@@ -26,6 +29,9 @@
     * Fix: IP-Adressen werden nun anonymisiert, indem der Host-Teil der Adresse maskiert wird: ein
       /24 für IPv4, dasselbe Netz, das auch WordPress selbst behält, wie in Antispam Bee 2.x, und
       ein /48 für IPv6 statt nur der ersten zwei Blöcke
+    * Fix: Die Länder-Regel fragt den Geolokalisierungs-Dienst nicht mehr zu Loopback-, Link-Local-
+      und privaten Adressen, die ohnehin kein Land haben – eine lokale Installation und eine Seite
+      hinter einem Reverse-Proxy ohne `pre_comment_user_ip`-Filter senden gar keine Anfragen mehr
 
 ### 2.11.12 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Fix: The language rule now also checks comments written in a script that does not delimit its words with spaces, for example Chinese, Japanese, Korean or Thai
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups
+    * Fix: The country rule no longer asks the geolocation service about loopback, link-local and private addresses, which have no country anyway
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/src/Helpers/IpHelper.php
+++ b/src/Helpers/IpHelper.php
@@ -97,7 +97,7 @@ class IpHelper {
 		// IPv4 addresses pack into four bytes, IPv6 addresses into sixteen.
 		if ( 4 === strlen( $packed ) ) {
 			$netmask = '255.255.255.0';
-		} elseif ( 0 === strncmp( $packed, str_repeat( "\0", 10 ) . "\xff\xff", 12 ) ) {
+		} elseif ( self::is_ipv4_mapped( $packed ) ) {
 			// An IPv4-mapped IPv6 address carries an IPv4 address, mask that one.
 			$netmask = '::ffff:255.255.255.0';
 		} else {
@@ -107,5 +107,50 @@ class IpHelper {
 		$anonymized = inet_ntop( $packed & (string) inet_pton( $netmask ) );
 
 		return false === $anonymized ? '' : $anonymized;
+	}
+
+	/**
+	 * Check whether an IP address is globally routable.
+	 *
+	 * Loopback, link-local, private and other reserved addresses have no country,
+	 * so there is no point in asking a geolocation service about them. Anything
+	 * that is not an IP address at all is not global either.
+	 *
+	 * @param string $ip The IP address to check.
+	 *
+	 * @return bool Whether the address is a global one.
+	 */
+	public static function is_global_ip( string $ip ): bool {
+		$packed = inet_pton( $ip );
+
+		if ( false === $packed ) {
+			return false;
+		}
+
+		/*
+		 * `FILTER_FLAG_NO_RES_RANGE` rejects the whole `::ffff:0:0/96` block, which
+		 * would discard the global address an IPv4-mapped IPv6 address carries, so
+		 * check that IPv4 address instead of the mapped form.
+		 */
+		if ( self::is_ipv4_mapped( $packed ) ) {
+			$ip = (string) inet_ntop( substr( $packed, 12 ) );
+		}
+
+		return false !== filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+	}
+
+	/**
+	 * Check whether a packed address is an IPv4-mapped IPv6 address.
+	 *
+	 * Such an address carries an IPv4 address in its last four bytes and can show
+	 * up in `REMOTE_ADDR` on a dual-stack host.
+	 *
+	 * @param string $packed The packed address, as returned by `inet_pton()`.
+	 *
+	 * @return bool Whether the address is an IPv4-mapped one.
+	 */
+	private static function is_ipv4_mapped( string $packed ): bool {
+		return 16 === strlen( $packed )
+			&& 0 === strncmp( $packed, str_repeat( "\0", 10 ) . "\xff\xff", 12 );
 	}
 }

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -77,6 +77,24 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			return (int) $is_country_spam;
 		}
 
+		/*
+		 * Loopback, link-local and private addresses have no country, which is a
+		 * common setup: a local install reports `127.0.0.1` or `::1`, and a site
+		 * behind a reverse proxy without a `pre_comment_user_ip` filter sees the
+		 * address of the proxy. Asking the service anyway would only tell it that
+		 * this site exists.
+		 */
+		if ( ! IpHelper::is_global_ip( $ip ) ) {
+			return 0;
+		}
+
+		$anonymized_ip = IpHelper::anonymize_ip( $ip );
+
+		// Never look up an address that anonymization could not preserve.
+		if ( '' === $anonymized_ip ) {
+			return 0;
+		}
+
 		/**
 		 * Filters the IPLocate API key. With this filter, you can add your own IPLocate API key.
 		 *
@@ -90,7 +108,7 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			esc_url_raw(
 				sprintf(
 					'https://www.iplocate.io/api/lookup/%s?apikey=%s',
-					IpHelper::anonymize_ip( $ip ),
+					$anonymized_ip,
 					$apikey
 				),
 				[ 'https' ]

--- a/tests/Unit/Helpers/IpHelperTest.php
+++ b/tests/Unit/Helpers/IpHelperTest.php
@@ -51,6 +51,38 @@ class IpHelperTest extends TestCase {
 		self::assertSame( $expected, IpHelper::anonymize_ip( $ip ), $message );
 	}
 
+	/**
+	 * @dataProvider is_global_ip_provider
+	 */
+	public function test_is_global_ip( string $ip, bool $expected, string $message ): void {
+		self::assertSame( $expected, IpHelper::is_global_ip( $ip ), $message );
+	}
+
+	public function is_global_ip_provider(): array {
+		return [
+			[ '198.51.100.42', true, 'a global IPv4 address should be global' ],
+			// Deliberately from `3fff::/20` (RFC 9637) rather than the older `2001:db8::/32`
+			// (RFC 3849): PHP 7.4 still rejects the latter as a reserved range, while PHP 8.3
+			// and later report it as global, so it cannot stand in for a routable address
+			// across the supported versions.
+			[ '3fff:85a3:1234::5', true, 'a global IPv6 address should be global' ],
+			// `FILTER_FLAG_NO_RES_RANGE` rejects all of `::ffff:0:0/96`, so the mapped
+			// IPv4 address has to be unwrapped before it is checked.
+			[ '::ffff:198.51.100.42', true, 'an IPv4-mapped global address should be global' ],
+			[ '127.0.0.1', false, 'the IPv4 loopback address should not be global' ],
+			[ '::1', false, 'the IPv6 loopback address should not be global' ],
+			[ '10.11.12.13', false, 'a private IPv4 address should not be global' ],
+			[ '172.16.0.1', false, 'another private IPv4 address should not be global' ],
+			[ '192.168.1.50', false, 'a third private IPv4 address should not be global' ],
+			[ '169.254.1.1', false, 'a link-local IPv4 address should not be global' ],
+			[ 'fe80::1', false, 'a link-local IPv6 address should not be global' ],
+			[ 'fc00::1', false, 'a unique local IPv6 address should not be global' ],
+			[ '::ffff:10.0.0.1', false, 'an IPv4-mapped private address should not be global' ],
+			[ '', false, 'empty input should not be global' ],
+			[ 'no-ip-at-all', false, 'non-IP input should not be global' ],
+		];
+	}
+
 	public function anonymize_ip_provider(): array {
 		return [
 			[ '198.51.100.42', '198.51.100.0', 'IPv4 address should be truncated to a /24 network' ],

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Rules;
+
+use AntispamBee\Rules\CountrySpam;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see CountrySpam}.
+ */
+class CountrySpamTest extends AbstractRuleTestCase {
+
+	/**
+	 * The country codes the rule denies, as stored by the settings.
+	 *
+	 * @var string
+	 */
+	private $denied_countries = '';
+
+	public function __construct() {
+		parent::__construct( CountrySpam::class, 'asb-country-spam' );
+	}
+
+	public function test_verify_does_not_call_the_service_without_an_ip(): void {
+		$this->expect_no_request();
+
+		$item       = self::make_comment();
+		$item['ip'] = '';
+
+		self::assertSame( 0, CountrySpam::verify( $item ), 'A reaction without an IP should not be flagged' );
+	}
+
+	public function test_verify_does_not_call_the_service_without_configured_countries(): void {
+		$this->expect_no_request();
+		$this->denied_countries = '';
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'Without a country list there is nothing to check'
+		);
+	}
+
+	/**
+	 * A local install reports the loopback address, and a site behind a reverse
+	 * proxy without a `pre_comment_user_ip` filter sees a private address. Neither
+	 * has a country, so the service must not be asked about them.
+	 *
+	 * The addresses are looped over instead of coming from a data provider,
+	 * because {@see AbstractRuleTestCase} takes over the constructor PHPUnit
+	 * would pass the provided data to.
+	 */
+	public function test_verify_does_not_call_the_service_for_a_non_global_ip(): void {
+		$this->expect_no_request();
+
+		$non_global_ips = [
+			'IPv4 loopback'    => '127.0.0.1',
+			'IPv6 loopback'    => '::1',
+			'private IPv4'     => '10.11.12.13',
+			'private IPv4 too' => '192.168.1.50',
+			'link-local IPv6'  => 'fe80::1',
+			'not an IP at all' => 'no-ip-at-all',
+		];
+
+		foreach ( $non_global_ips as $description => $ip ) {
+			self::assertSame(
+				0,
+				CountrySpam::verify( self::make_comment_from( $ip ) ),
+				"A $description address should not be sent to the service"
+			);
+		}
+	}
+
+	public function test_verify_flags_a_reaction_from_a_denied_country(): void {
+		$this->expect_request( '{"country_code":"DE"}' );
+
+		self::assertSame(
+			1,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'A reaction from a denied country should be flagged'
+		);
+	}
+
+	public function test_verify_does_not_flag_a_reaction_from_another_country(): void {
+		$this->expect_request( '{"country_code":"FR"}' );
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'A reaction from a country that is not denied should not be flagged'
+		);
+	}
+
+	public function test_verify_does_not_flag_an_undetermined_country(): void {
+		$this->expect_request( '{}' );
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'A response without a country code should not be flagged'
+		);
+	}
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'AntispamBee\MAIN_PLUGIN_FILE' ) ) {
+			define( 'AntispamBee\MAIN_PLUGIN_FILE', dirname( __DIR__, 3 ) . '/antispam_bee.php' );
+		}
+
+		when( 'esc_url_raw' )->returnArg();
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+
+		// Keep the plugin update logic, which the settings run into, from touching the database.
+		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0' ] );
+
+		$this->denied_countries = 'DE';
+
+		when( 'get_option' )->alias(
+			function ( string $option ) {
+				if ( 'antispambee_db_version' === $option ) {
+					return '3.0.0';
+				}
+
+				return [
+					'comment' => [
+						'rule_asb_country_spam_denied' => $this->denied_countries,
+					],
+				];
+			}
+		);
+	}
+
+	/**
+	 * Generate a comment payload from the given IP address.
+	 *
+	 * @param string $ip The IP address of the author.
+	 *
+	 * @return array Comment array.
+	 */
+	private static function make_comment_from( string $ip ): array {
+		return self::make_comment( 1, 'Test Author', 'test.author@example.com', 'www.example.com', $ip );
+	}
+
+	/**
+	 * Expect a single request to the geolocation service.
+	 *
+	 * @param string $body The response body to return.
+	 *
+	 * @return void
+	 */
+	private function expect_request( string $body ): void {
+		expect( 'wp_safe_remote_get' )->once()->andReturn( [ 'body' => $body ] );
+		when( 'wp_remote_retrieve_body' )->justReturn( $body );
+	}
+
+	/**
+	 * Expect that the geolocation service is not called at all.
+	 *
+	 * @return void
+	 */
+	private function expect_no_request(): void {
+		expect( 'wp_safe_remote_get' )->never();
+	}
+}


### PR DESCRIPTION
Fixes #786.

## Description

`CountrySpam::verify()` sent every address to iplocate.io, including ones that cannot resolve to a country at all. A local installation reports `127.0.0.1` or `::1`, and a site behind a reverse proxy without a `pre_comment_user_ip` filter sees the private address of the proxy — so those setups produced one pointless outbound request per reaction, in the request path of the comment, and told the service that the site exists and is receiving comments.

The rule now bails out before the request when the address is not globally routable:

```php
if ( ! IpHelper::is_global_ip( $ip ) ) {
	return 0;
}

$anonymized_ip = IpHelper::anonymize_ip( $ip );

// Never look up an address that anonymization could not preserve.
if ( '' === $anonymized_ip ) {
	return 0;
}
```

Both guards run **after** the `antispam_bee_is_country_spam` filter, so a custom IP check can still handle addresses the built-in lookup skips.

## `IpHelper::is_global_ip()`

`filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE )` does the work, with two details that matter:

- It runs on the **original** address, not the anonymized one. A masked global address must not be mistaken for a private one.
- An **IPv4-mapped IPv6 address is unwrapped first.** PHP treats the whole `::ffff:0:0/96` block as reserved, so a bare `filter_var()` call rejects `::ffff:203.0.113.5` — a perfectly global IPv4 address as a dual-stack host reports it. Without the unwrapping this would silently disable the country check for those visitors, which is the same class of bug as the one #761 fixes.

The unwrapping shares the new private `is_ipv4_mapped()` helper with `anonymize_ip()`.

| address | global |
|---|---|
| `198.51.100.42` | yes |
| `2a02:8109:aa00:1234::5` | yes |
| `::ffff:198.51.100.42` | yes |
| `127.0.0.1`, `::1` | no |
| `10.11.12.13`, `172.16.0.1`, `192.168.1.50` | no |
| `169.254.1.1`, `fe80::1`, `fc00::1` | no |
| `::ffff:10.0.0.1` | no |
| `''`, `no-ip-at-all` | no |

## On the empty-string guard

It **cannot fire on this branch.** `is_global_ip()` already rejects anything `inet_pton()` cannot parse, so every address that reaches `anonymize_ip()` masks to a non-empty string. On plain `v3` it would be reachable — `2a02::1` anonymizes to `''` there, because the regex `\w+([\.:])\w+` cannot match an address whose second group is elided — but #761 removes that case.

It is kept as a safety net for the documented contract of `anonymize_ip()`, so that no code path can ever build a lookup URL with no address in it. Happy to drop it if you would rather not carry a guard that is currently unreachable.

## Testing

New `tests/Unit/Rules/CountrySpamTest.php`, following the `expect( 'wp_safe_remote_get' )->never()` pattern from `LangSpamTest`:

- no request without an IP, and none without configured country lists;
- no request for loopback, private, link-local or unparseable addresses;
- a denied country is flagged, another country is not, and a response without a `country_code` is not.

Plus an `is_global_ip_provider` in `IpHelperTest` covering the table above. Verified that `test_verify_does_not_call_the_service_for_a_non_global_ip` fails when the guard is removed, so it is not vacuous.

`composer test:unit` — 90 tests pass. `phpcs` and `phpstan` (level 8) clean.

> **Note:** stacked on #761, because `is_ipv4_mapped()` is shared with `anonymize_ip()`. The base is `test/anonymize-ip-unit-test` so the diff stays limited to this change; GitHub will retarget it to `v3` once #761 merges.

## Not included

There is still no caching of lookups, so each reaction with a global address is one request. Worth considering separately.

