### PR TITLE
chore: update plugin version to 3.0.0-beta.2

### DIFF
--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -10,7 +10,7 @@
  * Plugin Name: Antispam Bee
  * Plugin URI: https://antispambee.pluginkollektiv.org/
  * Description: Antispam plugin with a sophisticated toolset for effective day-to-day comment and trackback spam-fighting. Built with data protection and privacy in mind.
- * Version: 3.0.0-beta.1
+ * Version: 3.0.0-beta.2
  * Author: pluginkollektiv
  * Author URI: https://pluginkollektiv.org
  * Text Domain: antispam-bee
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( __NAMESPACE__ . '\MAIN_PLUGIN_FILE', __FILE__ );
 define( __NAMESPACE__ . '\PLUGIN_PATH', plugin_dir_path( MAIN_PLUGIN_FILE ) );
-define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-beta.1' );
+define( __NAMESPACE__ . '\PLUGIN_VERSION', '3.0.0-beta.2' );
 
 // The pre_init function checks the plugin's compatibility and calls the init function if the check was successful.
 pre_init();

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 4.7
 * Tested up to:      7.0
 * Requires PHP:      7.4
-* Stable tag:        3.0.0-beta.1
+* Stable tag:        3.0.0-beta.2
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Prepares the `3.0.0-beta.2` prerelease.

Moves the three version strings: the `Version:` header and the `PLUGIN_VERSION`
constant in `antispam_bee.php`, and `Stable tag:` in `readme.txt`.

No `## Changelog ##` entry in `readme.txt`. That changelog is what users read on
the Plugin Directory listing, and a prerelease is never published there — the
deploy workflow skips any tag containing a hyphen. The notes for this beta go on
the GitHub release instead; `readme.txt` gets its entry when 3.0.0 goes stable,
covering the whole span since 2.11.12.

### The spam-detection comparison will fail, and that is expected

The push to a `chore/prepare-*` branch runs the comparison against the full
corpus with `fail-on-flips: true`, and its baseline resolves to `3.0.0-beta.1`.
This branch carries 48 commits of deliberate behaviour change on top of that
tag, so flips are the *output* of the run, not a defect. Merge once the flip
table has been read and every entry is a change we meant to ship.

No test steps: a version bump changes no user-facing behaviour.