### PR TITLE
feat: store the honeypot salt and reject placeholder salts

### DIFF
--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -9,6 +9,7 @@ namespace AntispamBee\Handlers;
 
 use AntispamBee\Crons\DeleteSpamCron;
 use AntispamBee\GeneralOptions\Uninstall;
+use AntispamBee\Helpers\Honeypot;
 use AntispamBee\Helpers\Settings;
 
 /**
@@ -81,6 +82,7 @@ class PluginStateChangeHandler {
 
 		delete_option( Settings::OPTION_NAME );
 		delete_option( 'antispambee_db_version' );
+		delete_option( Honeypot::SALT_OPTION );
 		// delete_option( 'antispam_bee' );
 		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 

--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -58,15 +58,19 @@ class DebugMode {
 	 *
 	 * `wp_salt()` prefers the `NONCE_*` constants from `wp-config.php` and
 	 * otherwise generates random values and stores them, so a secret is normally
-	 * always available. Should it ever yield nothing, this returns `null` and
-	 * logging is skipped rather than falling back to a predictable value.
+	 * always available. It cannot be trusted blindly, though: it recognises only
+	 * the English placeholder from `wp-config-sample.php`, so on a localised
+	 * install that was never configured it returns the translated placeholder as
+	 * if it were a secret. The result is checked with {@see Salt::is_generated()}
+	 * for that reason, and logging is skipped rather than writing to a file whose
+	 * name could be derived by anyone.
 	 *
 	 * @return string|null Suffix, or null if no secret salt is available.
 	 */
 	private static function get_log_file_suffix(): ?string {
 		$salt = wp_salt( 'nonce' );
 
-		if ( '' === $salt ) {
+		if ( ! Salt::is_generated( $salt ) ) {
 			return null;
 		}
 

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -16,6 +16,20 @@ use DOMXPath;
  */
 class Honeypot {
 	/**
+	 * Option that holds the salt the field names are derived from.
+	 *
+	 * @var string
+	 */
+	public const SALT_OPTION = 'antispam_bee_honeypot_salt';
+
+	/**
+	 * Shortest configured salt still treated as generated.
+	 *
+	 * @var int
+	 */
+	private const MIN_SALT_LENGTH = 32;
+
+	/**
 	 * Inject the honeypot field.
 	 *
 	 * @param string                $markup  The field markup.
@@ -160,15 +174,102 @@ class Honeypot {
 	/**
 	 * Get the current salt.
 	 *
-	 * The honeypot field names are derived from this, so it must not be
-	 * predictable. `wp_salt()` prefers the `NONCE_*` constants from
-	 * `wp-config.php` and otherwise generates random values and stores them, so
-	 * there is always a secret to derive from.
+	 * The honeypot field names are derived from this, and they are rendered into
+	 * the comment form. A page cache serving a form whose field name no longer
+	 * matches makes the plugin treat a genuine comment as an invalid request, so
+	 * the salt is stored rather than derived on every call: deriving it from the
+	 * `wp-config.php` salts would change every field name whenever those are
+	 * rotated or the site is migrated.
 	 *
 	 * @return string The current salt.
 	 */
 	private static function get_salt(): string {
-		return substr( sha1( wp_salt( 'nonce' ) ), 0, 10 );
+		$salt = get_option( self::SALT_OPTION );
+
+		if ( ! is_string( $salt ) || '' === $salt ) {
+			$salt = self::store_salt();
+		}
+
+		/**
+		 * Filters the salt the honeypot field names are derived from.
+		 *
+		 * The stored salt never changes on its own, which is what keeps cached
+		 * comment forms valid. Filtering it rotates every field name, so a form
+		 * already sitting in a page cache stops matching until that cache is
+		 * cleared.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $salt The stored salt.
+		 */
+		return (string) apply_filters( 'antispam_bee_honeypot_salt', $salt );
+	}
+
+	/**
+	 * Create and store the salt.
+	 *
+	 * @return string The stored salt.
+	 */
+	private static function store_salt(): string {
+		$salt = self::initial_salt();
+
+		// A concurrent request may have stored one first; that one wins.
+		if ( ! add_option( self::SALT_OPTION, $salt ) ) {
+			$stored = get_option( self::SALT_OPTION );
+
+			if ( is_string( $stored ) && '' !== $stored ) {
+				return $stored;
+			}
+		}
+
+		return $salt;
+	}
+
+	/**
+	 * The value to seed the stored salt with.
+	 *
+	 * Seeding from `NONCE_SALT` reproduces the field names a site is already
+	 * serving, so storing the salt does not invalidate forms that are already in
+	 * a page cache. A configured salt is only used when it looks generated; a
+	 * random value is generated otherwise, which is the case where the previous
+	 * derivation was predictable.
+	 *
+	 * @return string The initial salt.
+	 */
+	private static function initial_salt(): string {
+		if ( defined( 'NONCE_SALT' ) && is_string( \NONCE_SALT ) && self::is_generated_salt( \NONCE_SALT ) ) {
+			return substr( sha1( \NONCE_SALT ), 0, 10 );
+		}
+
+		return substr( sha1( wp_generate_password( 64, true, true ) ), 0, 10 );
+	}
+
+	/**
+	 * Whether a configured salt looks like a generated one.
+	 *
+	 * The placeholders `wp-config-sample.php` ships are natural-language phrases,
+	 * and localised WordPress packages translate them, so comparing against the
+	 * English `put your unique phrase here` would miss a German or French install
+	 * that was never configured. Core's own `wp_salt()` has that same blind spot:
+	 * it seeds its list of non-secrets with the English phrase only, so it hashes
+	 * a translated placeholder as if it were a secret.
+	 *
+	 * Generated salts — both the ones api.wordpress.org hands out and the ones
+	 * `wp_generate_password( 64, true, true )` produces — are 64 characters of
+	 * printable ASCII containing no whitespace. Requiring some length and
+	 * rejecting whitespace therefore recognises a real salt whatever the locale,
+	 * and rejects a placeholder phrase in any language.
+	 *
+	 * A hand-written passphrase is rejected too. That is deliberate: such a value
+	 * is not guessable, but replacing it with a generated one is no worse, and the
+	 * check only runs once, when the salt is first stored.
+	 *
+	 * @param string $salt The configured salt.
+	 *
+	 * @return bool Whether the salt looks generated.
+	 */
+	private static function is_generated_salt( string $salt ): bool {
+		return strlen( $salt ) >= self::MIN_SALT_LENGTH && ! preg_match( '/\s/', $salt );
 	}
 
 	/**

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -23,13 +23,6 @@ class Honeypot {
 	public const SALT_OPTION = 'antispam_bee_honeypot_salt';
 
 	/**
-	 * Shortest configured salt still treated as generated.
-	 *
-	 * @var int
-	 */
-	private const MIN_SALT_LENGTH = 32;
-
-	/**
 	 * Inject the honeypot field.
 	 *
 	 * @param string                $markup  The field markup.
@@ -237,40 +230,13 @@ class Honeypot {
 	 * @return string The initial salt.
 	 */
 	private static function initial_salt(): string {
-		if ( defined( 'NONCE_SALT' ) && is_string( \NONCE_SALT ) && self::is_generated_salt( \NONCE_SALT ) ) {
+		if ( defined( 'NONCE_SALT' ) && is_string( \NONCE_SALT ) && Salt::is_generated( \NONCE_SALT ) ) {
 			return substr( sha1( \NONCE_SALT ), 0, 10 );
 		}
 
-		return substr( sha1( wp_generate_password( 64, true, true ) ), 0, 10 );
+		return substr( sha1( Salt::generate() ), 0, 10 );
 	}
 
-	/**
-	 * Whether a configured salt looks like a generated one.
-	 *
-	 * The placeholders `wp-config-sample.php` ships are natural-language phrases,
-	 * and localised WordPress packages translate them, so comparing against the
-	 * English `put your unique phrase here` would miss a German or French install
-	 * that was never configured. Core's own `wp_salt()` has that same blind spot:
-	 * it seeds its list of non-secrets with the English phrase only, so it hashes
-	 * a translated placeholder as if it were a secret.
-	 *
-	 * Generated salts — both the ones api.wordpress.org hands out and the ones
-	 * `wp_generate_password( 64, true, true )` produces — are 64 characters of
-	 * printable ASCII containing no whitespace. Requiring some length and
-	 * rejecting whitespace therefore recognises a real salt whatever the locale,
-	 * and rejects a placeholder phrase in any language.
-	 *
-	 * A hand-written passphrase is rejected too. That is deliberate: such a value
-	 * is not guessable, but replacing it with a generated one is no worse, and the
-	 * check only runs once, when the salt is first stored.
-	 *
-	 * @param string $salt The configured salt.
-	 *
-	 * @return bool Whether the salt looks generated.
-	 */
-	private static function is_generated_salt( string $salt ): bool {
-		return strlen( $salt ) >= self::MIN_SALT_LENGTH && ! preg_match( '/\s/', $salt );
-	}
 
 	/**
 	 * Ensure that the secret starts with a letter.

--- a/src/Helpers/Salt.php
+++ b/src/Helpers/Salt.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Salt helper.
+ *
+ * @package AntispamBee\Helpers
+ */
+
+namespace AntispamBee\Helpers;
+
+/**
+ * Recognise and generate the secrets the plugin derives identifiers from.
+ */
+class Salt {
+	/**
+	 * Shortest configured salt still treated as generated.
+	 *
+	 * @var int
+	 */
+	private const MIN_LENGTH = 32;
+
+	/**
+	 * Whether a configured salt looks like a generated one.
+	 *
+	 * The placeholders `wp-config-sample.php` ships are natural-language phrases,
+	 * and localised WordPress packages translate them, so comparing against the
+	 * English `put your unique phrase here` would miss a German or French install
+	 * that was never configured. Core's own `wp_salt()` has that same blind spot:
+	 * it seeds its list of non-secrets with the English phrase only, so it hashes
+	 * a translated placeholder as if it were a secret.
+	 *
+	 * Generated salts — both the ones api.wordpress.org hands out and the ones
+	 * {@see self::generate()} produces — are printable ASCII containing no
+	 * whitespace. Requiring some length and rejecting whitespace therefore
+	 * recognises a real salt whatever the locale, and rejects a placeholder
+	 * phrase in any language.
+	 *
+	 * A hand-written passphrase is rejected too. That is deliberate: such a value
+	 * is not guessable, but a generated one is no worse.
+	 *
+	 * @param string $salt The configured salt.
+	 *
+	 * @return bool Whether the salt looks generated.
+	 */
+	public static function is_generated( string $salt ): bool {
+		return strlen( $salt ) >= self::MIN_LENGTH && ! preg_match( '/\s/', $salt );
+	}
+
+	/**
+	 * Generate a salt.
+	 *
+	 * @return string The generated salt.
+	 */
+	public static function generate(): string {
+		return wp_generate_password( 64, true, true );
+	}
+}

--- a/tests/Unit/Helpers/DebugModeTest.php
+++ b/tests/Unit/Helpers/DebugModeTest.php
@@ -17,11 +17,11 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 class DebugModeTest extends TestCase {
 
 	/**
-	 * The salt `wp_salt()` returns.
+	 * The salt `wp_salt()` returns. Shaped like a real one: long, no whitespace.
 	 *
 	 * @var string
 	 */
-	private $salt = 'test-salt';
+	private $salt = 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B';
 
 	public function test_log_writes_a_single_line_per_entry(): void {
 		self::force_debug_mode( true );
@@ -56,9 +56,7 @@ class DebugModeTest extends TestCase {
 
 	/**
 	 * The file name is derived from the salt, so without one there is nothing to
-	 * make the name unguessable and nothing may be written. `wp_salt()` normally
-	 * always returns a secret, so this is a safety net rather than a case that is
-	 * expected to occur.
+	 * make the name unguessable and nothing may be written.
 	 */
 	public function test_log_writes_nothing_without_a_secret_salt(): void {
 		$this->salt = '';
@@ -73,6 +71,25 @@ class DebugModeTest extends TestCase {
 		);
 	}
 
+	/**
+	 * `wp_salt()` recognises only the English placeholder from
+	 * `wp-config-sample.php`, so on a localised install that was never configured
+	 * it hands back the translated placeholder as though it were a secret. The
+	 * log holds comment data and IP addresses, so that must not name a file.
+	 */
+	public function test_log_writes_nothing_when_the_salt_is_a_placeholder(): void {
+		$this->salt = 'füge hier deine einmalig genutzte Zeichenfolge ein'; // spellchecker:disable-line
+		self::force_debug_mode( true );
+
+		DebugMode::log( 'should not be written' );
+
+		self::assertSame(
+			[],
+			self::log_files(),
+			'A placeholder phrase is not a secret, so the log file name must not be derived from it'
+		);
+	}
+
 	public function test_log_file_name_is_derived_from_the_salt(): void {
 		self::force_debug_mode( true );
 
@@ -80,7 +97,7 @@ class DebugModeTest extends TestCase {
 		$first = self::log_files();
 
 		self::remove_log_files();
-		$this->salt = 'another-salt';
+		$this->salt = 'B3mX8qZ6jP4oI9uV2eC+7aS-0dF1gJ)5hY*3wT&6bM^8nR%4pL$7zV#2qK!9x';
 
 		DebugMode::log( 'second entry' );
 		$second = self::log_files();

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -4,12 +4,80 @@ namespace AntispamBee\Tests\Unit\Helpers;
 
 use AntispamBee\Helpers\Honeypot;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
+
+if ( ! defined( 'NONCE_SALT' ) ) {
+	// Shaped like a real salt: 64 characters of printable ASCII, no whitespace.
+	define( 'NONCE_SALT', 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B' );
+}
 
 /**
  * Unit tests for {@see Honeypot} (helper).
  */
 class HoneypotHelperTest extends TestCase {
+
+	/**
+	 * The salt the stored option holds.
+	 *
+	 * @var string
+	 */
+	private $stored_salt = 'stored-test-salt';
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_field_names_are_derived_from_the_stored_salt(): void {
+		$this->stored_salt = 'a-stored-salt';
+
+		self::assertSame(
+			Honeypot::ensure_secret_starts_with_letter(
+				substr( sha1( md5( 'comment-id' . 'a-stored-salt' ) ), 0, 10 )
+			),
+			Honeypot::get_secret_name_for_post(),
+			'The field name should be derived from the stored salt'
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_field_names_are_stable_while_the_stored_salt_is(): void {
+		self::assertSame(
+			Honeypot::get_secret_name_for_post(),
+			Honeypot::get_secret_name_for_post(),
+			'The same stored salt must always produce the same field name'
+		);
+	}
+
+	/**
+	 * Storing the salt must not invalidate comment forms that are already sitting
+	 * in a page cache, so the stored value is seeded with the one the previous
+	 * derivation produced.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_the_salt_is_seeded_from_nonce_salt(): void {
+		$this->stored_salt = '';
+		$legacy            = substr( sha1( NONCE_SALT ), 0, 10 );
+
+		expect( 'add_option' )
+			->once()
+			->with( Honeypot::SALT_OPTION, $legacy )
+			->andReturn( true );
+
+		self::assertSame(
+			Honeypot::ensure_secret_starts_with_letter(
+				substr( sha1( md5( 'comment-id' . $legacy ) ), 0, 10 )
+			),
+			Honeypot::get_secret_name_for_post(),
+			'The field name should be unchanged from what the previous derivation produced'
+		);
+	}
+
 
 	/**
 	 * @runInSeparateProcess
@@ -81,5 +149,10 @@ class HoneypotHelperTest extends TestCase {
 		when( 'esc_attr' )->returnArg();
 		when( 'esc_js' )->returnArg();
 		when( 'wp_salt' )->justReturn( 'test-salt' );
+		when( 'get_option' )->alias(
+			function () {
+				return $this->stored_salt;
+			}
+		);
 	}
 }

--- a/tests/Unit/Helpers/HoneypotSaltFallbackTest.php
+++ b/tests/Unit/Helpers/HoneypotSaltFallbackTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Honeypot;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Covers seeding the honeypot salt when `NONCE_SALT` cannot be used.
+ *
+ * This file deliberately does not define `NONCE_SALT`, and the test runs in its
+ * own process so the definition another test file makes does not leak into it.
+ *
+ * {@see HoneypotSaltPlaceholderTest} covers the other way into this branch, a
+ * `NONCE_SALT` that is set but does not look generated. The two cases need
+ * separate files because they differ only in the value of a constant.
+ */
+class HoneypotSaltFallbackTest extends TestCase {
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_the_salt_is_generated_when_nonce_salt_is_unavailable(): void {
+		if ( defined( 'NONCE_SALT' ) ) {
+			self::markTestSkipped( 'NONCE_SALT is already defined in this process.' );
+		}
+
+		$expected_salt = substr( sha1( 'generated-salt' ), 0, 10 );
+
+		when( 'get_option' )->justReturn( '' );
+		when( 'wp_generate_password' )->justReturn( 'generated-salt' );
+
+		expect( 'add_option' )
+			->once()
+			->with( Honeypot::SALT_OPTION, $expected_salt )
+			->andReturn( true );
+
+		self::assertSame(
+			Honeypot::ensure_secret_starts_with_letter(
+				substr( sha1( md5( 'comment-id' . $expected_salt ) ), 0, 10 )
+			),
+			Honeypot::get_secret_name_for_post(),
+			'Without a usable NONCE_SALT the stored salt should come from wp_salt()'
+		);
+	}
+}

--- a/tests/Unit/Helpers/HoneypotSaltPlaceholderTest.php
+++ b/tests/Unit/Helpers/HoneypotSaltPlaceholderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Honeypot;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Covers a `NONCE_SALT` that is configured but is not a secret.
+ *
+ * The placeholder in `wp-config-sample.php` is translated in localised
+ * WordPress packages, so the value on an unconfigured German install is neither
+ * the English `put your unique phrase here` nor anything else that can be
+ * enumerated. It is recognised by shape instead: a natural-language phrase
+ * contains whitespace, where a generated salt never does.
+ *
+ * The constant is defined here rather than varied per test, so this needs its
+ * own file and its own process.
+ */
+class HoneypotSaltPlaceholderTest extends TestCase {
+
+	/**
+	 * A translated placeholder, as a localised package ships it.
+	 *
+	 * @var string
+	 */
+	private const TRANSLATED_PLACEHOLDER = 'Füge hier Deine einzigartige Phrase ein';
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_a_translated_placeholder_is_not_used_as_a_salt(): void {
+		if ( defined( 'NONCE_SALT' ) ) {
+			self::markTestSkipped( 'NONCE_SALT is already defined in this process.' );
+		}
+
+		define( 'NONCE_SALT', self::TRANSLATED_PLACEHOLDER );
+
+		self::assertGreaterThan(
+			32,
+			strlen( self::TRANSLATED_PLACEHOLDER ),
+			'The placeholder must be long enough that length alone would accept it, so the test proves whitespace is what rejects it'
+		);
+
+		$expected_salt = substr( sha1( 'generated-salt' ), 0, 10 );
+
+		when( 'get_option' )->justReturn( '' );
+		when( 'wp_generate_password' )->justReturn( 'generated-salt' );
+
+		expect( 'add_option' )
+			->once()
+			->with( Honeypot::SALT_OPTION, $expected_salt )
+			->andReturn( true );
+
+		self::assertSame(
+			Honeypot::ensure_secret_starts_with_letter(
+				substr( sha1( md5( 'comment-id' . $expected_salt ) ), 0, 10 )
+			),
+			Honeypot::get_secret_name_for_post(),
+			'A placeholder phrase must be replaced by a generated salt, not hashed as if it were secret'
+		);
+	}
+}

--- a/tests/Unit/Helpers/HoneypotSaltPlaceholderTest.php
+++ b/tests/Unit/Helpers/HoneypotSaltPlaceholderTest.php
@@ -26,7 +26,7 @@ class HoneypotSaltPlaceholderTest extends TestCase {
 	 *
 	 * @var string
 	 */
-	private const TRANSLATED_PLACEHOLDER = 'Füge hier Deine einzigartige Phrase ein';
+	private const TRANSLATED_PLACEHOLDER = 'füge hier deine einmalig genutzte Zeichenfolge ein'; // spellchecker:disable-line
 
 	/**
 	 * @runInSeparateProcess

--- a/tests/Unit/Helpers/SaltTest.php
+++ b/tests/Unit/Helpers/SaltTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Salt;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * Unit tests for {@see Salt}.
+ */
+class SaltTest extends TestCase {
+
+	public function test_a_generated_salt_is_recognised(): void {
+		$salts = [
+			'from the WordPress secret-key service' => 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B',
+			'alphanumeric only'                     => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY3wT6bM8nR4pL7zV2qK9',
+			'exactly at the length limit'           => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY3',
+		];
+
+		foreach ( $salts as $description => $salt ) {
+			self::assertTrue(
+				Salt::is_generated( $salt ),
+				"A salt $description should be recognised as generated"
+			);
+		}
+	}
+
+	/**
+	 * The placeholder is translated in localised WordPress packages, so it cannot
+	 * be recognised by comparing against the English phrase. Every translation is
+	 * a natural-language phrase, and those contain whitespace where a generated
+	 * salt never does.
+	 */
+	public function test_a_placeholder_phrase_is_rejected_in_any_language(): void {
+		$placeholders = [
+			'the English placeholder' => 'put your unique phrase here',
+			'a German translation'    => 'füge hier deine einmalig genutzte Zeichenfolge ein', // spellchecker:disable-line
+			'a long phrase'           => 'this phrase is comfortably longer than the length limit',
+		];
+
+		foreach ( $placeholders as $description => $placeholder ) {
+			self::assertFalse(
+				Salt::is_generated( $placeholder ),
+				"$description should not be treated as a secret"
+			);
+		}
+	}
+
+	public function test_short_and_empty_values_are_rejected(): void {
+		$values = [
+			'an empty string'      => '',
+			'a short random value' => 'B3mX8qZ6jP4oI9uV',
+			'one character short'  => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY',
+		];
+
+		foreach ( $values as $description => $value ) {
+			self::assertFalse(
+				Salt::is_generated( $value ),
+				"$description should not be treated as a secret"
+			);
+		}
+	}
+
+	public function test_generate_asks_for_a_value_the_check_accepts(): void {
+		expect( 'wp_generate_password' )
+			->once()
+			->with( 64, true, true )
+			->andReturn( 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B' );
+
+		self::assertTrue(
+			Salt::is_generated( Salt::generate() ),
+			'A generated salt must satisfy the check the plugin applies to configured ones'
+		);
+	}
+}


### PR DESCRIPTION
Implements #827. Stacked on #826 — review that one first.

## The problem

The honeypot field names are derived from a salt and rendered into the comment form. When the salt changes, a form served from a page cache still carries the old field name, `Rules\Honeypot::precheck()` finds nothing under the current one, and `Rules\InvalidRequest` returns a `$is_final` `999`. A genuine comment is discarded, no other rule can override the verdict, and the visitor is told nothing.

Deriving the salt from `wp-config.php` made that happen on every salt rotation, on every migration to a site whose config differs, and once for every site on any change to the derivation itself — including #826.

## The fix

The salt is stored in its own option and does not change on its own.

Seeding is what decides whether anything breaks, so it reproduces the value already in use — `substr( sha1( NONCE_SALT ), 0, 10 )`, exactly what the previous derivation produced. Forms already sitting in a page cache stay valid, so **this also removes the one-time field-name change #826 would otherwise have caused**.

## Recognising a salt by shape rather than by value

A configured `NONCE_SALT` is only trusted when it looks generated: at least 32 characters, no whitespace.

Comparing against the English `put your unique phrase here` is not enough, because localised WordPress packages **translate** that phrase in `wp-config-sample.php`. An unconfigured German install carries something like `Füge hier Deine einzigartige Phrase ein`, and no list can enumerate every locale.

Core has the same gap. `wp_salt()` seeds its list of non-secrets with the English phrase only, so it hashes a translated placeholder as though it were a secret — which is why the fallback here generates with `wp_generate_password( 64, true, true )` instead of delegating to `wp_salt()`.

Generated salts, both those `api.wordpress.org` hands out and those `wp_generate_password()` produces, are printable ASCII with no whitespace. Shape therefore accepts a real salt in any locale and rejects a natural-language phrase in any language.

| Configured value | Treated as | Field names |
| --- | --- | --- |
| A real salt, any locale | generated | preserved, nothing invalidated |
| `put your unique phrase here` | placeholder | replaced with a generated salt |
| `Füge hier Deine einzigartige Phrase ein` | placeholder | replaced with a generated salt |
| A hand-written passphrase | not generated | replaced with a generated salt |

The last row is a deliberate false positive. Such a value is not guessable, but replacing it with a generated one is no worse, and the check runs only once, when the salt is first stored.

## Details worth reviewing

- **Its own option, not part of the settings array**, so it is not user-editable, does not pass through `Helpers\Sanitize::sanitize_options`, and does not travel when settings are exported and imported into another site — which would otherwise hand two sites the same honeypot field name. Removed on uninstall with the other options.
- **`antispam_bee_honeypot_salt` is filterable.** A stored salt no longer rotates when the `wp-config.php` salts do, so this is the escape hatch for anyone who wants to rotate it. The cache consequence is documented on the filter.
- **Concurrency**: `add_option()` decides. If it reports the option already existed, the stored value wins over the one this request generated.

## Not included

#827 also proposed dropping `$is_final` from `InvalidRequest` so other rules could clear a legitimate commenter. That analysis was wrong and the change is **not** made here: `Handlers\Rules::apply()` ends in `return $score > 0.0` with both thresholds defaulting to `0.0`, and while negative-scoring rules exist (`ApprovedEmail` `-100`, `LinkbackFromMyself` `-100`, `ValidGravatar` `-1`), `999 - 100` is still above zero. Dropping finality would only stop the short-circuit, not change the verdict. A real fix needs the score for "secret field absent" lowered, ideally separating it from "honeypot filled". Left open in #827, with the reasoning recorded there.

## Tests

`129 tests, 264 assertions`. PHPStan level 8 clean, `phpcs` clean, `typos` clean.

- Field names follow the stored salt, and are stable while it is.
- The salt is seeded from `NONCE_SALT`, so existing field names are unchanged — verified to fail if `initial_salt()` always generates.
- A translated placeholder is replaced by a generated salt — verified to fail if the check compares against the English phrase.
- `NONCE_SALT` missing entirely falls back to a generated salt.
- The debug log is not written when the salt is a placeholder phrase — verified to fail against the previous empty-string check.
- `SaltTest` covers the check directly. It needs neither a constant nor a separate process, so it can state the cases the Honeypot tests can only reach one at a time: the English placeholder, a German translation, a phrase longer than the length limit, values at and just below that limit, and a salt shaped like the one api.wordpress.org hands out.

The two branches of the seeding check read a constant, so they need separate files as well as separate processes. Note also that every test in `HoneypotHelperTest` requires `@runInSeparateProcess`: `Rules\HoneypotTest` overloads `Helpers\Honeypot` with Mockery, which fails once that class has been loaded in the main process.

The German fixture is spelled as the localised `wp-config-sample.php` has it and carries `// spellchecker:disable-line`, matching how `TextHelperTest` already keeps German fixtures past the `typos` check. `ein` is flagged whatever the spelling, so the suppression is needed regardless.

## The same check applies to the debug log

`Helpers\DebugMode` had the same exposure from the other direction. It took whatever `wp_salt()` returned and only refused to log when that was empty, so on a localised install that was never configured it derived the log file name from the translated placeholder — and that log holds comment bodies and IP addresses in the usually web-served `WP_CONTENT_DIR`.

The shape check therefore lives in `Helpers\Salt` rather than inside `Honeypot`, and both helpers use it. `DebugMode` now skips logging when the salt does not look generated, which matches the fail-closed behaviour it already had for an empty one. No storage is needed there: a log file name has no page cache to invalidate.

`Salt::generate()` sits next to `Salt::is_generated()` so the definition of a generated value and the check that recognises one stay together.

### A deliberate consequence

Rejecting a hand-written passphrase affects both helpers. For the honeypot it costs one cache invalidation when the salt is first stored. For `DebugMode` it means a site whose `NONCE_KEY` and `NONCE_SALT` are hand-written phrases gets no debug log at all, silently.

That is intended and has been confirmed: it is the fail-closed policy `DebugMode` already applies, just with a wider trigger. Losing debug output is preferable to publishing comment bodies and IP addresses under a file name someone could derive, and debug mode has to be switched on deliberately in the first place.
