### PR TITLE
fix: stop sending an empty `apikey` to the geolocation service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
       reverse proxy without a `pre_comment_user_ip` filter stop sending requests altogether
     * Fix: The regular expression rule no longer raises a PHP warning when the author or the
       content of a comment is not valid UTF-8
+    * Fix: The country rule works again without an IPLocate API key — an empty `apikey` parameter
+      made the geolocation service reject every lookup. A key set through the
+      `antispam_bee_country_spam_apikey` filter is now sent as a request header, which also keeps
+      it out of proxy and server logs
     * Enhancement: New `antispam_bee_country_spam_ip` filter to change which address the country
       rule looks up — mask it differently, send the original one for a more precise country, or
       return an empty string to skip the lookup
@@ -39,6 +43,10 @@
       hinter einem Reverse-Proxy ohne `pre_comment_user_ip`-Filter senden gar keine Anfragen mehr
     * Fix: Die Regex-Regel löst keine PHP-Warnung mehr aus, wenn der Autor oder der Inhalt eines
       Kommentars kein gültiges UTF-8 ist
+    * Fix: Die Länder-Regel funktioniert wieder ohne IPLocate-API-Key – ein leerer
+      `apikey`-Parameter führte dazu, dass der Geolokalisierungs-Dienst jede Abfrage ablehnte. Ein
+      über den Filter `antispam_bee_country_spam_apikey` gesetzter Key wird nun als Request-Header
+      gesendet, was ihn zugleich aus Proxy- und Server-Logs heraushält
     * Verbesserung: Neuer Filter `antispam_bee_country_spam_ip`, um die Adresse zu ändern, die die
       Länder-Regel abfragt – anders maskieren, die ursprüngliche Adresse für ein genaueres Land
       senden oder mit einem leeren String die Abfrage ganz überspringen

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -114,17 +114,25 @@ class CountrySpam extends ControllableBase implements SpamReason {
 		 *
 		 * @param string $apikey The current IPLocate API key. Default is empty string.
 		 */
-		$apikey = apply_filters( 'antispam_bee_country_spam_apikey', '' );
+		$apikey = trim( (string) apply_filters( 'antispam_bee_country_spam_apikey', '' ) );
+
+		/*
+		 * The service answers anonymous lookups within its free tier, but rejects
+		 * an empty `apikey` parameter with `401 Invalid API key`. Only send the key
+		 * when there is one, and send it as a header so that it stays out of the
+		 * URL, and with it out of proxy and server logs.
+		 */
+		$args = '' === $apikey ? [] : [ 'headers' => [ 'X-Api-Key' => $apikey ] ];
 
 		$response = wp_safe_remote_get(
 			esc_url_raw(
 				sprintf(
-					'https://www.iplocate.io/api/lookup/%s?apikey=%s',
-					$lookup_ip,
-					$apikey
+					'https://www.iplocate.io/api/lookup/%s',
+					$lookup_ip
 				),
 				[ 'https' ]
-			)
+			),
+			$args
 		);
 
 		if ( is_wp_error( $response ) ) {

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -19,6 +19,20 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	 */
 	private $denied_countries = '';
 
+	/**
+	 * The URL the last expected request went to.
+	 *
+	 * @var string
+	 */
+	private $request_url = '';
+
+	/**
+	 * The arguments the last expected request was made with.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $request_args = [];
+
 	public function __construct() {
 		parent::__construct( CountrySpam::class, 'asb-country-spam' );
 	}
@@ -97,10 +111,7 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	 * the original one to choose from.
 	 */
 	public function test_verify_looks_up_the_address_the_filter_returns(): void {
-		$this->expect_request(
-			'{"country_code":"DE"}',
-			'https://www.iplocate.io/api/lookup/198.51.100.42?apikey='
-		);
+		$this->expect_request( '{"country_code":"DE"}' );
 
 		expectApplied( 'antispam_bee_country_spam_ip' )
 			->once()
@@ -111,6 +122,11 @@ class CountrySpamTest extends AbstractRuleTestCase {
 			1,
 			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
 			'The address returned by the filter should be used for the lookup'
+		);
+		self::assertSame(
+			'https://www.iplocate.io/api/lookup/198.51.100.42',
+			$this->request_url,
+			'The address returned by the filter should be the one in the lookup URL'
 		);
 	}
 
@@ -141,6 +157,48 @@ class CountrySpamTest extends AbstractRuleTestCase {
 			0,
 			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
 			'A response without a country code should not be flagged'
+		);
+	}
+
+	/**
+	 * Without a key, the service answers anonymous lookups, but rejects an empty
+	 * `apikey` parameter with `401 Invalid API key`.
+	 *
+	 * @see https://github.com/pluginkollektiv/antispam-bee/issues/819
+	 */
+	public function test_verify_does_not_send_an_empty_api_key(): void {
+		$this->expect_request( '{"country_code":"DE"}' );
+
+		self::assertSame( 1, CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ) );
+
+		self::assertStringNotContainsString(
+			'apikey',
+			$this->request_url,
+			'Without a key, the lookup URL should not carry an `apikey` parameter'
+		);
+		self::assertSame(
+			[],
+			$this->request_args,
+			'Without a key, the request should not carry any headers'
+		);
+	}
+
+	public function test_verify_sends_a_configured_api_key_as_a_header(): void {
+		expectApplied( 'antispam_bee_country_spam_apikey' )->once()->andReturn( ' secret-key ' );
+
+		$this->expect_request( '{"country_code":"DE"}' );
+
+		self::assertSame( 1, CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ) );
+
+		self::assertStringNotContainsString(
+			'secret-key',
+			$this->request_url,
+			'The key should stay out of the URL, and with it out of proxy and server logs'
+		);
+		self::assertSame(
+			[ 'headers' => [ 'X-Api-Key' => 'secret-key' ] ],
+			$this->request_args,
+			'The key should be sent as a header, trimmed'
 		);
 	}
 
