### PR TITLE
ci: attach the built plugin ZIP to every release

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,9 +1,10 @@
 # Sets up PHP with Composer and installs the Composer dependencies.
 #
-# Every job that touches PHP starts with these two steps, and only three things ever
-# differ: the PHP version, the extensions and ini values the unit suite needs, and the
+# Every job that touches PHP starts with these two steps, and only four things ever
+# differ: the PHP version, the extensions and ini values the unit suite needs, the
 # flags for `composer install` (`--ignore-platform-req=php` for the static checks,
-# `--no-dev --optimize-autoloader` for the end-to-end build, nothing for the unit suite).
+# `--no-dev --optimize-autoloader` for the end-to-end build, nothing for the unit suite),
+# and the tools on top of Composer (`wp-cli` for the jobs that build the release archive).
 # So the steps live here once instead of five times across the workflows.
 #
 # Used with a local path (`uses: ./.github/actions/setup-php`), so the calling job has to
@@ -28,6 +29,10 @@ inputs:
     description: Extra flags to pass to `composer install`.
     required: false
     default: ''
+  tools:
+    description: The tools to set up, as a comma-separated list. Composer is always needed.
+    required: false
+    default: composer
 
 runs:
   using: composite
@@ -45,7 +50,7 @@ runs:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.extensions }}
         ini-values: ${{ inputs.ini-values }}
-        tools: composer
+        tools: ${{ inputs.tools }}
     - name: Install Composer dependencies
       shell: bash
       run: composer install ${{ inputs.composer-flags }}

--- a/.github/workflows/attach-plugin-zip.yml
+++ b/.github/workflows/attach-plugin-zip.yml
@@ -1,0 +1,115 @@
+# Builds the distributable plugin archive and attaches it to the GitHub release.
+#
+# For a pre-release this is the only channel there is: `wordpress-plugin-deploy.yml`
+# filters tags with `"!*-*"`, so every hyphenated tag (`3.0.0-beta.2`, `3.0.0-alpha.15`,
+# `2.9.0-beta`) deliberately never reaches wordpress.org. Testers can only get an
+# installable build from an asset on the release page — which used to be uploaded by
+# hand, and was duly forgotten for `3.0.0-beta.2`.
+#
+# The build itself is the one `wordpress-plugin-check.yml` already performs and throws
+# away: production dependencies, then `wp dist-archive`, which filters through
+# `.distignore`. Stable releases get the same asset; they are published to
+# wordpress.org as well, but a release page that carries the exact zip is worth having
+# either way.
+#
+# Kept separate from `attach-snapshot.yml`, which reacts to the same event: that one
+# fails on purpose when the detection-snapshot chain was interrupted, and a missing
+# snapshot must not keep the plugin zip off the release.
+#
+# Note on `workflow_dispatch`: GitHub only offers that trigger for workflows that exist
+# on the repository's *default* branch. While the default branch is `master` (the 2.x
+# line) and this file lives on `v3`, the manual re-run is therefore unavailable and only
+# the `release` trigger fires. It starts working, without any change here, once the v3
+# line becomes the default branch.
+
+name: Attach plugin ZIP to release
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag to build the plugin ZIP for and attach it to.
+        required: true
+
+permissions:
+  contents: write        # needed to upload a release asset
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    env:
+      # Both triggers share one code path from here on.
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Checkout
+        # Explicitly the tag, not the branch head: a manual run has to build the code
+        # that was released, and the checkout directory is named after the repository,
+        # which is what gives the archive its `antispam-bee/` top-level directory.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Setup PHP and install production dependencies
+        # The archive ships `vendor/autoload.php` and `vendor/composer/`, so the
+        # autoloader inside it has to be the production one. `vendor/` is not committed,
+        # so this step is what puts it there in the first place.
+        uses: ./.github/actions/setup-php
+        with:
+          php-version: '8.3'
+          tools: 'composer, wp-cli'
+          composer-flags: '--no-dev --optimize-autoloader'
+
+      - name: Verify the plugin version matches the tag
+        # The version is maintained by hand in three places, and the header regularly
+        # lags behind on a working branch. A zip that announces a version other than the
+        # one it was released as would misreport itself to every site that installs it
+        # and defeat WordPress' update check, so this fails loudly instead of publishing
+        # it.
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*$/\1/p' antispam_bee.php | head -1)"
+          if [ -z "$version" ]; then
+            echo "::error::Could not read the version from the antispam_bee.php header."
+            exit 1
+          fi
+          if [ "$version" != "$TAG" ]; then
+            echo "::error::antispam_bee.php declares version $version, but the release is $TAG."
+            exit 1
+          fi
+          echo "Plugin header says $version — matches the tag."
+
+      - name: Install the dist-archive command
+        # `setup-php` seeds Composer's auth with a github-oauth token that Composer
+        # itself rejects as malformed, and `wp package install` registers the package as
+        # a GitHub VCS repository, which forces that token to be used. Isolate Composer
+        # from the ambient auth: a fresh COMPOSER_HOME (no seeded auth.json), an empty
+        # COMPOSER_AUTH and no GITHUB_TOKEN. The package is public, so anonymous access
+        # suffices.
+        env:
+          COMPOSER_HOME: ${{ runner.temp }}/composer-home
+          COMPOSER_AUTH: '{}'
+        run: |
+          unset GITHUB_TOKEN
+          wp package install wp-cli/dist-archive-command:^3.1
+
+      - name: Build the plugin archive
+        # Built outside the workspace so the archive cannot end up inside itself. The
+        # file name reproduces what `wp dist-archive` would pick on its own and what the
+        # manual uploads used, but derives it from the tag rather than the header.
+        run: |
+          set -euo pipefail
+          zip="${{ runner.temp }}/antispam-bee.$TAG.zip"
+          wp dist-archive . "$zip"
+          unzip -l "$zip" | tail -1
+          echo "ZIP_FILE=$zip" >> "$GITHUB_ENV"
+
+      - name: Attach to the release
+        # `--clobber` keeps re-runs and manual backfills idempotent.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" "$ZIP_FILE" --clobber
+          echo "Attached $(basename "$ZIP_FILE") to $TAG."


