### PR TITLE
fix: stop advising against page caching for the comment time rule

### DIFF
--- a/src/Rules/TooFastSubmit.php
+++ b/src/Rules/TooFastSubmit.php
@@ -45,6 +45,11 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 					return $field_markup;
 				}
 
+				// The timestamp is set again client-side below, because the rendered value is
+				// frozen for as long as a page cache serves this form. On a client that does
+				// not run the script the rendered value survives, and behind a cache it is
+				// always old enough to clear the limit, so the rule lets the reaction pass
+				// rather than rejecting a visitor whose browser it cannot measure.
 				$unique_id = uniqid( 'antispam-bee-time-' );
 				$script    = sprintf(
 					'<script>(function() {
@@ -132,10 +137,14 @@ class TooFastSubmit extends ControllableBase implements SpamReason {
 	/**
 	 * Get the rule description.
 	 *
+	 * The time the form was opened is measured client-side, so a page cache does not
+	 * stop the rule from working. Without JavaScript the measurement falls back to
+	 * the rendered timestamp, which a cache makes useless.
+	 *
 	 * @return string|null The rule description, or null.
 	 */
 	public static function get_description(): ?string {
-		return __( 'Not recommended when using page caching', 'antispam-bee' );
+		return __( 'Works with page caching only if JavaScript is enabled', 'antispam-bee' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #828, which turned out to describe a bug that was fixed in 2023.

## The premise did not hold

#828 quotes the hidden field and concludes that a page cache freezes the timestamp. `Rules\TooFastSubmit::init()` does not stop there — it also renders an inline script that overwrites the value at page load:

```php
'<script>(function() {
    var time = Math.floor(Date.now() / 1000),
        timeField = document.querySelector(\'input[data-unique-id="%s"]\');

    if (timeField) {
        timeField.value = time;
    }
}());</script>'
```

`src/Rules/TooFastSubmit.php:48-59`, added in 51b98b3 (2023-01-26) — *"Overwrite timestamp in hidden field with JS so that it works with caching (if JS is enabled)"*. The script sits inside the cached markup but runs when the page is **viewed**, so for any JS-capable client the elapsed time reflects when the visitor opened the form. The rule fires normally behind a page cache.

Meanwhile `get_description()` still told users the opposite: *"Not recommended when using page caching"*. That is advice to switch off a rule that works on their site.

## What it says now

> Works with page caching only if JavaScript is enabled

Which is the actual condition, and names the one case that does not work.

## The no-JS case, and why it is not fixed here

Without JavaScript the server-rendered fallback survives, and behind a cache it is always old enough to clear the limit, so the reaction passes. That is a deliberate fail-open, and there is no cheap way out of it:

| Option | Why not |
| --- | --- |
| Render `value="0"` | `verify()` returns `0` for that too (`TooFastSubmit.php:90`), so nothing changes — and it removes a working check on sites with no cache at all |
| Treat a missing or stale value as spam | Fails closed on genuine visitors whose browser cannot be measured |
| Disable the rule when a cache is detected | Gives up the JS path, which works |

#828 puts it well: the field is unsigned and forgeable, so the rule is a speed bump rather than a control. A fix should not cost more than the rule is worth. The limitation is documented in a comment next to the fallback instead.

## Tests

`160 unit tests, 325 assertions`. PHPStan clean, `phpcs` clean.

## Note for the translators

`Works with page caching only if JavaScript is enabled` is a new string replacing an existing one.
