### PR TITLE
feat: store the honeypot secret so field names survive page caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
       made the geolocation service reject every lookup. A key set through the
       `antispam_bee_country_spam_apikey` filter is now sent as a request header, which also keeps
       it out of proxy and server logs
+    * Fix: The honeypot field names are stored once instead of being derived from the salts in
+      `wp-config.php` on every request, so a comment form served from a page cache keeps working
+      after those salts are rotated or the site is migrated. A site that configured its salts
+      keeps the field names it already used in Antispam Bee 2.x
     * Enhancement: New `antispam_bee_country_spam_ip` filter to change which address the country
       rule looks up — mask it differently, send the original one for a more precise country, or
       return an empty string to skip the lookup
@@ -58,6 +62,11 @@
       `apikey`-Parameter führte dazu, dass der Geolokalisierungs-Dienst jede Abfrage ablehnte. Ein
       über den Filter `antispam_bee_country_spam_apikey` gesetzter Key wird nun als Request-Header
       gesendet, was ihn zugleich aus Proxy- und Server-Logs heraushält
+    * Fix: Die Feldnamen des Honeypots werden einmalig gespeichert, anstatt bei jeder Anfrage aus
+      den Salts der `wp-config.php` abgeleitet zu werden. Ein aus einem Page-Cache ausgeliefertes
+      Kommentarformular funktioniert damit auch nach dem Rotieren dieser Salts oder einer Migration
+      der Website weiter. Eine Website mit konfigurierten Salts behält die Feldnamen, die sie schon
+      in Antispam Bee 2.x verwendet hat
     * Verbesserung: Neuer Filter `antispam_bee_country_spam_ip`, um die Adresse zu ändern, die die
       Länder-Regel abfragt – anders maskieren, die ursprüngliche Adresse für ein genaueres Land
       senden oder mit einem leeren String die Abfrage ganz überspringen

--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -9,6 +9,7 @@ namespace AntispamBee\Handlers;
 
 use AntispamBee\Crons\DeleteSpamCron;
 use AntispamBee\GeneralOptions\Uninstall;
