### PR TITLE
fix: escape the slug in the unknown-rule spam reason text

### DIFF
--- a/src/Helpers/SpamReasonTextHelper.php
+++ b/src/Helpers/SpamReasonTextHelper.php
@@ -89,7 +89,7 @@ class SpamReasonTextHelper {
 			$texts[] = sprintf(
 				/* translators: s=slug of unknown spam reason */
 				esc_html_x( 'Unknown rule: %s', 'spam-reason-unknown-text', 'antispam-bee' ),
-				$slug
+				esc_html( $slug )
 			);
 		}
 

--- a/tests/Unit/Helpers/SpamReasonTextHelperTest.php
+++ b/tests/Unit/Helpers/SpamReasonTextHelperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\SpamReasonTextHelper;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\stubs;
+
+/**
+ * Unit tests for {@see SpamReasonTextHelper}.
+ */
+class SpamReasonTextHelperTest extends TestCase {
+
+	/**
+	 * Stub the escaping functions with their real escaping behaviour.
+	 *
+	 * The point of these tests is that the helper escapes, so stubbing the
+	 * `esc_*` functions as pass-throughs would defeat them.
+	 *
+	 * @return void
+	 */
+	private function stub_escaping(): void {
+		stubs(
+			[
+				'esc_html'   => function ( string $text ) {
+					return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+				},
+				'esc_html_x' => function ( string $text ) {
+					return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+				},
+			]
+		);
+	}
+
+	public function test_unknown_slug_is_escaped(): void {
+		$this->stub_escaping();
+
+		self::assertSame(
+			[ 'Unknown rule: &lt;script&gt;alert(1)&lt;/script&gt;' ],
+			SpamReasonTextHelper::get_texts_by_slugs( [ '<script>alert(1)</script>' ] ),
+			'An unknown rule slug should be escaped before it is interpolated into the text'
+		);
+	}
+
+	public function test_unknown_slug_leaves_harmless_values_readable(): void {
+		$this->stub_escaping();
+
+		self::assertSame(
+			[ 'Unknown rule: some_removed_rule' ],
+			SpamReasonTextHelper::get_texts_by_slugs( [ 'some_removed_rule' ] ),
+			'A harmless unknown slug should still be rendered verbatim'
+		);
+	}
+
+	public function test_every_returned_text_is_escaped(): void {
+		$this->stub_escaping();
+
+		$texts = SpamReasonTextHelper::get_texts_by_slugs(
+			[ 'server', '"><img src=x onerror=alert(1)>' ]
+		);
+
+		foreach ( $texts as $text ) {
+			self::assertDoesNotMatchRegularExpression(
+				'/[<>"]/',
+				$text,
+				'Callers echo these texts unescaped, so no returned text may contain raw markup characters'
+			);
+		}
+	}
+}


### PR DESCRIPTION
Fixes the unescaped-slug finding from #822.

`Helpers\SpamReasonTextHelper::get_texts_by_slugs()` escapes the known-rule and legacy-rule branches, but the unknown-rule branch passed `$slug` straight to `sprintf()`. `esc_html_x()` there escapes only the static format string, not the substituted value.

`Admin\CommentsColumns::print_plugin_column()` echoes the joined result under a deliberate `WordPress.Security.EscapeOutput` ignore, on the assumption that every text the helper returns is already escaped. That assumption did not hold for this one branch.

## Scope

**Not currently reachable.** The `antispam_bee_reason` comment meta is only ever written from hard-coded static rule slugs, so a commenter cannot supply an arbitrary one. This is defence in depth: it keeps the helper contract intact for any future import, migration, third-party plugin, or rule whose slug becomes dynamic — any of which would otherwise turn this into stored XSS against admins.

## Verification

- Unit tests pass (`composer test:unit`).
- No existing test references `SpamReasonTextHelper` or the "Unknown rule" string, so no expectations changed.

A regression test would be worthwhile as a follow-up; it needs stub coverage for `esc_html()` / `esc_html_x()` in `tests/_stubs/`.