### PR TITLE
fix: prefer a configured `NONCE_SALT` over the managed salt

### DIFF
--- a/src/Helpers/DebugMode.php
+++ b/src/Helpers/DebugMode.php
@@ -56,15 +56,15 @@ class DebugMode {
 	 * The log contains comment data and `WP_CONTENT_DIR` is usually served
 	 * publicly, so the file name must not be guessable.
 	 *
-	 * `wp_salt()` prefers the `NONCE_*` constants from `wp-config.php` and
-	 * otherwise generates random values and stores them, so a secret is normally
-	 * always available. Should it ever yield nothing, this returns `null` and
-	 * logging is skipped rather than falling back to a predictable value.
+	 * {@see Salt::get()} prefers a configured `NONCE_SALT` and otherwise falls
+	 * back to `wp_salt()`, so a secret is normally always available. Should it
+	 * ever yield nothing, this returns `null` and logging is skipped rather than
+	 * falling back to a predictable value.
 	 *
 	 * @return string|null Suffix, or null if no secret salt is available.
 	 */
 	private static function get_log_file_suffix(): ?string {
-		$salt = wp_salt( 'nonce' );
+		$salt = Salt::get();
 
 		if ( '' === $salt ) {
 			return null;

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -161,14 +161,18 @@ class Honeypot {
 	 * Get the current salt.
 	 *
 	 * The honeypot field names are derived from this, so it must not be
-	 * predictable. `wp_salt()` prefers the `NONCE_*` constants from
-	 * `wp-config.php` and otherwise generates random values and stores them, so
-	 * there is always a secret to derive from.
+	 * predictable. {@see Salt::get()} prefers a configured `NONCE_SALT` and
+	 * otherwise falls back to `wp_salt()`, so there is always a secret to derive
+	 * from.
+	 *
+	 * The value is returned as it is, rather than hashed and shortened first: the
+	 * callers hash it anyway, and hashing it here would change every field name
+	 * relative to Antispam Bee 2.x, which derived them from the raw constant.
 	 *
 	 * @return string The current salt.
 	 */
 	private static function get_salt(): string {
-		return substr( sha1( wp_salt( 'nonce' ) ), 0, 10 );
+		return Salt::get();
 	}
 
 	/**

--- a/src/Helpers/Salt.php
+++ b/src/Helpers/Salt.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Salt helper.
+ *
+ * @package AntispamBee\Helpers
+ */
+
+namespace AntispamBee\Helpers;
+
+/**
+ * Resolve the secret the plugin derives identifiers from.
+ */
+class Salt {
+	/**
+	 * Shortest configured salt still treated as generated.
+	 *
+	 * @var int
+	 */
+	private const MIN_LENGTH = 32;
+
+	/**
+	 * Get the secret to derive identifiers from.
+	 *
+	 * `NONCE_SALT` is preferred over `wp_salt()` so the derived values stay the
+	 * same as in Antispam Bee 2.x, where the honeypot field names were hashed
+	 * from that constant alone. `wp_salt( 'nonce' )` returns `NONCE_KEY` and
+	 * `NONCE_SALT` concatenated, which is a different input and would therefore
+	 * rename every honeypot field once, on upgrade, for every site.
+	 *
+	 * The constant is read with `constant()` rather than imported with
+	 * `use const`, because an import has to resolve during static analysis and
+	 * would need `NONCE_SALT` declared in `phpstan-bootstrap.php` to do so.
+	 *
+	 * @return string The secret, empty if none is available.
+	 */
+	public static function get(): string {
+		$configured = defined( 'NONCE_SALT' ) ? constant( 'NONCE_SALT' ) : null;
+
+		/*
+		 * `wp-config.php` can define the constant as anything, and the file is not
+		 * validated, so a value that is not a string counts as not configured. The
+		 * check lives here rather than in the signature below, because without
+		 * `strict_types` an array would raise a `TypeError` on the way in.
+		 */
+		return self::resolve( is_string( $configured ) ? $configured : null );
+	}
+
+	/**
+	 * Choose between a configured salt and the one WordPress manages.
+	 *
+	 * Split from {@see self::get()} so the choice can be tested without defining
+	 * a constant, which a test cannot undo for the tests that follow it.
+	 *
+	 * @param string|null $configured The configured salt, or null if there is none
+	 *                                or it was not defined as a string.
+	 *
+	 * @return string The secret, empty if none is available.
+	 */
+	public static function resolve( ?string $configured ): string {
+		if ( null !== $configured && self::is_generated( $configured ) ) {
+			return $configured;
+		}
+
+		return wp_salt( 'nonce' );
+	}
+
+	/**
+	 * Whether a configured salt looks like a generated one.
+	 *
+	 * The placeholders `wp-config-sample.php` ships are natural-language phrases,
+	 * and localised WordPress packages translate them, so comparing against the
+	 * English `put your unique phrase here` would miss a German or French install
+	 * that was never configured. Core's own `wp_salt()` has that same blind spot:
+	 * it seeds its list of non-secrets with the English phrase only, so it hashes
+	 * a translated placeholder as if it were a secret.
+	 *
+	 * Generated salts — both the ones api.wordpress.org hands out and the ones
+	 * WordPress stores itself — are printable ASCII containing no whitespace.
+	 * Requiring some length and rejecting whitespace therefore recognises a real
+	 * salt whatever the locale, and rejects a placeholder phrase in any language.
+	 *
+	 * A hand-written passphrase is rejected too. That is deliberate: such a value
+	 * is not guessable, but the value `wp_salt()` falls back to is no worse.
+	 *
+	 * @param string $salt The configured salt.
+	 *
+	 * @return bool Whether the salt looks generated.
+	 */
+	public static function is_generated( string $salt ): bool {
+		return strlen( $salt ) >= self::MIN_LENGTH && ! preg_match( '/\s/', $salt );
+	}
+}

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -76,6 +76,31 @@ class HoneypotHelperTest extends TestCase {
 		self::assertStringContainsString( 'name="' . $name . '"', $result, 'Secret name should be in the output for unquoted markup' );
 	}
 
+	/**
+	 * Antispam Bee 2.x derived the field names from the raw salt with this exact
+	 * chain, so a site upgrading keeps the names it already rendered — including
+	 * the ones sitting in a page cache. Hashing or shortening the salt first would
+	 * rename every field once, on upgrade, for every site.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_the_secret_is_derived_the_way_version_2_derived_it(): void {
+		// Version 2's formula, spelled out here rather than called, so this asserts
+		// against the old behaviour instead of against the current implementation.
+		$secret     = substr( sha1( md5( 'comment-id' . 'test-salt' ) ), 0, 10 );
+		$first_char = substr( $secret, 0, 1 );
+		$expected   = is_numeric( $first_char )
+			? chr( (int) $first_char + 97 ) . substr( $secret, 1 )
+			: $secret;
+
+		self::assertSame(
+			$expected,
+			Honeypot::get_secret_name_for_post(),
+			'The field name must stay byte-for-byte what Antispam Bee 2.x produced for the same salt'
+		);
+	}
+
 	protected function set_up(): void {
 		parent::set_up();
 		when( 'esc_attr' )->returnArg();

--- a/tests/Unit/Helpers/SaltTest.php
+++ b/tests/Unit/Helpers/SaltTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Helpers;
+
+use AntispamBee\Helpers\Salt;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see Salt}.
+ */
+class SaltTest extends TestCase {
+
+	public function test_a_generated_salt_is_recognised(): void {
+		$salts = [
+			'from the WordPress secret-key service' => 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B',
+			'alphanumeric only'                     => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY3wT6bM8nR4pL7zV2qK9',
+			'exactly at the length limit'           => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY3',
+		];
+
+		foreach ( $salts as $description => $salt ) {
+			self::assertTrue(
+				Salt::is_generated( $salt ),
+				"A salt $description should be recognised as generated"
+			);
+		}
+	}
+
+	/**
+	 * The placeholder is translated in localised WordPress packages, so it cannot
+	 * be recognised by comparing against the English phrase. Every translation is
+	 * a natural-language phrase, and those contain whitespace where a generated
+	 * salt never does.
+	 */
+	public function test_a_placeholder_phrase_is_rejected_in_any_language(): void {
+		$placeholders = [
+			'the English placeholder' => 'put your unique phrase here',
+			'a German translation'    => 'füge hier deine einmalig genutzte Zeichenfolge ein', // spellchecker:disable-line
+			'a long phrase'           => 'this phrase is comfortably longer than the length limit',
+		];
+
+		foreach ( $placeholders as $description => $placeholder ) {
+			self::assertFalse(
+				Salt::is_generated( $placeholder ),
+				"$description should not be treated as a secret"
+			);
+		}
+	}
+
+	public function test_short_and_empty_values_are_rejected(): void {
+		$values = [
+			'an empty string'      => '',
+			'a short random value' => 'B3mX8qZ6jP4oI9uV',
+			'one character short'  => 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY',
+		];
+
+		foreach ( $values as $description => $value ) {
+			self::assertFalse(
+				Salt::is_generated( $value ),
+				"$description should not be treated as a secret"
+			);
+		}
+	}
+
+	/**
+	 * The point of preferring the constant: a site that configured its salts keeps
+	 * the identifiers it already had in Antispam Bee 2.x, so honeypot field names
+	 * sitting in a page cache stay valid across the upgrade.
+	 */
+	public function test_a_configured_salt_is_preferred_over_the_managed_one(): void {
+		when( 'wp_salt' )->justReturn( 'managed-salt' );
+		$configured = 'B3mX8qZ6jP4oI9uV2eC7aS0dF1gJ5hY3wT6bM8nR4pL7zV2qK9';
+
+		self::assertSame(
+			$configured,
+			Salt::resolve( $configured ),
+			'A configured salt that looks generated should be used as it is'
+		);
+	}
+
+	/**
+	 * A placeholder must not become the secret the honeypot names derive from, or
+	 * the field names would be identical — and so predictable — on every site that
+	 * never configured its salts.
+	 */
+	public function test_a_salt_that_does_not_look_generated_falls_back(): void {
+		when( 'wp_salt' )->justReturn( 'managed-salt' );
+
+		$rejected = [
+			'a placeholder phrase' => 'put your unique phrase here',
+			'a short value'        => 'too-short',
+			'an empty string'      => '',
+		];
+
+		foreach ( $rejected as $description => $value ) {
+			self::assertSame(
+				'managed-salt',
+				Salt::resolve( $value ),
+				"With $description the managed salt should be used instead"
+			);
+		}
+	}
+
+	/**
+	 * `get()` passes null for a constant that is missing, and for one that
+	 * `wp-config.php` defined as something other than a string.
+	 */
+	public function test_a_missing_salt_falls_back(): void {
+		when( 'wp_salt' )->justReturn( 'managed-salt' );
+
+		self::assertSame(
+			'managed-salt',
+			Salt::resolve( null ),
+			'Without a configured salt the managed one should be used'
+		);
+	}
+
+	/**
+	 * `DebugMode` skips logging when no secret is available, so the empty string
+	 * has to survive as an empty string rather than becoming a usable value.
+	 */
+	public function test_an_empty_managed_salt_is_passed_through(): void {
+		when( 'wp_salt' )->justReturn( '' );
+
+		self::assertSame( '', Salt::resolve( null ), 'An unavailable secret should stay empty' );
+	}
+}


### PR DESCRIPTION
Implements the "Alternative considered" from #826, which that PR documented but did not take.

#826 moved both `Helpers\Honeypot` and `Helpers\DebugMode` to `wp_salt( 'nonce' )`. That returns `NONCE_KEY . NONCE_SALT` concatenated, where the helpers previously derived from `NONCE_SALT` alone — so it renames every honeypot field once, on upgrade, for every site. A form already sitting in a page cache then submits names the current salt does not produce, which the honeypot and invalid-request rules read as a malformed submission until the cache is cleared.

Preferring the configured constant avoids that. #826 rejected it for two reasons, and both are answerable.

## The placeholder objection

The concern was that a site whose `NONCE_SALT` is still the `wp-config-sample.php` placeholder would keep a predictable honeypot permanently.

`Salt::is_generated()` settles it by checking the *shape* of the value — at least 32 characters and no whitespace — rather than comparing against a known phrase. Generated salts, both the ones api.wordpress.org hands out and the ones WordPress stores itself, are printable ASCII without whitespace; every placeholder is a natural-language phrase, and localised WordPress packages translate it. Core's own `wp_salt()` seeds `$duplicated_keys` with the English phrase only, so it hashes a German or French placeholder as if it were a secret. This check does not have that blind spot.

A hand-written passphrase is rejected too. That is deliberate: such a value is not guessable, but the salt `wp_salt()` falls back to is no worse.

## The machinery objection

The concern was that reading the constant means bringing back the `use const NONCE_SALT` import and the `phpstan-bootstrap.php` declaration that existed only so the import would resolve.

It does not: `defined( 'NONCE_SALT' )` with `constant( 'NONCE_SALT' )` needs neither, because `constant()` is typed `mixed`. PHPStan is clean without any bootstrap entry, which also makes the `NONCE_SALT` lint suppression added in #825 permanently unnecessary.

## Which sites keep their field names

`Honeypot::get_salt()` now returns the salt **as it is** rather than hashed and shortened. That is the part that restores the old names, and it is worth being precise about who is affected:

| | Previous derivation | After this PR |
| --- | --- | --- |
| Antispam Bee 2.x | `sha1( md5( 'comment-id' . NONCE_SALT ) )` | unchanged ✔ |
| v3 before #826 | `sha1( md5( 'comment-id' . substr( sha1( NONCE_SALT ), 0, 10 ) ) )` | changes |
| v3 after #826 | `sha1( md5( 'comment-id' . substr( sha1( wp_salt() ), 0, 10 ) ) )` | changes |

So the overwhelming majority — every site upgrading from 2.x — keeps the field names it is already serving. Current 3.0 beta installs see one change, which is the right trade while 3.0 is unreleased.

`test_the_secret_is_derived_the_way_version_2_derived_it()` spells version 2's formula out by hand rather than calling the current implementation, so it asserts against the old behaviour and cannot drift with a refactor.

## Notes

- `Salt::resolve()` is split from `Salt::get()` so the choice between the two salts can be tested without defining a constant, which a test cannot undo for the tests that follow it. That is also what let #826's `@runInSeparateProcess` removal stand.
- `DebugMode` keeps returning `null` when no secret is available, so logging is skipped rather than falling back to a guessable file name.
- The debug log file name changes. That is harmless: a new file is created and existing ones are left alone.

## Tests

`142 tests, 295 assertions`. PHPStan clean, `phpcs` clean, `typos` clean.
