### PR TITLE
fix: keep invalid UTF-8 out of the regular expression patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
     * Fix: The country rule no longer asks the geolocation service about loopback, link-local and
       private addresses, which have no country anyway — a local installation and a site behind a
       reverse proxy without a `pre_comment_user_ip` filter stop sending requests altogether
+    * Fix: The regular expression rule no longer raises a PHP warning when the author or the
+      content of a comment is not valid UTF-8
 
 * **Deutsch**
     * Kompletter Code-Rewrite und Überarbeitung des Backend-User-Interfaces
@@ -32,6 +34,8 @@
     * Fix: Die Länder-Regel fragt den Geolokalisierungs-Dienst nicht mehr zu Loopback-, Link-Local-
       und privaten Adressen, die ohnehin kein Land haben – eine lokale Installation und eine Seite
       hinter einem Reverse-Proxy ohne `pre_comment_user_ip`-Filter senden gar keine Anfragen mehr
+    * Fix: Die Regex-Regel löst keine PHP-Warnung mehr aus, wenn der Autor oder der Inhalt eines
+      Kommentars kein gültiges UTF-8 ist
 
 ### 2.11.12 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Fix: The language rule no longer marks a comment as spam if the language could not be determined at all
     * Fix: IP addresses are now anonymized by masking the host portion of the address: a /24 for IPv4, the same network WordPress itself keeps, as in Antispam Bee 2.x, and a /48 for IPv6 instead of only its first two groups
     * Fix: The country rule no longer asks the geolocation service about loopback, link-local and private addresses, which have no country anyway
+    * Fix: The regular expression rule no longer raises a PHP warning when the author or the content of a comment is not valid UTF-8
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/src/Rules/RegexpSpam.php
+++ b/src/Rules/RegexpSpam.php
@@ -56,15 +56,24 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 			'useragent',
 		];
 
