### PR TITLE
refactor: introduce a `DB_VERSION_OPTION_NAME` constant

### DIFF
--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -80,7 +80,7 @@ class PluginStateChangeHandler {
 		}
 
 		delete_option( Settings::OPTION_NAME );
-		delete_option( 'antispambee_db_version' );
+		delete_option( PluginUpdate::DB_VERSION_OPTION_NAME );
 		// delete_option( 'antispam_bee' );
 		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -15,6 +15,11 @@ use const AntispamBee\MAIN_PLUGIN_FILE;
  */
 class PluginUpdate {
 	/**
+	 * Name of the option holding the database version.
+	 */
+	const DB_VERSION_OPTION_NAME = 'antispambee_db_version';
+
+	/**
 	 * Mapping of spam reason keys (key is pre-3.0, value 3.0 and later).
 	 *
 	 * @var array<string, string|null>
@@ -70,7 +75,7 @@ class PluginUpdate {
 		}
 
 		self::$db_version_is_current = (bool) version_compare(
-			get_option( 'antispambee_db_version', '1.0' ),
+			get_option( self::DB_VERSION_OPTION_NAME, '1.0' ),
 			self::get_plugin_version(),
 			'=='
 		);
@@ -96,9 +101,9 @@ class PluginUpdate {
 		// Prevent further update triggers during the same request that run before the DB version is updated.
 		self::$db_update_triggered = true;
 
-		$version_from_db = get_option( 'antispambee_db_version', null );
+		$version_from_db = get_option( self::DB_VERSION_OPTION_NAME, null );
 
-		update_option( 'antispambee_db_version', self::get_plugin_version() );
+		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
 
 		if ( null === $version_from_db ) {
 			return;


### PR DESCRIPTION
## Description

Every option name in the plugin comes from a class constant — `Settings::OPTION_NAME`, `DeleteSpamCron::CRONJOB_NAME` — except `antispambee_db_version`, which was repeated as a bare string literal across two classes and four call sites.

This adds `PluginUpdate::DB_VERSION_OPTION_NAME` and routes all usages through it. `PluginUpdate` is the natural owner: it is the class that reads, writes and reasons about the database version. `PluginStateChangeHandler` (which deletes the option on uninstall) lives in the same namespace, so it needs no extra `use` statement.

## Changes

- `src/Handlers/PluginUpdate.php`: new `DB_VERSION_OPTION_NAME` constant; the two `get_option()` calls and the `update_option()` call now use `self::DB_VERSION_OPTION_NAME`.
- `src/Handlers/PluginStateChangeHandler.php`: `delete_option()` now uses `PluginUpdate::DB_VERSION_OPTION_NAME`.

Pure refactoring — no behaviour change, the stored option key is unchanged.

## Notes

The string literals in the unit tests were left as-is on purpose: those tests mock `get_option()` by key, so keeping the literal there acts as a guard that the constant's *value* never silently changes.

## Testing

- `vendor/bin/phpcs` clean on both changed files.
- `vendor/bin/phpunit --testsuite unit`: 134 tests, 277 assertions, all passing.
