### PR TITLE
fix: bump the database version only after the migration succeeded

### DIFF
--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -103,12 +103,47 @@ class PluginUpdate {
 
 		$version_from_db = get_option( self::DB_VERSION_OPTION_NAME, null );
 
-		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
-
-		if ( null === $version_from_db ) {
-			return;
+		/*
+		 * `null` is a fresh install, which has nothing to migrate. A recorded revision
+		 * that is not a scalar cannot be compared against at all, and since the version
+		 * write below no longer happens first, retrying such a value would now fatal on
+		 * every request rather than once. Neither case has a migration to run, so both
+		 * fall through to the version write.
+		 */
+		if ( is_scalar( $version_from_db ) ) {
+			static::run_migration_steps( (string) $version_from_db );
 		}
 
+		/*
+		 * Only now that every step has completed. Writing the version first would spend
+		 * the one chance a site gets: `db_version_is_current()` would report the database
+		 * as up-to-date on every later request, so a step interrupted by a fatal, a DB
+		 * error, a timeout or a warning promoted to an exception would never run again.
+		 * The legacy option would still be in place while `antispam_bee_options` was
+		 * never written, leaving the site on `Settings::$defaults` — the user's entire
+		 * configuration gone, with no way to retrigger the migration short of editing
+		 * the option by hand.
+		 *
+		 * Deferring the write cannot make the migration run twice within a request,
+		 * because `self::$db_update_triggered` is already set above.
+		 */
+		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+	}
+
+	/**
+	 * Bring an existing install up to the current database revision.
+	 *
+	 * Called for an install that has a recorded revision; a fresh install has nothing
+	 * to migrate and only gets the revision written.
+	 *
+	 * Every step has to tolerate running against an install that already passed it: a
+	 * later step may fail and bring the whole method back on the next request.
+	 *
+	 * @param string $version_from_db The database revision the install is on.
+	 *
+	 * @return void
+	 */
+	protected static function run_migration_steps( string $version_from_db ): void {
 		if ( $version_from_db < 1.01 ) {
 			global $wpdb;
 

--- a/tests/Integration/Handlers/PluginUpdateTest.php
+++ b/tests/Integration/Handlers/PluginUpdateTest.php
@@ -10,7 +10,29 @@ namespace AntispamBee\Tests\Integration\Handlers;
 use AntispamBee\Handlers\PluginUpdate;
 use AntispamBee\Helpers\Settings;
 use ReflectionClass;
+use RuntimeException;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * A migration whose steps fail, standing in for a fatal, a DB error, a timeout or a
+ * warning promoted to an exception. `PluginUpdate` reaches the steps through
+ * `static::`, so overriding them here is enough to drive the failure path.
+ */
+final class FailingPluginUpdate extends PluginUpdate {
+
+	/**
+	 * Fail before anything is migrated.
+	 *
+	 * @param string $version_from_db The database revision the install is on.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException Always.
+	 */
+	protected static function run_migration_steps( string $version_from_db ): void {
+		throw new RuntimeException( 'A migration step failed at revision ' . $version_from_db );
+	}
+}
 
 /**
  * The migration runs once per site and its result becomes the user's configuration,
@@ -261,6 +283,56 @@ final class PluginUpdateTest extends TestCase {
 			$first_run,
 			get_option( Settings::OPTION_NAME ),
 			'Running the update logic twice must not change the migrated options.'
+		);
+	}
+
+	public function test_a_failed_migration_step_leaves_the_database_version_untouched(): void {
+		$this->seed_legacy_install();
+
+		$this->expectException( RuntimeException::class );
+
+		try {
+			FailingPluginUpdate::maybe_run_plugin_updated_logic();
+		} finally {
+			self::assertSame(
+				'1.02',
+				get_option( self::DB_VERSION_OPTION ),
+				'A migration that fails must not leave the database version bumped, or it is never retried.'
+			);
+			self::assertFalse(
+				get_option( Settings::OPTION_NAME ),
+				'Nothing was migrated, so the v3 option must not exist.'
+			);
+		}
+	}
+
+	public function test_a_failed_migration_is_retried_on_the_next_request(): void {
+		$this->seed_legacy_install();
+
+		try {
+			FailingPluginUpdate::maybe_run_plugin_updated_logic();
+		} catch ( RuntimeException $exception ) {
+			unset( $exception );
+		}
+
+		// The next request starts with the per-request guards cleared.
+		$this->reset_plugin_update_state();
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertNotFalse(
+			get_option( Settings::OPTION_NAME ),
+			'The retry has to migrate the options the failed run never wrote.'
+		);
+		self::assertSame(
+			4711,
+			get_option( Settings::OPTION_NAME )['spam_count'],
+			'The retry has to migrate from the legacy option, not from defaults.'
+		);
+		self::assertNotSame(
+			'1.02',
+			get_option( self::DB_VERSION_OPTION ),
+			'A successful retry has to record the current database version.'
 		);
 	}
 


### PR DESCRIPTION
Fixes #798.

`Handlers\PluginUpdate::maybe_update_database()` wrote the new database version **before** it migrated anything, so any error inside the steps spent the one chance a site gets. `db_version_is_current()` then reported the database as up-to-date on every later request and the migration never ran again.

What the user sees: the legacy `antispam_bee` option is still in the database, `antispam_bee_options` was never written, and the site falls back to `Settings::$defaults`. Their entire configuration is gone, silently, with no way to retrigger the migration short of editing `antispambee_db_version` by hand.

#793 removed the most likely trigger — the `Undefined array key` warnings — but not the failure mode. A fatal, a DB error, a timeout, or anything a future step adds still burns the one attempt.

## The change

The `update_option()` call moves after the steps. Deferring it cannot make the migration run twice inside one request: `self::$db_update_triggered` is set before any of it, which is what the issue already noted.

The steps move into `run_migration_steps()`, reached through `static::` rather than `self::`. That is what lets a test supply a failing migration — the suite cannot provoke a real fatal on purpose, and defining a constant to force one leaks into every later test in the process.

## One thing worth reviewing

The `null === $version_from_db` check became `is_scalar( $version_from_db )`.

A fresh install has nothing to migrate, which `null` already covered. But a recorded revision that is not a scalar cannot be compared against at all, and with the version write no longer happening first, such a value would now fatal on **every** request rather than once. Both cases have no migration to run, so both fall through to the version write. Only this class ever writes that option, so this is defence against a corrupted row rather than a case anyone should hit.

## Tests

Two integration tests, in `tests/Integration/Handlers/PluginUpdateTest.php`:

- a failing migration leaves the database version at `1.02` and writes no v3 option
- the next request retries it and migrates from the legacy option, not from defaults

Both fail against the old code — verified by reinstating the early write:

```
...S.........FF                                                   15 / 15 (100%)
Tests: 15, Assertions: 29, Failures: 2.
```

The failure is driven through `FailingPluginUpdate`, a subclass whose `run_migration_steps()` throws, standing in for a fatal, a DB error, a timeout or a promoted warning.

| Suite | Result |
| --- | --- |
| unit | 160 tests, 325 assertions |
| integration, single site | 15 tests, 29 assertions, 1 skipped |
| integration, multisite | 15 tests, 31 assertions |

PHPStan clean, `phpcs` clean.