-		$subject = [
-			'ip'        => $item['ip'] ?? '',
-			'rawurl'    => $item['url'] ?? '',
-			'host'      => $item['host'] ?? '',
-			'body'      => $item['body'] ?? '',
-			'email'     => $item['email'] ?? '',
-			'author'    => $item['author'] ?? '',
-			'useragent' => $item['useragent'] ?? '',
-		];
+		/*
+		 * Repair the payload up front, before anything is built from it. The author
+		 * is spliced into the patterns below, and a pattern that is not valid UTF-8
+		 * makes the `u` modifier fail to compile — which raises a warning instead of
+		 * simply not matching.
+		 */
+		$subject = array_map(
+			[ self::class, 'repair_utf8' ],
+			[
+				'ip'        => $item['ip'] ?? '',
+				'rawurl'    => $item['url'] ?? '',
+				'host'      => $item['host'] ?? '',
+				'body'      => $item['body'] ?? '',
+				'email'     => $item['email'] ?? '',
+				'author'    => $item['author'] ?? '',
+				'useragent' => $item['useragent'] ?? '',
+			]
+		);
 
 		$patterns = [
 			[
@@ -158,11 +167,13 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 					continue;
 				}
 
-				if ( function_exists( 'iconv' ) ) {
-					$converted = iconv( 'utf-8', 'utf-8//TRANSLIT', $subject[ $field ] );
-					if ( false !== $converted ) {
-						$subject[ $field ] = $converted;
-					}
+				/*
+				 * Patterns reach this point through the `antispam_bee_patterns` filter
+				 * as well, so a third party can supply one that is not valid UTF-8.
+				 * Skip it rather than let the compilation warning through.
+				 */
+				if ( ! self::is_valid_utf8( (string) $regexp ) ) {
+					continue;
 				}
 
 				if ( empty( $subject[ $field ] ) ) {
@@ -180,6 +191,57 @@ class RegexpSpam extends ControllableBase implements SpamReason {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Check whether a string is well-formed UTF-8.
+	 *
+	 * An empty pattern with the `u` modifier reports malformed input through its
+	 * return value instead of a warning, which is what makes it usable as a guard
+	 * in front of the patterns that would otherwise fail to compile.
+	 *
+	 * @param string $value Value to check.
+	 *
+	 * @return bool Whether the value is valid UTF-8.
+	 */
+	private static function is_valid_utf8( string $value ): bool {
+		return '' === $value || 1 === preg_match( '//u', $value );
+	}
+
+	/**
+	 * Drop byte sequences that are not valid UTF-8.
+	 *
+	 * Comment payloads are not guaranteed to be well-formed: a client can post an
+	 * overlong encoding or a truncated multibyte character, and that value then
+	 * travels into both the subjects and the patterns built from them.
+	 *
+	 * `iconv()` with `//TRANSLIT` is deliberately not used, because it raises a
+	 * warning of its own and returns `false` for exactly this input.
+	 *
+	 * @param mixed $value Value to repair.
+	 *
+	 * @return string Repaired value, or an empty string when it cannot be repaired.
+	 */
+	private static function repair_utf8( $value ): string {
+		$value = is_scalar( $value ) ? (string) $value : '';
+
+		if ( self::is_valid_utf8( $value ) ) {
+			return $value;
+		}
+
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+			$repaired = mb_convert_encoding( $value, 'UTF-8', 'UTF-8' );
+		} elseif ( function_exists( 'iconv' ) ) {
+			$repaired = iconv( 'utf-8', 'utf-8//IGNORE', $value );
+		} else {
+			$repaired = false;
+		}
+
+		if ( ! is_string( $repaired ) || ! self::is_valid_utf8( $repaired ) ) {
+			return '';
+		}
+
+		return $repaired;
 	}
 
 	/**

--- a/tests/Unit/Rules/RegexpSpamTest.php
+++ b/tests/Unit/Rules/RegexpSpamTest.php
@@ -108,6 +108,82 @@ class RegexpSpamTest extends AbstractRuleTestCase {
 	}
 
 	/**
+	 * An author that is not valid UTF-8 must not raise a warning.
+	 *
+	 * Regression test for #587: the author is spliced into three of the patterns,
+	 * so malformed bytes travel into the pattern rather than the subject, and the
+	 * `u` modifier then fails to *compile* it — which warns instead of not matching.
+	 * `\xC0\xAF` is an overlong encoding of `/`, the sequence class from the report.
+	 */
+	public function test_verify_author_with_invalid_utf8() {
+		$item           = self::make_comment();
+		$item['author'] = "Spam\xC0\xAFName";
+
+		self::assertSame(
+			0,
+			RegexpSpam::verify( $item ),
+			'An author that is not valid UTF-8 should be handled without a warning'
+		);
+	}
+
+	/**
+	 * A body that is not valid UTF-8 must not raise a warning either.
+	 *
+	 * The former `iconv( 'utf-8', 'utf-8//TRANSLIT', … )` sanitisation warned on
+	 * exactly this input and returned `false`, so it never sanitised anything.
+	 */
+	public function test_verify_body_with_invalid_utf8() {
+		$item         = self::make_comment();
+		$item['body'] = "Harmless \xE2\x28\xA1 text";
+
+		self::assertSame(
+			0,
+			RegexpSpam::verify( $item ),
+			'A body that is not valid UTF-8 should be handled without a warning'
+		);
+	}
+
+	/**
+	 * Repairing the author must not cost detection: a spam term next to malformed
+	 * bytes still has to be flagged.
+	 */
+	public function test_verify_still_detects_spam_author_with_invalid_utf8() {
+		$item           = self::make_comment();
+		$item['author'] = "Buy Viagra\xC0\xAF";
+
+		self::assertSame(
+			1,
+			RegexpSpam::verify( $item ),
+			'A known spam term should still be flagged when the author also carries malformed bytes'
+		);
+	}
+
+	/**
+	 * A pattern supplied through the filter can be malformed too, and must be
+	 * skipped rather than allowed to fail compilation.
+	 */
+	public function test_verify_skips_custom_patterns_that_are_not_valid_utf8() {
+		$item         = self::make_comment();
+		$item['body'] = 'A perfectly harmless custom message.';
+
+		expectApplied( 'antispam_bee_patterns' )
+			->once()
+			->andReturn(
+				[
+					[
+						'body' => "harmless\xC0\xAF custom message",
+					],
+				]
+			);
+
+		self::assertSame(
+			0,
+			RegexpSpam::verify( $item ),
+			'A custom pattern that is not valid UTF-8 should be skipped without a warning'
+		);
+	}
+
+	/**
 	 * Set up the test environment.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes #587.

## The cause

`RegexpSpam::verify()` splices the comment author into three of its patterns:

```php
$quoted_author = preg_quote( $subject['author'], '/' );
```

The `u` modifier requires the **pattern** to be valid UTF-8, not just the subject. So an author carrying malformed bytes — an overlong encoding, a truncated multibyte character — produces a pattern that cannot be compiled, and `preg_match()` raises `Compilation failed: UTF-8 error: …` rather than simply not matching. That is why the reported trace points at the `preg_match()` call while the malformed data is in the author.

An invalid *subject* would not do this: with `u`, PCRE reports a malformed subject through the return value and `preg_last_error()`, silently.

## A second warning, in the sanitisation itself

The existing guard was:

```php
$converted = iconv( 'utf-8', 'utf-8//TRANSLIT', $subject[ $field ] );
if ( false !== $converted ) { … }
```

On exactly this input `iconv()` emits `iconv(): Detected an illegal character in input string` **and** returns `false`, so it warned and then sanitised nothing. It also ran after the patterns were built, so it could never have protected the spliced author anyway.

## The fix

- Repair every payload field once, up front, before any pattern is built from it. `mb_convert_encoding( …, 'UTF-8', 'UTF-8' )` is preferred and `iconv( …, 'utf-8//IGNORE', … )` is the fallback; both drop malformed bytes without warning. A field that cannot be repaired becomes an empty string, which the existing `empty()` guard already skips.
- Skip any pattern that is not valid UTF-8. Patterns also arrive through the public `antispam_bee_patterns` filter, so a third party can supply a malformed one. `preg_match( '//u', $value )` reports this through its return value, without a warning, which is what makes it usable as a guard.

Detection is unaffected: a repaired author still matches the spam terms, which is covered by a test.

## Tests

Four regression tests in `RegexpSpamTest`. `phpunit.xml.dist` sets `convertWarningsToExceptions="true"`, so a warning fails the test outright.

| Test | Without the fix |
|---|---|
| `test_verify_author_with_invalid_utf8` | fails — `Compilation failed: UTF-8 error: overlong 2-byte sequence` |
| `test_verify_still_detects_spam_author_with_invalid_utf8` | fails — same warning |
| `test_verify_skips_custom_patterns_that_are_not_valid_utf8` | fails — same warning |
| `test_verify_body_with_invalid_utf8` | fails on builds with `iconv` — `Detected an illegal character in input string` |

The last one only fails where `iconv` is loaded, which is the case on CI.

Verified locally on PHP 8.4 and 8.5: 104 tests green, `phpcs` clean, `phpstan` reports no errors.

## Note on the alternative

The issue discussed using the HTML API instead of a regular expression. That would need the minimum WordPress version raised to 6.2, and it would not address the author being spliced into the pattern, so it is left out of scope here.