+use AntispamBee\Helpers\Honeypot;
 use AntispamBee\Helpers\Settings;
 
 /**
@@ -81,6 +82,7 @@ class PluginStateChangeHandler {
 
 		delete_option( Settings::OPTION_NAME );
 		delete_option( PluginUpdate::DB_VERSION_OPTION_NAME );
+		delete_option( Honeypot::SECRET_OPTION );
 		// delete_option( 'antispam_bee' );
 		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 

--- a/src/Helpers/Honeypot.php
+++ b/src/Helpers/Honeypot.php
@@ -16,6 +16,13 @@ use DOMXPath;
  */
 class Honeypot {
 	/**
+	 * Option that holds the secret the field names are built from.
+	 *
+	 * @var string
+	 */
+	public const SECRET_OPTION = 'antispam_bee_honeypot_secret';
+
+	/**
 	 * Inject the honeypot field.
 	 *
 	 * @param string                $markup  The field markup.
@@ -152,27 +159,92 @@ class Honeypot {
 	 * @return string The secret used in the textarea id attribute.
 	 */
 	public static function get_secret_id_for_post(): string {
-		$secret = substr( sha1( md5( 'comment-id' . self::get_salt() ) ), 0, 10 );
+		return self::get_secret();
+	}
 
+	/**
+	 * Get the secret the honeypot field names are built from.
+	 *
+	 * The names are rendered into the comment form, so a page cache can serve a
+	 * form long after it was generated. If the names have changed by the time that
+	 * form is submitted, the honeypot and invalid-request rules see a field they
+	 * did not create and treat a genuine comment as spam. Deriving the names from
+	 * the `wp-config.php` salts made that happen whenever those were rotated or a
+	 * site was migrated, so the secret is stored once and then reused.
+	 *
+	 * What is stored is the finished secret, not the salt it came from: the secret
+	 * is in the markup of every comment form already, so keeping it in the options
+	 * table discloses nothing, whereas storing the salt would copy a value out of
+	 * `wp-config.php` into the database.
+	 *
+	 * @return string The secret.
+	 */
+	private static function get_secret(): string {
+		$secret = get_option( self::SECRET_OPTION );
+
+		if ( ! is_string( $secret ) || '' === $secret ) {
+			$secret = self::store_secret();
+		}
+
+		/**
+		 * Filters the secret the honeypot field names are built from.
+		 *
+		 * The stored secret never changes on its own, which is what keeps cached
+		 * comment forms valid. Filtering it renames every field, so a form already
+		 * sitting in a page cache stops matching until that cache is cleared.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $secret The stored secret.
+		 */
+		$secret = (string) apply_filters( 'antispam_bee_honeypot_secret', $secret );
+
+		// The secret is used as an HTML id, which may not start with a digit, so the
+		// invariant is re-applied in case a filter returned a value that breaks it.
 		return self::ensure_secret_starts_with_letter( $secret );
 	}
 
 	/**
-	 * Get the current salt.
+	 * Create and store the secret.
 	 *
-	 * The honeypot field names are derived from this, so it must not be
-	 * predictable. {@see Salt::get()} prefers a configured `NONCE_SALT` and
-	 * otherwise falls back to `wp_salt()`, so there is always a secret to derive
-	 * from.
-	 *
-	 * The value is returned as it is, rather than hashed and shortened first: the
-	 * callers hash it anyway, and hashing it here would change every field name
-	 * relative to Antispam Bee 2.x, which derived them from the raw constant.
-	 *
-	 * @return string The current salt.
+	 * @return string The stored secret.
 	 */
-	private static function get_salt(): string {
-		return Salt::get();
+	private static function store_secret(): string {
+		$secret = self::derive_secret();
+
+		// A concurrent request may have stored one first; that one wins.
+		if ( ! add_option( self::SECRET_OPTION, $secret ) ) {
+			$stored = get_option( self::SECRET_OPTION );
+
+			if ( is_string( $stored ) && '' !== $stored ) {
+				return $stored;
+			}
+		}
+
+		return $secret;
+	}
+
+	/**
+	 * Derive the secret to store.
+	 *
+	 * Deriving it from the configured salt reproduces the names the site is
+	 * already serving, so storing the secret does not invalidate forms that are
+	 * already in a page cache. {@see Salt::get()} only returns a configured salt
+	 * when it looks generated, and falls back to the one WordPress manages
+	 * otherwise — the case where the previous derivation was predictable anyway.
+	 *
+	 * @return string The derived secret.
+	 */
+	private static function derive_secret(): string {
+		$salt = Salt::get();
+
+		if ( '' === $salt ) {
+			$salt = Salt::generate();
+		}
+
+		return self::ensure_secret_starts_with_letter(
+			substr( sha1( md5( 'comment-id' . $salt ) ), 0, 10 )
+		);
 	}
 
 	/**
@@ -209,8 +281,6 @@ class Honeypot {
 	 * @return string The secret used in the textarea name attribute.
 	 */
 	public static function get_secret_name_for_post(): string {
-		$secret = substr( sha1( md5( 'comment-id' . self::get_salt() ) ), 0, 10 );
-
-		return self::ensure_secret_starts_with_letter( $secret );
+		return self::get_secret();
 	}
 }

--- a/src/Helpers/Salt.php
+++ b/src/Helpers/Salt.php
@@ -65,6 +65,15 @@ class Salt {
 	}
 
 	/**
+	 * Generate a salt.
+	 *
+	 * @return string The generated salt.
+	 */
+	public static function generate(): string {
+		return wp_generate_password( 64, true, true );
+	}
+
+	/**
 	 * Whether a configured salt looks like a generated one.
 	 *
 	 * The placeholders `wp-config-sample.php` ships are natural-language phrases,

--- a/tests/Integration/Handlers/PluginStateChangeHandlerTest.php
+++ b/tests/Integration/Handlers/PluginStateChangeHandlerTest.php
@@ -10,6 +10,7 @@ namespace AntispamBee\Tests\Integration\Handlers;
 use AntispamBee\Crons\DeleteSpamCron;
 use AntispamBee\Handlers\PluginStateChangeHandler;
 use AntispamBee\Handlers\PluginUpdate;
+use AntispamBee\Helpers\Honeypot;
 use AntispamBee\Helpers\Settings;
 use ReflectionClass;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
@@ -69,6 +70,10 @@ final class PluginStateChangeHandlerTest extends TestCase {
 			get_option( self::DB_VERSION_OPTION ),
 			'The database version has to be removed on uninstall.'
 		);
+		self::assertFalse(
+			get_option( Honeypot::SECRET_OPTION ),
+			'The stored honeypot secret has to be removed on uninstall.'
+		);
 	}
 
 	public function test_uninstall_keeps_the_plugin_options_when_disabled(): void {
@@ -83,6 +88,10 @@ final class PluginStateChangeHandlerTest extends TestCase {
 		self::assertNotFalse(
 			get_option( self::DB_VERSION_OPTION ),
 			'The database version must survive an uninstall that was not opted into.'
+		);
+		self::assertNotFalse(
+			get_option( Honeypot::SECRET_OPTION ),
+			'The stored honeypot secret must survive an uninstall that was not opted into.'
 		);
 	}
 
@@ -171,6 +180,7 @@ final class PluginStateChangeHandlerTest extends TestCase {
 		);
 		update_option( self::DB_VERSION_OPTION, '3.0.0-beta.1' );
 		update_option( self::LEGACY_OPTION, [ 'regexp_check' => 1 ] );
+		update_option( Honeypot::SECRET_OPTION, 'abcdefghij' );
 
 		wp_cache_delete( Settings::OPTION_NAME );
 	}

--- a/tests/Unit/Helpers/HoneypotHelperTest.php
+++ b/tests/Unit/Helpers/HoneypotHelperTest.php
@@ -86,19 +86,115 @@ class HoneypotHelperTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_the_secret_is_derived_the_way_version_2_derived_it(): void {
-		// Version 2's formula, spelled out here rather than called, so this asserts
-		// against the old behaviour instead of against the current implementation.
-		$secret     = substr( sha1( md5( 'comment-id' . 'test-salt' ) ), 0, 10 );
-		$first_char = substr( $secret, 0, 1 );
-		$expected   = is_numeric( $first_char )
-			? chr( (int) $first_char + 97 ) . substr( $secret, 1 )
-			: $secret;
-
 		self::assertSame(
-			$expected,
+			self::version_2_secret( 'test-salt' ),
 			Honeypot::get_secret_name_for_post(),
 			'The field name must stay byte-for-byte what Antispam Bee 2.x produced for the same salt'
 		);
+	}
+
+	/**
+	 * The names have to survive salt rotation and site migration, which is the
+	 * whole reason the secret is stored instead of derived on every call.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_a_stored_secret_is_used_even_when_the_salt_changed(): void {
+		when( 'get_option' )->justReturn( 'storedvalue' );
+		when( 'wp_salt' )->justReturn( 'a-completely-different-salt' );
+
+		self::assertSame(
+			'storedvalue',
+			Honeypot::get_secret_name_for_post(),
+			'A stored secret must win over anything the current salt would derive'
+		);
+	}
+
+	/**
+	 * What lands in the options table has to be the finished field name, which is
+	 * public in every comment form anyway — never the salt it came from, which
+	 * would copy a `wp-config.php` secret into the database.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_the_stored_value_is_the_secret_and_not_the_salt(): void {
+		$stored = null;
+		when( 'get_option' )->justReturn( '' );
+		when( 'add_option' )->alias(
+			static function ( $option, $value ) use ( &$stored ) {
+				$stored = $value;
+
+				return true;
+			}
+		);
+
+		$secret = Honeypot::get_secret_name_for_post();
+
+		self::assertSame( $secret, $stored, 'The stored value should be the secret the form renders' );
+		self::assertSame( self::version_2_secret( 'test-salt' ), $stored, 'The secret should be the derived one' );
+		self::assertStringNotContainsString( 'test-salt', (string) $stored, 'The salt must never reach the database' );
+	}
+
+	/**
+	 * Two requests can miss the option at the same time. Whichever one gets its
+	 * `add_option()` in first defines the names, and the other has to adopt it
+	 * rather than keep a value it never stored.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_a_concurrently_stored_secret_wins(): void {
+		$calls = 0;
+		when( 'get_option' )->alias(
+			static function () use ( &$calls ) {
+				++$calls;
+
+				// Missing on the first read, present on the re-read after the failed write.
+				return $calls > 1 ? 'winningvalue' : '';
+			}
+		);
+		when( 'add_option' )->justReturn( false );
+
+		self::assertSame(
+			'winningvalue',
+			Honeypot::get_secret_name_for_post(),
+			'A secret stored by a concurrent request should be adopted'
+		);
+	}
+
+	/**
+	 * The secret is used as an HTML id, which may not start with a digit.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_a_filtered_secret_still_starts_with_a_letter(): void {
+		when( 'get_option' )->justReturn( '7abcdefghi' );
+
+		self::assertSame(
+			'habcdefghi',
+			Honeypot::get_secret_name_for_post(),
+			'A stored or filtered secret starting with a digit should be corrected'
+		);
+	}
+
+	/**
+	 * Antispam Bee 2.x's derivation, spelled out here rather than called, so the
+	 * tests assert against the old behaviour and not against the implementation.
+	 *
+	 * @param string $salt The salt to derive from.
+	 *
+	 * @return string The secret version 2 produced for that salt.
+	 */
+	private static function version_2_secret( string $salt ): string {
+		$secret     = substr( sha1( md5( 'comment-id' . $salt ) ), 0, 10 );
+		$first_char = substr( $secret, 0, 1 );
+
+		return is_numeric( $first_char )
+			? chr( (int) $first_char + 97 ) . substr( $secret, 1 )
+			: $secret;
 	}
 
 	protected function set_up(): void {
@@ -106,5 +202,7 @@ class HoneypotHelperTest extends TestCase {
 		when( 'esc_attr' )->returnArg();
 		when( 'esc_js' )->returnArg();
 		when( 'wp_salt' )->justReturn( 'test-salt' );
+		when( 'get_option' )->justReturn( '' );
+		when( 'add_option' )->justReturn( true );
 	}
 }

--- a/tests/Unit/Helpers/SaltTest.php
+++ b/tests/Unit/Helpers/SaltTest.php
@@ -4,6 +4,7 @@ namespace AntispamBee\Tests\Unit\Helpers;
 
 use AntispamBee\Helpers\Salt;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -123,5 +124,17 @@ class SaltTest extends TestCase {
 		when( 'wp_salt' )->justReturn( '' );
 
 		self::assertSame( '', Salt::resolve( null ), 'An unavailable secret should stay empty' );
+	}
+
+	public function test_generate_asks_for_a_value_the_check_accepts(): void {
+		expect( 'wp_generate_password' )
+			->once()
+			->with( 64, true, true )
+			->andReturn( 'x9!Kq2#Vz7$Lp4%Rn8^Mb6&Tw3*Yh5(Jg1)Fd0-Sa7+Ce2=Vu9~Io4Pj6Zq8Xm3B' );
+
+		self::assertTrue(
+			Salt::is_generated( Salt::generate() ),
+			'A generated salt must satisfy the check the plugin applies to configured ones'
+		);
 	}
 }


