### PR TITLE
feat: ship a Fail2Ban filter and guard the spam log format against it

### DIFF
--- a/fail2ban/filter.d/antispam-bee.conf
+++ b/fail2ban/filter.d/antispam-bee.conf
@@ -1,0 +1,26 @@
+# Fail2Ban filter for Antispam Bee
+#
+# Matches the spam log Antispam Bee writes when `ANTISPAM_BEE_LOG_FILE` is defined
+# in `wp-config.php`. One line is appended per detected spam item:
+#
+#   2026-01-15T10:23:45+01:00 ip=192.0.2.42 type=comment post=474 reasons=asb-honeypot
+#
+# Copy this file to /etc/fail2ban/filter.d/antispam-bee.conf and see
+# jail.d/antispam-bee.local for the matching jail.
+#
+# The address is matched by field name rather than by position. `ip` keeps its name
+# and its shape across versions of the log format, so this expression survives new
+# fields being appended, whereas an expression spelling out the whole line does not.
+#
+# The `?` is not optional: without it the expression is greedy and binds to the last
+# `ip=` on the line, so a field whose value happens to contain `ip=` would decide who
+# gets banned. See the Antispam Bee FAQ for a variant that bans honeypot hits only.
+#
+# Fail2Ban strips the timestamp from the line before applying failregex, which is why
+# nothing here matches it.
+
+[Definition]
+
+failregex = ^.*?\bip=<HOST>\b
+
+ignoreregex =

--- a/fail2ban/jail.d/antispam-bee.local
+++ b/fail2ban/jail.d/antispam-bee.local
@@ -1,0 +1,16 @@
+# Example Fail2Ban jail for Antispam Bee
+#
+# Copy to /etc/fail2ban/jail.d/antispam-bee.local and set `logpath` to the file you
+# defined as `ANTISPAM_BEE_LOG_FILE` in `wp-config.php`.
+#
+# Put the log outside the web root, or make sure the web server refuses to serve it:
+# it contains the IP addresses of everyone whose submission was rejected.
+
+[antispam-bee]
+enabled  = true
+filter   = antispam-bee
+logpath  = /var/log/antispam-bee.log
+port     = http,https
+maxretry = 3
+findtime = 1h
+bantime  = 1d

--- a/readme.txt
+++ b/readme.txt
@@ -122,11 +122,18 @@ Yes. Define the constant `ANTISPAM_BEE_LOG_FILE` in your `wp-config.php` with th
 
 The fields are space-separated `key=value` pairs, and every value is free of spaces, so the line can be parsed without quoting. A field that does not apply to a reaction is written as `-`; a form submission, for example, has no post to refer to. `reasons` lists the slugs of the rules that caught the item, so a Fail2Ban jail can ban honeypot hits longer than other detections.
 
-Match the IP with `ip=<HOST>` rather than by position: that field is the one Fail2Ban needs, and it will keep its name and shape in future versions of the format. This filter bans every detected item and keeps working if the rest of the line changes:
+A ready-made filter and an example jail ship with the plugin, in the `fail2ban` directory:
+
+> cp wp-content/plugins/antispam-bee/fail2ban/filter.d/antispam-bee.conf /etc/fail2ban/filter.d/
+> cp wp-content/plugins/antispam-bee/fail2ban/jail.d/antispam-bee.local /etc/fail2ban/jail.d/
+
+Then set `logpath` in the jail to the file you defined as `ANTISPAM_BEE_LOG_FILE` and reload Fail2Ban. Check the result with `fail2ban-regex /path/to/your.log /etc/fail2ban/filter.d/antispam-bee.conf`, which reports how many lines matched.
+
+The shipped filter matches the IP by field name rather than by position, because that field is the one Fail2Ban needs and it keeps its name and shape in future versions of the format:
 
 `failregex = ^.*?\bip=<HOST>\b`
 
-The `?` matters. Without it the expression is greedy and binds to the *last* `ip=` on the line, so a field added by a plugin whose value happens to contain `ip=` would decide who gets banned.
+The `?` matters. Without it the expression is greedy and binds to the *last* `ip=` on the line, so a field added by a plugin whose value happens to contain `ip=` would decide who gets banned. Every release checks this expression against a freshly written log line, so a change to the format that would stop your jail matching cannot pass unnoticed — which is the reason to prefer the shipped filter over a hand-written one.
 
 Because the reasons are logged, a jail can also act on one detection only — banning honeypot hits, which no human ever triggers, for far longer than a content-based match:
 

