### PR TITLE
fix: scope the nonce verification suppressions in `CommentsColumns`

### DIFF
--- a/src/Admin/CommentsColumns.php
+++ b/src/Admin/CommentsColumns.php
@@ -136,7 +136,7 @@ class CommentsColumns {
 		<select id="filter-by-comment-spam-reason" name="comment_spam_reason">
 			<option value=""><?php esc_html_e( 'All spam reasons', 'antispam-bee' ); ?></option>
 			<?php
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$spam_reason = isset( $_GET['comment_spam_reason'] ) ? sanitize_text_field( wp_unslash( $_GET['comment_spam_reason'] ) ) : '';
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$tmp = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}commentmeta WHERE meta_key = 'antispam_bee_reason' GROUP BY meta_value", ARRAY_A );
@@ -175,6 +175,7 @@ class CommentsColumns {
 	 * @param WP_Comment_Query $query Current WordPress query.
 	 */
 	public static function filter_by_spam_reason( WP_Comment_Query $query ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$spam_reason = isset( $_GET['comment_spam_reason'] ) ? sanitize_text_field( wp_unslash( $_GET['comment_spam_reason'] ) ) : '';
 		if ( empty( $spam_reason ) ) {
 			return;


### PR DESCRIPTION
`CommentsColumns::filter_columns()` opened a `phpcs:disable WordPress.Security.NonceVerification.Recommended` that was never closed with a matching `phpcs:enable`. A `disable` without an `enable` applies to the rest of the file, so it silently blanketed everything below it — including the unrelated `$_GET` read in `filter_by_spam_reason()`, which carried no annotation of its own and was only passing because of the leak.

## What changed

- The `phpcs:disable` becomes a `phpcs:ignore`, so it covers exactly the one line it is meant to cover — matching how the same sniff is already suppressed in `set_orderby_query()` and in `DashboardHelper`.
- `filter_by_spam_reason()` gets its own `phpcs:ignore` for the line that actually reads `$_GET`.

No behaviour changes; both lines were already suppressed in practice, one of them accidentally.

## Verification

Removing the newly added annotation makes phpcs report the line, which confirms the suppression is doing real work rather than being decorative:

```
 178 | WARNING | Processing form data without nonce verification.
     |         | (WordPress.Security.NonceVerification.Recommended)
```

With the annotation in place the file is clean, and the full run over all 72 non-test PHP files reports no errors or warnings.

Both reads are `sanitize_text_field( wp_unslash( … ) )` on an admin list-table filter parameter, which is why the sniff is suppressed rather than answered with a nonce: these are read-only view filters, not state changes.