@@ -194,19 +252,21 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	/**
 	 * Expect a single request to the geolocation service.
 	 *
-	 * @param string      $body The response body to return.
-	 * @param string|null $url  The URL the request is expected to go to, if it matters.
+	 * @param string $body The response body to return.
 	 *
 	 * @return void
 	 */
-	private function expect_request( string $body, ?string $url = null ): void {
-		$expectation = expect( 'wp_safe_remote_get' )->once();
+	private function expect_request( string $body ): void {
+		expect( 'wp_safe_remote_get' )
+			->once()
+			->andReturnUsing(
+				function ( string $url, array $args = [] ) use ( $body ) {
+					$this->request_url  = $url;
+					$this->request_args = $args;
 
-		if ( null !== $url ) {
-			$expectation = $expectation->with( $url );
-		}
-
-		$expectation->andReturn( [ 'body' => $body ] );
+					return [ 'body' => $body ];
+				}
+			);
 		when( 'wp_remote_retrieve_body' )->justReturn( $body );
 	}
 


### PR DESCRIPTION
Fixes #819.

`CountrySpam::verify()` always built `…/lookup/{ip}?apikey={key}`. Without the `antispam_bee_country_spam_apikey` filter the key is empty, and IPLocate answers `401 {"error":"Invalid API key"}` — so the rule silently returned `0` for every comment, and the country check never did anything.

The query parameter is gone; the URL is now the plain anonymous lookup, which IPLocate serves in its free tier. A non-empty key (trimmed) goes into an `X-Api-Key` request header instead, which also keeps it out of proxy and server logs.

Adds two unit tests asserting the request shape in both cases — the request helper now captures URL and args — plus EN/DE changelog entries.

Note: #814 still builds the `?apikey=` URL and carries the same bug, so whichever of the two lands second needs a rebase.