--- a/tests/Unit/PostProcessors/UpdateSpamLogTest.php
+++ b/tests/Unit/PostProcessors/UpdateSpamLogTest.php
@@ -371,4 +371,161 @@ class UpdateSpamLogTest extends TestCase {
 
 		self::assertCount( 2, array_filter( explode( PHP_EOL, $this->get_log() ) ) );
 	}
+
+	/*
+	 * The tests below guard the shipped Fail2Ban filter against the log format drifting
+	 * away from it. A jail whose filter stops matching reports no error on either side:
+	 * Fail2Ban simply stops banning, and the site owner finds out from a rise in spam.
+	 * These assertions are the only place where such a mismatch becomes visible.
+	 */
+
+	public function test_the_shipped_fail2ban_filter_matches_a_logged_comment(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( '192.0.2.42', $this->host_the_filter_bans_for( $this->get_log() ) );
+	}
+
+	public function test_the_shipped_fail2ban_filter_matches_a_line_full_of_placeholders(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type' => 'form',
+				'ip'            => '192.0.2.43',
+			]
+		);
+
+		self::assertSame(
+			'192.0.2.43',
+			$this->host_the_filter_bans_for( $this->get_log() ),
+			'A reaction with no post and no reasons writes `-` for both, which must not stop the filter matching.'
+		);
+	}
+
+	public function test_the_shipped_fail2ban_filter_matches_an_ipv6_address(): void {
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '2001:db8::42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame( '2001:db8::42', $this->host_the_filter_bans_for( $this->get_log() ) );
+	}
+
+	public function test_the_shipped_fail2ban_filter_survives_a_field_appended_by_a_filter(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					$fields['agent'] = 'some-bot/1.0';
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'192.0.2.42',
+			$this->host_the_filter_bans_for( $this->get_log() ),
+			'The filter is anchored on the field name, so appending a field must not break it.'
+		);
+	}
+
+	public function test_the_shipped_fail2ban_filter_ignores_a_later_field_containing_an_address(): void {
+		expectApplied( 'antispam_bee_spam_log_fields' )
+			->once()
+			->andReturnUsing(
+				static function ( $fields ) {
+					$fields['note'] = 'see-ip=203.0.113.9';
+
+					return $fields;
+				}
+			);
+
+		UpdateSpamLog::process(
+			[
+				'reaction_type'     => 'comment',
+				'comment_post_ID'   => 474,
+				'comment_author_IP' => '192.0.2.42',
+				'asb_reasons'       => [ 'asb-honeypot' ],
+			]
+		);
+
+		self::assertSame(
+			'192.0.2.42',
+			$this->host_the_filter_bans_for( $this->get_log() ),
+			'The expression is non-greedy, so a later field whose value contains `ip=` must not decide who gets banned.'
+		);
+	}
+
+	/**
+	 * Apply the shipped `failregex` to a log line the way Fail2Ban does.
+	 *
+	 * Read from the shipped file rather than restated here, so that editing the filter
+	 * without editing the log format — or the other way round — fails these tests.
+	 *
+	 * Fail2Ban strips the timestamp it detected before applying `failregex`, which is why
+	 * it is removed here too. Verified against the real `fail2ban-regex`, which picks
+	 * `{^LN-BEG}...Zone offset` for this format, so no `datepattern` is needed.
+	 *
+	 * @param string $log The contents of the log file.
+	 *
+	 * @return string|null The address the jail would ban, or null if nothing matched.
+	 */
+	private function host_the_filter_bans_for( string $log ): ?string {
+		$line = trim( $log );
+
+		self::assertNotSame( '', $line, 'Nothing was logged, so there is nothing to match.' );
+		self::assertStringNotContainsString( PHP_EOL, $line, 'The helper expects a single log line.' );
+
+		// What Fail2Ban's date detection consumes: the ISO 8601 timestamp and the space after it.
+		$line = (string) preg_replace( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\s*/', '', $line );
+
+		// `<HOST>` stands for an address in Fail2Ban's own expressions; the character class
+		// covers IPv4 and IPv6 without reimplementing its full definition.
+		$pattern = str_replace( '<HOST>', '(?P<host>[0-9A-Fa-f.:]+)', $this->shipped_failregex() );
+
+		if ( ! preg_match( '/' . $pattern . '/', $line, $matches ) ) {
+			return null;
+		}
+
+		return $matches['host'];
+	}
+
+	/**
+	 * Read `failregex` out of the Fail2Ban filter shipped with the plugin.
+	 *
+	 * @return string The expression.
+	 */
+	private function shipped_failregex(): string {
+		$path = dirname( __DIR__, 3 ) . '/fail2ban/filter.d/antispam-bee.conf';
+
+		self::assertFileExists( $path, 'The Fail2Ban filter has to ship with the plugin.' );
+
+		$contents = (string) file_get_contents( $path );
+
+		self::assertSame(
+			1,
+			preg_match( '/^failregex\s*=\s*(?P<expression>.+)$/m', $contents, $matches ),
+			'The shipped filter has to define exactly one failregex.'
+		);
+
+		return trim( $matches['expression'] );
+	}
 }