### PR DESCRIPTION
Stacked on #833 — review that one first. Supersedes #829 and closes #827.

The honeypot field names are rendered into the comment form, so a page cache can serve a form long after it was generated. If the names have changed by the time that form is submitted, the honeypot and invalid-request rules see a field they did not create and treat a genuine comment as spam. Deriving the names from the `wp-config.php` salts makes that happen whenever those salts are rotated or a site is migrated — a form in a cache goes stale through no fault of the visitor.

So the secret is resolved once and stored.

## What is stored, and what is not

The stored value is the **finished 10-character secret**, not the salt it came from.

That distinction is the whole point of the rewrite. #829 stored a value derived from `NONCE_SALT` in the options table; this stores the secret that already appears in the markup of every comment form, so the database holds nothing that is not public already. A `wp-config.php` secret backs every nonce on the site, and it should not be copied into a table that a database-only disclosure exposes.

## Keeping the names a site already serves

`derive_secret()` seeds from `Salt::get()`, which #833 makes prefer a configured `NONCE_SALT`. Combined, that means a site upgrading from Antispam Bee 2.x keeps the exact field names it is already serving, and keeps them permanently from then on — the stored secret does not follow a later salt rotation.

A site whose salt does not look generated falls back to the salt WordPress manages, and to `Salt::generate()` in the case where even that yields nothing. Those are the sites whose previous derivation was predictable anyway.

