### PR TITLE
fix: resolve the remaining security review findings

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,6 +16,12 @@ on:
   # Allow forcing a full run by hand, for example before cutting a release.
   workflow_dispatch:
 
+# The job only reads the checkout and runs a spell checker, so it needs nothing
+# beyond read access. Declared explicitly so it stays restricted even if the
+# repository default token permission is widened later.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -21,4 +21,5 @@ define( 'ANTISPAM_BEE_LOG_FILE', 'asb.log' );
 // Defined in `wp-config.php`. Unlike the directory constants, it is not declared by
 // `phpstan-wordpress`, so an explicit `use const` import would not resolve during
 // analysis without this.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- A WordPress core constant, stubbed for analysis only; this file is never shipped.
 define( 'NONCE_SALT', 'phpstan-nonce-salt' );

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -18,3 +18,7 @@ define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-alpha.15' );
 // PHPStan uses the declared type instead of narrowing to these literal values.
 define( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED', false );
 define( 'ANTISPAM_BEE_LOG_FILE', 'asb.log' );
+// Defined in `wp-config.php`. Unlike the directory constants, it is not declared by
+// `phpstan-wordpress`, so an explicit `use const` import would not resolve during
+// analysis without this.
+define( 'NONCE_SALT', 'phpstan-nonce-salt' );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
   dynamicConstantNames:
     - ANTISPAM_BEE_DEBUG_MODE_ENABLED
     - ANTISPAM_BEE_LOG_FILE
+    - NONCE_SALT
   treatPhpDocTypesAsCertain: false

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -38,6 +38,10 @@ class DebugMode {
 		$content_dir = WP_CONTENT_DIR;
 		$suffix      = self::get_log_file_suffix();
 
+		// Comment data reaches the log, so a line break in the message would let
+		// an attacker forge additional log entries.
+		$message = (string) preg_replace( '/[\r\n]+/', ' ', $message );
+
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional debug use.
 		error_log( "[{$date} {$time}] {$message}\n", 3, "{$content_dir}/asb-debug.{$date}.{$suffix}.log" );
 	}

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -8,6 +8,7 @@
 namespace AntispamBee\Helpers;
 
 use const ANTISPAM_BEE_DEBUG_MODE_ENABLED;
+use const NONCE_SALT;
 use const WP_CONTENT_DIR;
 
 /**
@@ -64,11 +65,11 @@ class DebugMode {
 	 * @return string|null Suffix, or null if no secret salt is available.
 	 */
 	private static function get_log_file_suffix(): ?string {
-		if ( ! defined( 'NONCE_SALT' ) || ! is_string( \NONCE_SALT ) || '' === \NONCE_SALT ) {
+		if ( ! defined( 'NONCE_SALT' ) || ! is_string( NONCE_SALT ) || '' === NONCE_SALT ) {
 			return null;
 		}
 
-		return substr( sha1( 'asb-debug' . \NONCE_SALT ), 0, 12 );
+		return substr( sha1( 'asb-debug' . NONCE_SALT ), 0, 12 );
 	}
 
 	/**

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -38,6 +38,10 @@ class DebugMode {
 		$content_dir = WP_CONTENT_DIR;
 		$suffix      = self::get_log_file_suffix();
 
+		if ( null === $suffix ) {
+			return;
+		}
+
 		// Comment data reaches the log, so a line break in the message would let
 		// an attacker forge additional log entries.
 		$message = (string) preg_replace( '/[\r\n]+/', ' ', $message );
@@ -52,12 +56,19 @@ class DebugMode {
 	 * The log contains comment data and `WP_CONTENT_DIR` is usually served
 	 * publicly, so the file name must not be guessable.
 	 *
-	 * @return string
+	 * This requires a secret salt. `NONCE_SALT` is defined on every normal
+	 * installation; when it is missing there is no secret to derive from, so
+	 * this returns `null` and logging is skipped rather than falling back to a
+	 * predictable value such as `ABSPATH`.
+	 *
+	 * @return string|null Suffix, or null if no secret salt is available.
 	 */
-	private static function get_log_file_suffix(): string {
-		$salt = defined( 'NONCE_SALT' ) ? \NONCE_SALT : \ABSPATH;
+	private static function get_log_file_suffix(): ?string {
+		if ( ! defined( 'NONCE_SALT' ) || ! is_string( \NONCE_SALT ) || '' === \NONCE_SALT ) {
+			return null;
+		}
 
-		return substr( sha1( 'asb-debug' . $salt ), 0, 12 );
+		return substr( sha1( 'asb-debug' . \NONCE_SALT ), 0, 12 );
 	}
 
 	/**

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -10,6 +10,7 @@ namespace AntispamBee\Helpers;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+use const NONCE_SALT;
 
 /**
  * Honeypot field.
@@ -163,7 +164,11 @@ class Honeypot {
 	 * @return string The current salt.
 	 */
 	private static function get_salt(): string {
-		$salt = defined( 'NONCE_SALT' ) ? NONCE_SALT : ABSPATH;
+		/*
+		 * `ABSPATH` is always a string at runtime, but `phpstan-wordpress` declares it
+		 * as `bool`, so it is normalised here to keep that union out of `sha1()`.
+		 */
+		$salt = defined( 'NONCE_SALT' ) && is_string( NONCE_SALT ) ? NONCE_SALT : (string) ABSPATH;
 
 		return substr( sha1( $salt ), 0, 10 );
 	}

--- a/src/Helpers/Sanitize.php
+++ b/src/Helpers/Sanitize.php
@@ -37,15 +37,11 @@ class Sanitize {
 	/**
 	 * Sanitize an array of strings to match ISO format.
 	 *
-	 * @param mixed $codes A list of potential ISO codes to sanitize.
+	 * @param array<array-key, string> $codes A list of potential ISO codes to sanitize.
 	 *
 	 * @return array<array-key, string> Sanitized ISO codes.
 	 */
-	public static function iso_codes( $codes ): array {
-		if ( ! is_array( $codes ) ) {
-			return [];
-		}
-
+	public static function iso_codes( array $codes ): array {
 		foreach ( $codes as $key => $code ) {
 			$code = trim( $code );
 

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -162,11 +162,20 @@ class CountrySpam extends ControllableBase implements SpamReason {
 			return 0;
 		}
 
-		if ( ! empty( $denied ) ) {
-			return in_array( $country, $denied, true ) ? 1 : 0;
+		/*
+		 * Both lists can be configured at once, so neither may short-circuit the
+		 * other: a denied country is spam, and once an allow list exists every
+		 * country outside it is spam too.
+		 */
+		if ( ! empty( $denied ) && in_array( $country, $denied, true ) ) {
+			return 1;
 		}
 
-		return in_array( $country, $allowed, true ) ? 0 : 1;
+		if ( ! empty( $allowed ) && ! in_array( $country, $allowed, true ) ) {
+			return 1;
+		}
+
+		return 0;
 	}
 
 	/**

--- a/src/Rules/LinkbackPostTitleIsBlogName.php
+++ b/src/Rules/LinkbackPostTitleIsBlogName.php
@@ -50,6 +50,11 @@ class LinkbackPostTitleIsBlogName extends Base implements SpamReason {
 	public static function verify( array $item ): int {
 		$body      = $item['body'] ?? null;
 		$blog_name = $item['author'] ?? null;
+
+		if ( ! is_string( $body ) || ! is_string( $blog_name ) ) {
+			return 0;
+		}
+
 		preg_match( '/<strong>(.*)<\/strong>\\n\\n/', $body, $matches );
 		if ( ! isset( $matches[1] ) ) {
 			return 0;

--- a/tests/Unit/Helpers/DebugModeTest.php
+++ b/tests/Unit/Helpers/DebugModeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\DebugMode;
+use ReflectionProperty;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/asb-debug-mode-test' );
+}
+
+/**
+ * Unit tests for {@see DebugMode}.
+ */
+class DebugModeTest extends TestCase {
+
+	public function test_log_writes_a_single_line_per_entry(): void {
+		self::force_debug_mode( true );
+
+		DebugMode::log( "first\nsecond\r\nthird" );
+
+		$contents = self::read_log();
+
+		self::assertCount(
+			1,
+			array_filter( explode( "\n", $contents ) ),
+			'A message containing line breaks must not become several log entries'
+		);
+		self::assertStringContainsString(
+			'first second third',
+			$contents,
+			'The line breaks should be collapsed into spaces rather than dropped'
+		);
+	}
+
+	public function test_log_writes_nothing_when_debug_mode_is_disabled(): void {
+		self::force_debug_mode( false );
+
+		DebugMode::log( 'should not be written' );
+
+		self::assertSame(
+			[],
+			self::log_files(),
+			'Nothing should be logged while debug mode is off'
+		);
+	}
+
+	/**
+	 * The file name is derived from `NONCE_SALT`, so without it there is no secret
+	 * to make the name unguessable and nothing may be written. `NONCE_SALT` cannot
+	 * be undefined once another test file has defined it, so this runs isolated.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_log_writes_nothing_without_a_secret_salt(): void {
+		if ( defined( 'NONCE_SALT' ) ) {
+			self::markTestSkipped( 'NONCE_SALT is already defined in this process.' );
+		}
+
+		self::force_debug_mode( true );
+
+		DebugMode::log( 'should not be written' );
+
+		self::assertSame(
+			[],
+			self::log_files(),
+			'Without NONCE_SALT the file name would be guessable, so nothing may be logged'
+		);
+	}
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! is_dir( WP_CONTENT_DIR ) ) {
+			mkdir( WP_CONTENT_DIR, 0777, true );
+		}
+
+		self::remove_log_files();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 *
+	 * @return void
+	 */
+	protected function tear_down() {
+		self::remove_log_files();
+		self::force_debug_mode( null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Override the cached debug mode state, which is otherwise read from a constant.
+	 *
+	 * @param bool|null $enabled Whether debug mode is enabled, or null to reset.
+	 *
+	 * @return void
+	 */
+	private static function force_debug_mode( ?bool $enabled ): void {
+		$property = new ReflectionProperty( DebugMode::class, 'debug_mode_enabled' );
+		$property->setAccessible( true );
+		$property->setValue( null, $enabled );
+	}
+
+	/**
+	 * All log files the helper may have written.
+	 *
+	 * @return string[] List of file paths.
+	 */
+	private static function log_files(): array {
+		return glob( WP_CONTENT_DIR . '/asb-debug.*.log' ) ?: [];
+	}
+
+	/**
+	 * Read the single log file that was written.
+	 *
+	 * @return string The log file contents.
+	 */
+	private static function read_log(): string {
+		$files = self::log_files();
+
+		self::assertCount( 1, $files, 'Exactly one log file should have been written' );
+
+		return (string) file_get_contents( $files[0] );
+	}
+
+	/**
+	 * Remove any log files left behind.
+	 *
+	 * @return void
+	 */
+	private static function remove_log_files(): void {
+		foreach ( self::log_files() as $file ) {
+			unlink( $file );
+		}
+	}
+}

--- a/tests/Unit/Helpers/SanitizeTest.php
+++ b/tests/Unit/Helpers/SanitizeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Sanitize;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Unit tests for {@see Sanitize}.
+ */
+class SanitizeTest extends TestCase {
+
+	public function test_iso_codes_keeps_two_letter_codes(): void {
+		self::assertSame(
+			[ 'DE', 'fr' ],
+			Sanitize::iso_codes( [ 'DE', 'fr' ] ),
+			'Two-letter codes should be kept as they are, without changing their case'
+		);
+	}
+
+	public function test_iso_codes_trims_surrounding_whitespace(): void {
+		self::assertSame(
+			[ 'DE', 'FR' ],
+			Sanitize::iso_codes( [ "  DE\t", "\nFR " ] ),
+			'Surrounding whitespace should be trimmed rather than making the code invalid'
+		);
+	}
+
+	public function test_iso_codes_drops_anything_that_is_not_a_country_code(): void {
+		self::assertSame(
+			[],
+			Sanitize::iso_codes(
+				[
+					'',
+					'D',
+					'DEU',
+					'D3',
+					'12',
+					'-)',
+				]
+			),
+			'Only two-character alphabetic codes should survive'
+		);
+	}
+
+	public function test_iso_codes_preserves_keys_of_the_codes_it_keeps(): void {
+		self::assertSame(
+			[
+				0 => 'DE',
+				2 => 'FR',
+			],
+			Sanitize::iso_codes( [ 'DE', 'nope', 'FR' ] ),
+			'Filtering should not reindex the list'
+		);
+	}
+
+	public function test_iso_codes_accepts_an_empty_list(): void {
+		self::assertSame(
+			[],
+			Sanitize::iso_codes( [] ),
+			'An empty list has nothing to sanitize'
+		);
+	}
+}

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -20,6 +20,13 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	private $denied_countries = '';
 
 	/**
+	 * The country codes the rule allows, as stored by the settings.
+	 *
+	 * @var string
+	 */
+	private $allowed_countries = '';
+
+	/**
 	 * The URL the last expected request went to.
 	 *
 	 * @var string
@@ -160,6 +167,71 @@ class CountrySpamTest extends AbstractRuleTestCase {
 		);
 	}
 
+	public function test_verify_flags_a_country_outside_the_allow_list(): void {
+		$this->expect_request( '{"country_code":"US"}' );
+		$this->denied_countries  = '';
+		$this->allowed_countries = 'FR';
+
+		self::assertSame(
+			1,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'With only an allow list, a country outside it should be flagged'
+		);
+	}
+
+	public function test_verify_does_not_flag_a_country_on_the_allow_list(): void {
+		$this->expect_request( '{"country_code":"FR"}' );
+		$this->denied_countries  = '';
+		$this->allowed_countries = 'FR';
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'With only an allow list, a country on it should not be flagged'
+		);
+	}
+
+	/**
+	 * The deny list used to return early, so with both lists configured a country
+	 * on neither list was treated as ham — even though an allow list means "only
+	 * these are ham".
+	 */
+	public function test_verify_flags_a_country_on_neither_list_when_both_are_configured(): void {
+		$this->expect_request( '{"country_code":"US"}' );
+		$this->denied_countries  = 'DE';
+		$this->allowed_countries = 'FR';
+
+		self::assertSame(
+			1,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'With both lists configured, a country outside the allow list should still be flagged'
+		);
+	}
+
+	public function test_verify_does_not_flag_an_allowed_country_when_both_lists_are_configured(): void {
+		$this->expect_request( '{"country_code":"FR"}' );
+		$this->denied_countries  = 'DE';
+		$this->allowed_countries = 'FR';
+
+		self::assertSame(
+			0,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'A country on the allow list and absent from the deny list should not be flagged'
+		);
+	}
+
+	public function test_verify_flags_a_denied_country_when_both_lists_are_configured(): void {
+		$this->expect_request( '{"country_code":"DE"}' );
+		$this->denied_countries  = 'DE';
+		$this->allowed_countries = 'FR';
+
+		self::assertSame(
+			1,
+			CountrySpam::verify( self::make_comment_from( '198.51.100.42' ) ),
+			'The deny list should still apply when an allow list is configured'
+		);
+	}
+
 	/**
 	 * Without a key, the service answers anonymous lookups, but rejects an empty
 	 * `apikey` parameter with `401 Invalid API key`.
@@ -221,7 +293,8 @@ class CountrySpamTest extends AbstractRuleTestCase {
 		// Keep the plugin update logic, which the settings run into, from touching the database.
 		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0' ] );
 
-		$this->denied_countries = 'DE';
+		$this->denied_countries  = 'DE';
+		$this->allowed_countries = '';
 
 		when( 'get_option' )->alias(
 			function ( string $option ) {
@@ -231,7 +304,8 @@ class CountrySpamTest extends AbstractRuleTestCase {
 
 				return [
 					'comment' => [
-						'rule_asb_country_spam_denied' => $this->denied_countries,
+						'rule_asb_country_spam_denied'  => $this->denied_countries,
+						'rule_asb_country_spam_allowed' => $this->allowed_countries,
 					],
 				];
 			}

--- a/tests/Unit/Rules/LinkbackPostTitleIsBlogNameTest.php
+++ b/tests/Unit/Rules/LinkbackPostTitleIsBlogNameTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Rules;
+
+use AntispamBee\Rules\LinkbackPostTitleIsBlogName;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Unit tests for {@see LinkbackPostTitleIsBlogName}.
+ */
+class LinkbackPostTitleIsBlogNameTest extends TestCase {
+
+	public function test_verify_flags_a_linkback_whose_title_is_the_blog_name(): void {
+		self::assertSame(
+			999,
+			LinkbackPostTitleIsBlogName::verify(
+				[
+					'body'   => "text <strong>My Blog</strong>\n\nmore text",
+					'author' => 'My Blog',
+				]
+			),
+			'A linkback whose linked post title equals the blog name should be flagged'
+		);
+	}
+
+	public function test_verify_ignores_surrounding_whitespace_when_comparing(): void {
+		self::assertSame(
+			999,
+			LinkbackPostTitleIsBlogName::verify(
+				[
+					'body'   => "<strong>  My Blog </strong>\n\n",
+					'author' => ' My Blog  ',
+				]
+			),
+			'The comparison should not be defeated by surrounding whitespace'
+		);
+	}
+
+	public function test_verify_does_not_flag_a_different_title(): void {
+		self::assertSame(
+			0,
+			LinkbackPostTitleIsBlogName::verify(
+				[
+					'body'   => "<strong>Some Post</strong>\n\n",
+					'author' => 'My Blog',
+				]
+			),
+			'A linkback to a post with another title should not be flagged'
+		);
+	}
+
+	public function test_verify_does_not_flag_a_body_without_a_title(): void {
+		self::assertSame(
+			0,
+			LinkbackPostTitleIsBlogName::verify(
+				[
+					'body'   => 'no markup here',
+					'author' => 'My Blog',
+				]
+			),
+			'Without a title in the body there is nothing to compare'
+		);
+	}
+
+	/**
+	 * The payload is not guaranteed to carry either attribute. Both used to be
+	 * read with a `null` fallback and passed straight to `preg_match()` and
+	 * `trim()`, which is deprecated for `null` on PHP 8.1+.
+	 */
+	public function test_verify_handles_a_missing_body_or_author(): void {
+		$payloads = [
+			'both missing'   => [],
+			'missing body'   => [ 'author' => 'My Blog' ],
+			'missing author' => [ 'body' => "<strong>My Blog</strong>\n\n" ],
+			'null body'      => [
+				'body'   => null,
+				'author' => 'My Blog',
+			],
+			'null author'    => [
+				'body'   => "<strong>My Blog</strong>\n\n",
+				'author' => null,
+			],
+		];
+
+		foreach ( $payloads as $description => $payload ) {
+			self::assertSame(
+				0,
+				LinkbackPostTitleIsBlogName::verify( $payload ),
+				"A payload with $description should not be flagged and must not raise a deprecation"
+			);
+		}
+	}
+}


### PR DESCRIPTION
Resolves the remaining findings from #822, one commit each, with tests.

Together with #823 and #824 this closes every finding from that review.

## Findings fixed

| Commit | Finding |
| --- | --- |
| `589a9d7` | `Sanitize::iso_codes()` raised a `TypeError` on a non-string element |
| `1f66bf0` | `LinkbackPostTitleIsBlogName` passed `null` to `preg_match()` / `trim()` (PHP 8.1+ deprecations) |
| `4f81ce4` | `DebugMode::log()` let a line break in the message forge extra log entries |
| `04116d9` | `DebugMode` fell back to `ABSPATH`, making a web-served log of comment data and IPs discoverable |
| `11da726` | `CountrySpam` silently ignored a configured allow list when a deny list also existed |
| `5b1dc35` | `spelling.yml` declared no `permissions:` |

## Decisions worth reviewing

**`DebugMode` now fails closed.** Without `NONCE_SALT` there is no secret to derive a non-guessable filename from, so `log()` returns without writing instead of producing a predictably named file of comment data. On an installation lacking `NONCE_SALT`, debug logging goes *silently* quiet. `NONCE_SALT` is defined on every normal installation, and losing debug output is preferable to publishing comment data.

**`CountrySpam` precedence.** Neither list short-circuits the other now: a denied country is spam, and once an allow list exists every country outside it is spam too. Single-list behaviour is unchanged, and the case where neither list is configured is still handled by the existing early return.

**`Sanitize::iso_codes()` tightens its contract instead of adding a guard.** The reported `TypeError` is unreachable — the only caller passes `explode()` output, always a list of strings. Rather than check for a case that cannot occur, the parameter is now a real `array` documented as `array<array-key, string>`, which PHPStan enforces at level 8. This drops the existing `is_array()` guard too, so an external caller passing a non-array now gets a `TypeError` at the boundary rather than a silent empty array.

**`NONCE_SALT` is imported with `use const`** in `DebugMode` and `Honeypot`. This needs a declaration in `phpstan-bootstrap.php`, because `NONCE_SALT` comes from `wp-config.php` and is not declared by `phpstan-wordpress`. Declaring it exposed a pre-existing error in `Honeypot::get_salt()`: `phpstan-wordpress` types `ABSPATH` as `bool` rather than `string`, so `defined( 'NONCE_SALT' ) ? NONCE_SALT : ABSPATH` is `bool|string`. Level 8 does not report `mixed`, so while `NONCE_SALT` was an unknown constant the union stayed invisible. `get_salt()` now requires `NONCE_SALT` to be a string and normalises `ABSPATH`; behaviour is unchanged.

## Known follow-up, deliberately not in this PR

`Honeypot::get_salt()` still falls back to `ABSPATH` — the same predictable-fallback weakness fixed here for `DebugMode`. It is **not** fixed the same way on purpose:

- For `DebugMode` the fallback *discloses data*, and refusing to log prevents that at the cost of debug output.
- For `Honeypot` the salt derives the honeypot field names. A predictable salt lets a bot compute the field name and dodge the trap, but refusing to produce a salt renders no honeypot field at all — equally ineffective, and nothing is disclosed either way. Failing closed would buy no security and break the feature.

The right fix is `wp_salt()`, which WordPress generates and persists when the constants are missing. That changes the generated field names, so cached pages and in-flight comment forms would carry stale names — a behaviour change in the anti-spam path that deserves its own change and tests.

Worth noting the scanner never flagged this; PHPStan surfaced it once `NONCE_SALT` resolved to a concrete type.

## Tests

`118 tests, 242 assertions` — up from 100 on `v3`. PHPStan level 8 clean, `phpcs` clean.

New coverage for four previously untested units:

- `DebugModeTest` — line-break collapsing, and that nothing is written without a secret salt. `NONCE_SALT` cannot be undefined once another test file has defined it, so that case runs in a separate process with global state disabled.
- `CountrySpamTest` — five cases for the allow list, alone and alongside a deny list.
- `SanitizeTest` — trimming, two-character alphabetic codes only, key preservation, and that case is left alone (the caller uppercases).
- `LinkbackPostTitleIsBlogNameTest` — the payloads that previously reached `preg_match()` and `trim()` as `null`.

Each regression test was verified to fail against the unfixed code, not just to pass against the fix.
