### PR TITLE
chore: declare compatibility with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags:              anti-spam, antispam, comments, spam filter, spam protection
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.7
-* Tested up to:      7.0
+* Tested up to:      7.1
 * Requires PHP:      7.4
 * Stable tag:        3.0.0-beta.2
 * License:           GPLv2 or later


### PR DESCRIPTION
WordPress 7.1 was released, so the `Tested up to` header in `readme.txt` is out of date and the Plugin Check workflow fails.

[Run #56](https://github.com/pluginkollektiv/antispam-bee/actions/runs/32521181410) on `v3`:

> `Tested up to: 7.0 < 7.1. The "Tested up to" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.`

This bumps `readme.txt` to `7.1`. No code change is needed — the check is purely a readme-header assertion.

Nothing else is touched: the `3.0.0 – WIP` changelog section carries no `Maintenance: Tested up to` line, and `.github/workflows/e2e.yml` already covers 7.1 via its `wordpress: 'latest'` matrix entry, with the explicit `7.0` entry now serving as previous-version coverage.