## Details

- `add_option()` rather than `update_option()`, so two requests that miss the option at the same time cannot disagree: whichever write lands first defines the names, and the other adopts it. Carried over from #829.
- `delete_option( Honeypot::SECRET_OPTION )` on uninstall, so opting into data removal does not leave the secret behind.
- `ensure_secret_starts_with_letter()` is re-applied *after* the filter. The secret is used as an HTML id, which may not start with a digit, and a filter could otherwise return a value that breaks that.
- The filter is named `antispam_bee_honeypot_secret`, matching what it now filters. #829's `antispam_bee_honeypot_salt` was never merged, so no released name changes.

## #829's second commit is no longer needed

"reject placeholder salts in the debug log file name too" is already covered: #833 routes `DebugMode` through `Salt::get()`, which rejects a placeholder before it can become a log file name.

## Tests

`147 unit tests, 303 assertions`. PHPStan clean, `phpcs` clean, `typos` clean.

Integration suite run in `wp-env`, single site and multisite:

| Suite | Result |
| --- | --- |
| single site | 13 tests, 25 assertions, 1 skipped |
| multisite | 13 tests, 27 assertions |

The skip is the multisite-only uninstall case, correctly gated. New unit coverage asserts that a stored secret wins over the current salt, that what reaches `add_option()` is the secret and never the salt, that a concurrently stored secret is adopted, and that a filtered secret still starts with a letter.

Changelog note added in English and German.
