### PR TITLE
ci: pass the release tag via `env:` in `attach-snapshot.yml`

### DIFF
--- a/.github/workflows/attach-snapshot.yml
+++ b/.github/workflows/attach-snapshot.yml
@@ -130,8 +130,9 @@ jobs:
         if: steps.download.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$TAG" \
             "$SNAPSHOT_FILE" --clobber
-          echo "Attached $(basename "$SNAPSHOT_FILE") to ${{ github.event.release.tag_name }}."
+          echo "Attached $(basename "$SNAPSHOT_FILE") to $TAG."


### PR DESCRIPTION
Fixes the expression-injection finding from #822.

`${{ github.event.release.tag_name }}` was interpolated directly into the `run:` block of the "Attach to the release" step. Workflow expressions are substituted **textually before the shell parses the script**, so a release tag containing shell metacharacters would execute as code — with `GH_TOKEN` in scope.

The tag is now bound to a `TAG` environment variable and referenced as `"$TAG"`, which passes it as data rather than as script source. This mirrors the "Find the run that classified this commit" step in the same workflow, which already uses that pattern.

## Scope

Publishing a release requires write access, so this was never exploitable by an outside contributor — it is a hardening fix, not a response to an active vulnerability.

Not covered by #810, which pins action refs but does not touch this step.

## Verification

- No `github.event` interpolation remains inside any `run:` block in the workflow; both remaining references are in `env:` blocks.
- The workflow still parses as valid YAML.