### PR TITLE
fix: let the settings sanitizers accept whatever was posted

### DIFF
--- a/src/Helpers/Sanitize.php
+++ b/src/Helpers/Sanitize.php
@@ -59,13 +59,20 @@ class Sanitize {
 	/**
 	 * Sanitize the options.
 	 *
-	 * @param array<string, array<string, string>> $options Options to sanitize.
+	 * Registered as the `sanitize_callback` of the settings API, so WordPress
+	 * passes whatever was posted. The settings screen submits an array, but the
+	 * request is not required to: a scalar posted for the option would reach a
+	 * declared `array` parameter and raise a `TypeError`. Sanitizing untrusted
+	 * input is this method's purpose, so it accepts anything and discards what it
+	 * cannot use, leaving the stored options untouched.
+	 *
+	 * @param mixed $options Options to sanitize.
 	 *
 	 * @return array<string, array<string, string>> Sanitized options.
 	 */
-	public static function sanitize_options( array $options ): array {
+	public static function sanitize_options( $options ): array {
 		$current_options = Settings::get_options();
-		$options         = ! empty( $options ) ? $options : [];
+		$options         = is_array( $options ) ? $options : [];
 
 		$tabs = self::get_tab_slugs();
 

--- a/src/Interfaces/Controllable.php
+++ b/src/Interfaces/Controllable.php
@@ -54,6 +54,13 @@ interface Controllable {
 	 *   ]
 	 * ]
 	 *
+	 * A `sanitize` callback is handed the posted value exactly as it arrived, so it
+	 * has to accept `mixed`. Nothing guarantees the shape a request submits — a
+	 * textarea can be posted as an array — and a callback that declares a narrower
+	 * parameter type turns that into a `TypeError` instead of a rejected value.
+	 * Returning `null` removes the option, so discarding an unusable value is
+	 * always possible.
+	 *
 	 * @return array<int, array<string, mixed>>|null A list of advanced options, or null.
 	 */
 	public static function get_options(): ?array;

--- a/src/Rules/CountrySpam.php
+++ b/src/Rules/CountrySpam.php
@@ -279,11 +279,22 @@ class CountrySpam extends ControllableBase implements SpamReason {
 	/**
 	 * Sanitize ISO code strings.
 	 *
-	 * @param string $value Comma-separated list of potential ISO country codes.
+	 * Reached from a `sanitize` callback, which is handed the posted value as it
+	 * is. The field is a textarea, but a request can post an array for it just as
+	 * easily, and an array reaching a declared `string` parameter is a `TypeError`
+	 * rather than a value this can reject. So anything that is not a string counts
+	 * as no countries at all, the same way {@see Sanitize::checkbox()} and
+	 * {@see Sanitize::checkbox_group()} discard what they cannot use.
+	 *
+	 * @param mixed $value Comma-separated list of potential ISO country codes.
 	 *
 	 * @return string Comma-separated list of sanitized ISO country codes.
 	 */
-	private static function sanitize_iso_codes_string( string $value ): string {
+	private static function sanitize_iso_codes_string( $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
 		$value  = strtoupper( $value );
 		$values = explode( ',', $value );
 		$values = Sanitize::iso_codes( $values );

--- a/tests/Unit/Helpers/SanitizeTest.php
+++ b/tests/Unit/Helpers/SanitizeTest.php
@@ -4,6 +4,7 @@ namespace AntispamBee\Tests\Unit\Helpers;
 
 use AntispamBee\Helpers\Sanitize;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\when;
 
 /**
  * Unit tests for {@see Sanitize}.
@@ -60,5 +61,24 @@ class SanitizeTest extends TestCase {
 			Sanitize::iso_codes( [] ),
 			'An empty list has nothing to sanitize'
 		);
+	}
+
+	/**
+	 * Registered as the settings API `sanitize_callback`, so WordPress hands this
+	 * whatever the request posted. A scalar posted for the option used to reach a
+	 * declared `array` parameter and raise a `TypeError`, turning a malformed save
+	 * into a fatal instead of a rejected value.
+	 */
+	public function test_sanitize_options_discards_a_value_that_is_not_an_array(): void {
+		$stored = [ 'general' => [ 'some_option' => 'on' ] ];
+		when( 'get_option' )->justReturn( $stored );
+		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0' ] );
+
+		foreach ( [ 'a string' => 'not-an-array', 'null' => null, 'a number' => 42 ] as $description => $value ) {
+			self::assertIsArray(
+				Sanitize::sanitize_options( $value ),
+				"Posting $description should be discarded rather than raise a TypeError"
+			);
+		}
 	}
 }

--- a/tests/Unit/Rules/CountrySpamTest.php
+++ b/tests/Unit/Rules/CountrySpamTest.php
@@ -275,6 +275,34 @@ class CountrySpamTest extends AbstractRuleTestCase {
 	}
 
 	/**
+	 * The `sanitize` callbacks are handed the posted value as it arrived. The two
+	 * country lists are textareas, but a request can post an array for them, and
+	 * that used to reach a `string` parameter and raise a `TypeError` — a fatal
+	 * while saving the settings, from the code whose job is to reject bad input.
+	 */
+	public function test_the_country_list_sanitizers_discard_a_value_that_is_not_a_string(): void {
+		$sanitizers = [];
+		foreach ( CountrySpam::get_options() as $option ) {
+			if ( isset( $option['option_name'], $option['sanitize'] )
+				&& in_array( $option['option_name'], [ 'denied', 'allowed' ], true ) ) {
+				$sanitizers[ $option['option_name'] ] = $option['sanitize'];
+			}
+		}
+
+		self::assertCount( 2, $sanitizers, 'Both country lists should expose a sanitize callback' );
+
+		foreach ( $sanitizers as $option_name => $sanitize ) {
+			foreach ( [ 'an array' => [ 'DE' ], 'null' => null, 'a number' => 42 ] as $description => $value ) {
+				self::assertSame(
+					'',
+					$sanitize( $value ),
+					"The $option_name list should discard $description instead of raising a TypeError"
+				);
+			}
+		}
+	}
+
+	/**
 	 * Set up the test environment.
 	 *
 	 * @return void


### PR DESCRIPTION
`Sanitize::sanitize_options()` is registered as the settings API `sanitize_callback`, so WordPress hands it whatever the request posted. Two places along that path declared narrower parameter types than the data is guaranteed to have, which turns malformed input into a fatal instead of a rejected value — in the code whose entire purpose is to reject malformed input.

The reachable path:

```
$_POST['antispam_bee']
  → Sanitize::sanitize_options()          ← declared `array`
  → sanitize_controllables()
  → call_sanitize_callback()
  → Settings::get_array_value_by_path()   ← returns the raw value, no coercion
  → call_user_func( $closure, $new_value )
  → CountrySpam::sanitize_iso_codes_string()   ← declared `string`
```

Posting `antispam_bee[general][country_denied][]=x` makes that value an array. There is no `declare( strict_types=1 )` in this codebase, but an array is never coercible to `string`, so it is a `TypeError` either way.

Triggering it needs `manage_options` and the settings nonce, so the only person who can reach it is an administrator crafting a request to break their own settings save. It is a robustness bug, not a vulnerability — but a sanitizer that fatals on unexpected input has failed at its one job.

## Audit of every `sanitize` callback

The other callbacks were already written to accept anything, which is what makes the two below the outliers rather than the norm:

| Callback | Receives | Verdict |
| --- | --- | --- |
| `GeneralOptions\DeleteOldSpam:69` | `absint()` | safe — casts anything |
| `GeneralOptions\DeleteOldSpam:79` | `Sanitize::checkbox()` | safe — `mixed` parameter |
| `PostProcessors\DeleteForReasons:103` | `Sanitize::checkbox_group()` | safe — `is_array()` guard |
| `Rules\LangSpam:241` | `Sanitize::checkbox_group()` | safe — `is_array()` guard |
| `Rules\CountrySpam:253` | `sanitize_iso_codes_string( string )` | **fatal on non-string** |
| `Rules\CountrySpam:272` | `sanitize_iso_codes_string( string )` | **fatal on non-string** |

## What changed

- `Sanitize::sanitize_options()` accepts `mixed` and keeps the stored options untouched when the posted value is not an array.
- `CountrySpam::sanitize_iso_codes_string()` accepts `mixed` and treats anything that is not a string as no countries at all. The guard lives in the method rather than in both closures, matching how `Sanitize::checkbox()` and `Sanitize::checkbox_group()` already discard what they cannot use.
- The contract is written down where the option shape is defined, in `Interfaces\Controllable::get_options()`: a `sanitize` callback is handed the posted value exactly as it arrived and has to accept `mixed`, and returning `null` removes the option, so discarding an unusable value is always possible. That is the part that keeps the next callback from reintroducing this.

## Tests

`144 tests, 303 assertions`. PHPStan clean, `phpcs` clean, `typos` clean.

Both new tests were checked by reverting the fix and confirming they fail for the right reason, rather than only that they pass:

- without the `CountrySpam` guard — `TypeError: sanitize_iso_codes_string(): Argument #1 ($value) must be of type string, array given`, raised from the closure at `CountrySpam.php:254`
- with `sanitize_options()` back to `array` — `TypeError: Argument #1 ($options) must be of type array, string given`

`test_the_country_list_sanitizers_discard_a_value_that_is_not_a_string()` pulls the real callbacks out of `CountrySpam::get_options()` and invokes them, rather than reaching the private method directly, so it drives the same path the settings API does.

No changelog entry: the fix is only reachable through a hand-crafted request from someone who already holds `manage_options`, so there is no behaviour a normal user would notice.