### PR DESCRIPTION
Pre-releases never reach wordpress.org: `wordpress-plugin-deploy.yml` filters tags with `"!*-*"`, so every hyphenated tag is deliberately skipped. That makes an asset on the GitHub release page the only way for testers to get an installable build — and uploading it was a manual step.

It has already been missed. `3.0.0-beta.1` carries a hand-uploaded `antispam-bee.3.0.0-beta.1.zip` (added a day after the release), while `3.0.0-beta.2` carries only the detection snapshot and no plugin ZIP at all.

## What this does

A new `attach-plugin-zip.yml` builds the distributable archive and attaches it to every published release, pre-release and stable alike. Nothing about it is new work — it is the build `wordpress-plugin-check.yml` already performs and then throws away, combined with the upload pattern `attach-snapshot.yml` already uses:

- `composer install --no-dev --optimize-autoloader`, because the archive ships `vendor/autoload.php` and `vendor/composer/` and the autoloader inside it has to be the production one
- `wp dist-archive`, so the filtering is `.distignore`, exactly as for the wordpress.org build
- `gh release upload "$TAG" … --clobber`, which keeps re-runs idempotent

It is deliberately a separate workflow rather than another job in `attach-snapshot.yml`: that one fails on purpose when the snapshot chain was interrupted, and a missing snapshot must not keep the plugin ZIP off the release.

### Version guard

The version is maintained by hand in three places and the header regularly lags behind on a working branch. A ZIP that announces a version other than the one it was released as would misreport itself to every site that installs it and defeat the update check, so the job compares the `antispam_bee.php` header against the tag and fails loudly rather than publishing a mislabelled archive.

### `setup-php`

The composite action hardcoded `tools: composer`; the build also needs `wp-cli`. It gains an optional `tools` input defaulting to `composer`, so every existing caller keeps its current behaviour.

## Verification

Built locally from the `3.0.0-beta.2` tag with the exact steps the workflow runs:

- 137 KB archive, in the ballpark of the 120 KB `3.0.0-beta.1` asset
- a single `antispam-bee/` top-level directory
- `antispam_bee.php`, `src/`, `assets/`, `readme.txt`, `CHANGELOG.md`, `LICENSE.txt`, `composer.json`, `vendor/autoload.php`, `vendor/composer/`
- no `tests/`, `.github/`, `bin/`, `docs/`, `phpunit*`, `phpcs.xml`, `node_modules/` or other dev files
- the generated `vendor/composer/platform_check.php` floors at PHP 7.4, from the `composer.json` requirement, so the runner’s PHP version does not leak into the archive

The release tag is bound to a `TAG` environment variable and every `run:` block references `"$TAG"` rather than interpolating the expression into the script, matching the hardening in `attach-snapshot.yml`.

## Known limitation

`workflow_dispatch` is included so a release can be re-run or an existing tag backfilled, but GitHub only offers that trigger for workflows that exist on the repository default branch. It therefore stays dormant until this file is present there. The `release` trigger is unaffected: release events run the workflow from the released tag’s own ref.