### PR TITLE
docs: replace the stale build badge with one badge per workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Antispam Bee #
 
-[![Build status](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/tests.yml/badge.svg)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/tests.yml) [![Current Antispam Bee version](https://img.shields.io/wordpress/plugin/v/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/) [![Number of downloads](https://img.shields.io/wordpress/plugin/dt/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/advanced/) [![Number of active installs](https://img.shields.io/wordpress/plugin/installs/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/advanced/) [![WordPress plugin rating](https://img.shields.io/wordpress/plugin/r/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/#reviews) [![Donate with PayPal](https://img.shields.io/badge/PayPal-Donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW)
+[![Current Antispam Bee version](https://img.shields.io/wordpress/plugin/v/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/)
+[![Number of downloads](https://img.shields.io/wordpress/plugin/dt/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/advanced/)
+[![Number of active installs](https://img.shields.io/wordpress/plugin/installs/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/advanced/)
+[![WordPress plugin rating](https://img.shields.io/wordpress/plugin/r/antispam-bee.svg)](https://wordpress.org/plugins/antispam-bee/#reviews)
+[![Donate with PayPal](https://img.shields.io/badge/PayPal-Donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW)
+
+[![Unit tests](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/unit.yml/badge.svg?branch=v3)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/unit.yml)
+[![Integration tests](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/integration.yml/badge.svg?branch=v3)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/integration.yml)
+[![E2E tests](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/e2e.yml/badge.svg?branch=v3)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/e2e.yml)
+[![Static analysis](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/static-analysis.yml/badge.svg?branch=v3)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/static-analysis.yml)
+[![Plugin Check](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/wordpress-plugin-check.yml/badge.svg?branch=v3)](https://github.com/pluginkollektiv/antispam-bee/actions/workflows/wordpress-plugin-check.yml)
 
 Antispam plugin with a sophisticated toolset for effective day-to-day comment and linkback
 spam-fighting. Built with data protection and privacy in mind and extendable with your own


### PR DESCRIPTION
`README.md` still advertised a single `Build status` badge pointing at `.github/workflows/tests.yml`. That workflow was split into per-concern workflows on `v3`, so the badge no longer describes anything this branch runs — and because a badge without `?branch=` tracks the default branch, it silently kept rendering `master`'s copy of `tests.yml` instead, currently under its long-outdated name `Tests, Behat, Coding Standards`.

## What changed

One badge per workflow that gates the build, replacing the single stale one:

| Workflow | Badge label |
| --- | --- |
| `unit.yml` | Unit tests |
| `integration.yml` | Integration tests |
| `static-analysis.yml` | Static analysis |
| `e2e.yml` | E2E tests |
| `wordpress-plugin-check.yml` | Plugin Check |

The label comes from each workflow's own `name:`, so there is no duplicated text to keep in sync.

Deliberately left out: `spelling.yml`, and the release automation (`wordpress-plugin-deploy.yml`, `wordpress-plugin-asset-update.yml`, `attach-snapshot.yml`) — none of them describe build health. `spam-detection-comparison.yml` is also left out, since it produces an informational report rather than a pass/fail gate.

The badges are also split onto one line each, grouped into a wp.org block and a CI block, rather than the previous single 1,200-character line. Markdown still renders them inline, so the visible result is unchanged, but the source is readable and future changes produce a one-line diff.

## Notes

- Every badge is pinned with `?branch=v3`. The five workflow files do not exist on `master`, so without the pin all five would render `no status`. **The pin has to be dropped once `v3` becomes the default branch.**
- The `integration.yml` badge renders `no status` until #794 lands and a `push` run happens on `v3`. The URL is already valid, so it starts working on its own — no follow-up needed.