### PR DESCRIPTION
Fixes #808.

Antispam Bee wrote a spam log for Fail2Ban but shipped no filter, so every user invented their own regex. #808 makes the case that the important half of the problem is not compatibility but **detectability**: a jail whose filter stops matching reports no error on either side. Fail2Ban simply stops banning, nothing on our side notices, and the site owner finds out from a rise in spam, if at all. A format version token or a promise to keep the line shape would not have changed that.

## What ships

```
fail2ban/filter.d/antispam-bee.conf
fail2ban/jail.d/antispam-bee.local
```

Deliberately **not** under `docs/`, which `.distignore` strips — a filter that does not reach an installed plugin is no filter. The readme FAQ now points at both files with the two `cp` commands and the `fail2ban-regex` invocation to check the result, instead of only describing the expression.

The filter is the short, field-name-anchored form the readme already recommended:

```ini
failregex = ^.*?\bip=<HOST>\b
```

No `datepattern`. I checked that against the real thing rather than assuming it:

```
Failregex: 3 total
|   1) [3] ^.*?\bip=<HOST>\b

Date template hits:
|  [3] {^LN-BEG}ExYear(?P<_sep>[-/.])Month(?P=_sep)Day(?:T|  ?)24hour:Minute:Second(?:[.,]Microseconds)?(?:\s*Zone offset)?

Lines: 3 lines, 0 ignored, 3 matched, 0 missed
```

`fail2ban-regex` autodetects the ISO 8601 timestamp with its offset and strips it before applying `failregex`, so pinning a pattern would only add a way to get it wrong.

## The part that answers the issue

Five tests in `UpdateSpamLogTest` read `failregex` **out of the shipped file**, strip the timestamp the way Fail2Ban does, and apply it to a line written by `UpdateSpamLog::process()` — asserting not merely that something matched but *which address the jail would ban*:

- a logged comment
- a line that is all placeholders (`post=-`, `reasons=-`), which a reaction with no post produces
- an IPv6 address
- a field appended through `antispam_bee_spam_log_fields`, the case that broke the `marked as spam$` regex #797 found
- the greedy trap: a later field whose value contains `ip=` must not decide who gets banned

Because the expression is read from the file and the line from the code, either drifting from the other fails the build. Renaming the `ip` field fails all five:

```
Tests: 5, Assertions: 25, Failures: 5.
```

That is the guard #808 asked for, and the reason the readme now tells users to prefer the shipped filter over a hand-written one.

## Independent of #807

Worth saying, since #808 was filed expecting to wait for it. A `filter.d` file holds only `failregex` and `ignoreregex`; the path lives in the admin's `jail.d` `logpath`. With `ANTISPAM_BEE_LOG_FILE` the path is always explicit, so nothing here needs the constants rework. #807's later `ANTISPAM_BEE_SPAM_LOG=true` generated name stays compatible: it already decided against a date in the file name precisely so Fail2Ban's `logpath` globs keep matching.

## Tests

`165 unit tests, 352 assertions`. PHPStan clean, `phpcs` clean.
