### PR TITLE
fix: derive the plugin path in the integration test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 		"env:stop": "wp-env stop",
 		"env:clean": "wp-env reset tests",
 		"env:destroy": "wp-env destroy",
-		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/antispam-bee -- composer test:integration",
-		"test:integration:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/antispam-bee -- env WP_MULTISITE=1 composer test:integration",
+		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/\"$(basename \"$PWD\")\" -- composer test:integration",
+		"test:integration:multisite": "wp-env run tests-cli --env-cwd=wp-content/plugins/\"$(basename \"$PWD\")\" -- env WP_MULTISITE=1 composer test:integration",
 		"test:e2e": "wp-scripts test-playwright",
 		"test:e2e:ui": "wp-scripts test-playwright --ui",
 		"test:e2e:debug": "wp-scripts test-playwright --debug"


### PR DESCRIPTION
Both integration test scripts hardcoded the plugin's path inside the container:

```
--env-cwd=wp-content/plugins/antispam-bee
```

`wp-env` mounts the project under its **directory** name, not the plugin slug, so that path is only correct when the checkout directory happens to be called `antispam-bee`. In a git worktree, or any clone with a different directory name, both scripts fail before running a single test:

```
OCI runtime exec failed: … chdir to cwd ("/var/www/html/wp-content/plugins/antispam-bee") failed: no such file or directory
✖ Command failed with exit code 127
```

CI is unaffected, because its checkout directory is `antispam-bee` — which is why this went unnoticed.

## What changed

The path is now derived from the current directory:

```
--env-cwd=wp-content/plugins/"$(basename "$PWD")"
```

Removing the flag entirely is not an option: `--env-cwd` defaults to the WordPress root, and `composer test:integration` has to run in the plugin directory to find `composer.json`.

## Verification

Run from a worktree directory named `beta3-followups`, i.e. exactly the case that used to fail:

| Script | Result |
| --- | --- |
| `npm run test:integration` | 13 tests, 23 assertions, 1 skipped |
| `npm run test:integration:multisite` | 13 tests, 25 assertions |

The single skip is `Uninstall removes the options of every site`, which is multisite-only and correctly gated — hence the two extra assertions in the multisite run.

`$(basename "$PWD")` relies on a POSIX shell, which is consistent with the existing `env WP_MULTISITE=1` prefix in the multisite script.
