### PR TITLE
fix: derive the honeypot and debug log salt from `wp_salt()`

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -18,8 +18,3 @@ define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-alpha.15' );
 // PHPStan uses the declared type instead of narrowing to these literal values.
 define( 'ANTISPAM_BEE_DEBUG_MODE_ENABLED', false );
 define( 'ANTISPAM_BEE_LOG_FILE', 'asb.log' );
-// Defined in `wp-config.php`. Unlike the directory constants, it is not declared by
-// `phpstan-wordpress`, so an explicit `use const` import would not resolve during
-// analysis without this.
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- A WordPress core constant, stubbed for analysis only; this file is never shipped.
-define( 'NONCE_SALT', 'phpstan-nonce-salt' );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,5 +11,4 @@ parameters:
   dynamicConstantNames:
     - ANTISPAM_BEE_DEBUG_MODE_ENABLED
     - ANTISPAM_BEE_LOG_FILE
-    - NONCE_SALT
   treatPhpDocTypesAsCertain: false

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -8,7 +8,6 @@
 namespace AntispamBee\Helpers;
 
 use const ANTISPAM_BEE_DEBUG_MODE_ENABLED;
-use const NONCE_SALT;
 use const WP_CONTENT_DIR;
 
 /**
@@ -57,19 +56,21 @@ class DebugMode {
 	 * The log contains comment data and `WP_CONTENT_DIR` is usually served
 	 * publicly, so the file name must not be guessable.
 	 *
-	 * This requires a secret salt. `NONCE_SALT` is defined on every normal
-	 * installation; when it is missing there is no secret to derive from, so
-	 * this returns `null` and logging is skipped rather than falling back to a
-	 * predictable value such as `ABSPATH`.
+	 * `wp_salt()` prefers the `NONCE_*` constants from `wp-config.php` and
+	 * otherwise generates random values and stores them, so a secret is normally
+	 * always available. Should it ever yield nothing, this returns `null` and
+	 * logging is skipped rather than falling back to a predictable value.
 	 *
 	 * @return string|null Suffix, or null if no secret salt is available.
 	 */
 	private static function get_log_file_suffix(): ?string {
-		if ( ! defined( 'NONCE_SALT' ) || ! is_string( NONCE_SALT ) || '' === NONCE_SALT ) {
+		$salt = wp_salt( 'nonce' );
+
+		if ( '' === $salt ) {
 			return null;
 		}
 
-		return substr( sha1( 'asb-debug' . NONCE_SALT ), 0, 12 );
+		return substr( sha1( 'asb-debug' . $salt ), 0, 12 );
 	}
 
 	/**

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -10,7 +10,6 @@ namespace AntispamBee\Helpers;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
-use const NONCE_SALT;
 
 /**
  * Honeypot field.
@@ -161,16 +160,15 @@ class Honeypot {
 	/**
 	 * Get the current salt.
 	 *
+	 * The honeypot field names are derived from this, so it must not be
+	 * predictable. `wp_salt()` prefers the `NONCE_*` constants from
+	 * `wp-config.php` and otherwise generates random values and stores them, so
+	 * there is always a secret to derive from.
+	 *
 	 * @return string The current salt.
 	 */
 	private static function get_salt(): string {
-		/*
-		 * `ABSPATH` is always a string at runtime, but `phpstan-wordpress` declares it
-		 * as `bool`, so it is normalised here to keep that union out of `sha1()`.
-		 */
-		$salt = defined( 'NONCE_SALT' ) && is_string( NONCE_SALT ) ? NONCE_SALT : (string) ABSPATH;
-
-		return substr( sha1( $salt ), 0, 10 );
+		return substr( sha1( wp_salt( 'nonce' ) ), 0, 10 );
 	}
 
 	/**

--- a/tests/Unit/Helpers/DebugModeTest.php
+++ b/tests/Unit/Helpers/DebugModeTest.php
@@ -5,6 +5,7 @@ namespace AntispamBee\Tests\Unit\Helpers;
 use AntispamBee\Helpers\DebugMode;
 use ReflectionProperty;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\when;
 
 if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/asb-debug-mode-test' );
@@ -14,6 +15,13 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
  * Unit tests for {@see DebugMode}.
  */
 class DebugModeTest extends TestCase {
+
+	/**
+	 * The salt `wp_salt()` returns.
+	 *
+	 * @var string
+	 */
+	private $salt = 'test-salt';
 
 	public function test_log_writes_a_single_line_per_entry(): void {
 		self::force_debug_mode( true );
@@ -30,7 +38,7 @@ class DebugModeTest extends TestCase {
 		self::assertStringContainsString(
 			'first second third',
 			$contents,
-			'The line breaks should be collapsed into spaces rather than dropped'
+			'Runs of line breaks should be collapsed into a single space'
 		);
 	}
 
@@ -47,18 +55,13 @@ class DebugModeTest extends TestCase {
 	}
 
 	/**
-	 * The file name is derived from `NONCE_SALT`, so without it there is no secret
-	 * to make the name unguessable and nothing may be written. `NONCE_SALT` cannot
-	 * be undefined once another test file has defined it, so this runs isolated.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * The file name is derived from the salt, so without one there is nothing to
+	 * make the name unguessable and nothing may be written. `wp_salt()` normally
+	 * always returns a secret, so this is a safety net rather than a case that is
+	 * expected to occur.
 	 */
 	public function test_log_writes_nothing_without_a_secret_salt(): void {
-		if ( defined( 'NONCE_SALT' ) ) {
-			self::markTestSkipped( 'NONCE_SALT is already defined in this process.' );
-		}
-
+		$this->salt = '';
 		self::force_debug_mode( true );
 
 		DebugMode::log( 'should not be written' );
@@ -66,7 +69,26 @@ class DebugModeTest extends TestCase {
 		self::assertSame(
 			[],
 			self::log_files(),
-			'Without NONCE_SALT the file name would be guessable, so nothing may be logged'
+			'Without a salt the file name would be guessable, so nothing may be logged'
+		);
+	}
+
+	public function test_log_file_name_is_derived_from_the_salt(): void {
+		self::force_debug_mode( true );
+
+		DebugMode::log( 'first entry' );
+		$first = self::log_files();
+
+		self::remove_log_files();
+		$this->salt = 'another-salt';
+
+		DebugMode::log( 'second entry' );
+		$second = self::log_files();
+
+		self::assertNotSame(
+			$first,
+			$second,
+			'A different salt must produce a different, unguessable file name'
 		);
 	}
 
@@ -77,6 +99,12 @@ class DebugModeTest extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+
+		when( 'wp_salt' )->alias(
+			function () {
+				return $this->salt;
+			}
+		);
 
 		if ( ! is_dir( WP_CONTENT_DIR ) ) {
 			mkdir( WP_CONTENT_DIR, 0777, true );

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -6,10 +6,6 @@ use AntispamBee\Helpers\Honeypot;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use function Brain\Monkey\Functions\when;
 
-if ( ! defined( 'NONCE_SALT' ) ) {
-	define( 'NONCE_SALT', 'test-nonce-salt' );
-}
-
 /**
  * Unit tests for {@see Honeypot} (helper).
  */
@@ -84,5 +80,6 @@ class HoneypotHelperTest extends TestCase {
 		parent::set_up();
 		when( 'esc_attr' )->returnArg();
 		when( 'esc_js' )->returnArg();
+		when( 'wp_salt' )->justReturn( 'test-salt' );
 	}
 }


### PR DESCRIPTION
Stacked on #825 — review that one first.

`Helpers\Honeypot::get_salt()` fell back to `ABSPATH` when `NONCE_SALT` was undefined. The honeypot field names are derived from that salt, so a predictable value lets a bot compute the field name and skip the trap. This is the same weakness #825 fixes for `Helpers\DebugMode`, and it was called out there as deliberately deferred.

Failing closed is not the remedy here: rendering no honeypot field is as ineffective as rendering a predictable one, and nothing is disclosed either way. `wp_salt()` is, so both helpers now use it.

## Why `wp_salt()`

It prefers the `NONCE_*` constants and otherwise generates a random 64-character value and stores it with `update_site_option()`, so a secret is always available without either helper reaching for a public value.

It also handles a case neither helper did: it reads `NONCE_KEY` / `NONCE_SALT` only when they are truthy **and not duplicated**, with `$duplicated_keys` seeded with `'put your unique phrase here'`. A site still carrying the sample placeholder — or reusing one string across several of the eight key/salt constants — is treated as having no salt and gets a stored random value instead. Reading `NONCE_SALT` directly leaves such a site with a permanently predictable honeypot.

## Simplification

Using the core API removes most of the surrounding code that #825 added:

- the `use const NONCE_SALT` imports in both helpers, now unreferenced
- the `phpstan-bootstrap.php` declaration and `dynamicConstantNames` entry that existed only so those imports would resolve
- the `ABSPATH` normalisation in `get_salt()`, which was only needed because `phpstan-wordpress` types `ABSPATH` as `bool`
- the `@runInSeparateProcess` annotation in `DebugModeTest`, since `wp_salt()` can simply be stubbed empty where `NONCE_SALT` could not be undefined

`DebugMode` keeps returning `null` for an empty salt as a safety net. Verified still load-bearing: removing that guard fails the test.

## Behaviour change to be aware of

The derived values change. The debug log file name is harmless — a new file is created and old ones are left alone. **The honeypot field names change too.**

The reason is not that the constant is ignored. `wp_salt( 'nonce' )` returns `NONCE_KEY . NONCE_SALT` concatenated (`wp-includes/pluggable.php`, `$cached_salts[ $scheme ] = $values['key'] . $values['salt'];`), where the helpers previously hashed `NONCE_SALT` alone. Same inputs, longer string, different hash.

A page cached with the previous field names will submit names the current salt does not produce, which the honeypot and invalid-request rules can read as a malformed submission until the cache is cleared. The same already happens whenever a site's salts are rotated or a site is migrated, but here it happens once on upgrade for every site, so it likely deserves a changelog note.

## Alternative considered

Preferring the constant and using `wp_salt()` only as a fallback would avoid that entirely:

```php
$salt = defined( 'NONCE_SALT' ) && is_string( NONCE_SALT ) && '' !== NONCE_SALT
    ? NONCE_SALT
    : wp_salt( 'nonce' );
```

Field names would stay identical for the overwhelming majority of sites, so there would be no cached-form window at all.

It was not taken because it keeps two drawbacks: a site whose `NONCE_SALT` is the sample placeholder would retain a predictable honeypot permanently, and it would require the `use const` import and the PHPStan bootstrap declaration to come back. A one-time transient was judged preferable to a permanent hole plus the extra machinery — but the trade-off is real, and this is easy to switch to if the cache window is considered the greater risk.

## Tests

`119 tests, 243 assertions`. PHPStan level 8 clean, `phpcs` clean.

- `DebugModeTest` drops the process-isolated case in favour of stubbing `wp_salt()` empty, and gains one asserting the file name follows the salt.
- `HoneypotHelperTest` stubs `wp_salt()` instead of defining `NONCE_SALT`.
