### PR TITLE
Prepare release 2.11.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ### 2.11.13 ###
 * **English**
-  * Enhancement: New `antispam_bee_honeypot_styles` filter to change the inline styles of the honeypot field — set it to an empty string and load the styles from a file instead if the site uses a strict CSP
-  * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
-  * Fix: Replace `strip_tags()` with `wp_strip_all_tags()` for WordPress-consistent tag stripping in spam notification email body (Refs #534) (Thanks @thisismyurl!)
-  * Fix: The plugin update notice is shown again — the `in_plugin_update_message-` hook used `__FILE__` instead of `plugin_basename( __FILE__ )`, and the notice text was read from an array key with a trailing space (Thanks @thisismyurl!)
-  * Fix: The `ANTISPAM_BEE_LOG_FILE` guard now rejects every invalid path `validate_file()` reports instead of only directory traversal, and validates the path before checking whether it is writable (Thanks @thisismyurl!)
-  * Fix: `_is_mobile()` returns a boolean again instead of the raw `strpos()` result (Thanks @thisismyurl!)
-  * Tweak: Use `wp_get_word_count_type()` when it is available (WordPress 6.2 and newer) to determine the word count type
+  * Enhancement: New filter to change the styles of the honeypot field
+  * Fix: Escape the URL of the settings link (Thanks @thisismyurl!)
+  * Fix: Strip tags in the spam notification email the WordPress way (Thanks @thisismyurl!)
+  * Fix: Show the plugin update notice again (Thanks @thisismyurl!)
+  * Fix: Reject more invalid paths for the spam log file (Thanks @thisismyurl!)
+  * Fix: Return a boolean from the mobile theme check (Thanks @thisismyurl!)
+  * Tweak: Use the WordPress function for the word count type
   * Maintenance: Tested up to WordPress 7.1
 
 * **Deutsch**
-  * Verbesserung: Neuer Filter `antispam_bee_honeypot_styles`, um die Inline-Styles des Honeypot-Feldes anzupassen — mit einem leeren Wert lassen sich die Styles stattdessen aus einer Datei laden, falls die Website eine strikte CSP verwendet
-  * Fix: Einstellungs-Link-URL mit `esc_url()` maskieren (Refs #534) (Danke @thisismyurl!)
-  * Fix: `strip_tags()` durch `wp_strip_all_tags()` für WordPress-konformes Entfernen von Tags im Spam-Benachrichtigungs-E-Mail-Body ersetzen (Refs #534) (Danke @thisismyurl!)
-  * Fix: Der Update-Hinweis des Plugins wird wieder angezeigt — der Hook `in_plugin_update_message-` nutzte `__FILE__` statt `plugin_basename( __FILE__ )`, und der Hinweistext wurde aus einem Array-Schlüssel mit angehängtem Leerzeichen gelesen (Danke @thisismyurl!)
-  * Fix: Die Prüfung von `ANTISPAM_BEE_LOG_FILE` weist nun jeden von `validate_file()` gemeldeten ungültigen Pfad zurück statt nur Directory Traversal und prüft den Pfad, bevor die Schreibbarkeit geprüft wird (Danke @thisismyurl!)
-  * Fix: `_is_mobile()` gibt wieder einen booleschen Wert zurück statt des rohen `strpos()`-Ergebnisses (Danke @thisismyurl!)
-  * Tweak: `wp_get_word_count_type()` wird genutzt, sofern verfügbar (WordPress 6.2 und neuer), um den Typ der Wortzählung zu ermitteln
+  * Verbesserung: Neuer Filter, um die Styles des Honeypot-Feldes anzupassen
+  * Fix: Die URL des Einstellungs-Links wird maskiert (Danke @thisismyurl!)
+  * Fix: Tags in der Spam-Benachrichtigungs-E-Mail werden WordPress-konform entfernt (Danke @thisismyurl!)
+  * Fix: Der Update-Hinweis des Plugins wird wieder angezeigt (Danke @thisismyurl!)
+  * Fix: Mehr ungültige Pfade für die Spam-Log-Datei werden abgelehnt (Danke @thisismyurl!)
+  * Fix: Die Prüfung auf mobile Themes gibt einen booleschen Wert zurück (Danke @thisismyurl!)
+  * Tweak: Die WordPress-Funktion für den Typ der Wortzählung wird genutzt
   * Wartung: Getestet mit WordPress 7.1
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,24 @@
 
 ### 2.11.13 ###
 * **English**
+  * Enhancement: New `antispam_bee_honeypot_styles` filter to change the inline styles of the honeypot field — set it to an empty string and load the styles from a file instead if the site uses a strict CSP
   * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
   * Fix: Replace `strip_tags()` with `wp_strip_all_tags()` for WordPress-consistent tag stripping in spam notification email body (Refs #534) (Thanks @thisismyurl!)
+  * Fix: The plugin update notice is shown again — the `in_plugin_update_message-` hook used `__FILE__` instead of `plugin_basename( __FILE__ )`, and the notice text was read from an array key with a trailing space (Thanks @thisismyurl!)
+  * Fix: The `ANTISPAM_BEE_LOG_FILE` guard now rejects every invalid path `validate_file()` reports instead of only directory traversal, and validates the path before checking whether it is writable (Thanks @thisismyurl!)
+  * Fix: `_is_mobile()` returns a boolean again instead of the raw `strpos()` result (Thanks @thisismyurl!)
+  * Tweak: Use `wp_get_word_count_type()` when it is available (WordPress 6.2 and newer) to determine the word count type
+  * Maintenance: Tested up to WordPress 7.1
 
 * **Deutsch**
+  * Verbesserung: Neuer Filter `antispam_bee_honeypot_styles`, um die Inline-Styles des Honeypot-Feldes anzupassen — mit einem leeren Wert lassen sich die Styles stattdessen aus einer Datei laden, falls die Website eine strikte CSP verwendet
   * Fix: Einstellungs-Link-URL mit `esc_url()` maskieren (Refs #534) (Danke @thisismyurl!)
   * Fix: `strip_tags()` durch `wp_strip_all_tags()` für WordPress-konformes Entfernen von Tags im Spam-Benachrichtigungs-E-Mail-Body ersetzen (Refs #534) (Danke @thisismyurl!)
+  * Fix: Der Update-Hinweis des Plugins wird wieder angezeigt — der Hook `in_plugin_update_message-` nutzte `__FILE__` statt `plugin_basename( __FILE__ )`, und der Hinweistext wurde aus einem Array-Schlüssel mit angehängtem Leerzeichen gelesen (Danke @thisismyurl!)
+  * Fix: Die Prüfung von `ANTISPAM_BEE_LOG_FILE` weist nun jeden von `validate_file()` gemeldeten ungültigen Pfad zurück statt nur Directory Traversal und prüft den Pfad, bevor die Schreibbarkeit geprüft wird (Danke @thisismyurl!)
+  * Fix: `_is_mobile()` gibt wieder einen booleschen Wert zurück statt des rohen `strpos()`-Ergebnisses (Danke @thisismyurl!)
+  * Tweak: `wp_get_word_count_type()` wird genutzt, sofern verfügbar (WordPress 6.2 und neuer), um den Typ der Wortzählung zu ermitteln
+  * Wartung: Getestet mit WordPress 7.1
 
 
 ### 2.11.12 ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.11.13 ###
 * **English**
-  * Enhancement: New filter to change the styles of the honeypot field
+  * Enhancement: New filter `antispam_bee_honeypot_styles` to change the styles of the honeypot field
   * Fix: Escape the URL of the settings link (Thanks @thisismyurl!)
   * Fix: Strip tags in the spam notification email the WordPress way (Thanks @thisismyurl!)
   * Fix: Show the plugin update notice again (Thanks @thisismyurl!)
@@ -12,7 +12,7 @@
   * Maintenance: Tested up to WordPress 7.1
 
 * **Deutsch**
-  * Verbesserung: Neuer Filter, um die Styles des Honeypot-Feldes anzupassen
+  * Verbesserung: Neuer Filter `antispam_bee_honeypot_styles`, um die Styles des Honeypot-Feldes anzupassen
   * Fix: Die URL des Einstellungs-Links wird maskiert (Danke @thisismyurl!)
   * Fix: Tags in der Spam-Benachrichtigungs-E-Mail werden WordPress-konform entfernt (Danke @thisismyurl!)
   * Fix: Der Update-Hinweis des Plugins wird wieder angezeigt (Danke @thisismyurl!)

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -9,7 +9,7 @@
  * Domain Path: /lang
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     2.11.12
+ * Version:     2.11.13
  *
  * @package Antispam Bee
  **/

--- a/readme.txt
+++ b/readme.txt
@@ -99,13 +99,13 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 ## Changelog ##
 
 ### 2.11.13 ###
-  * Enhancement: New `antispam_bee_honeypot_styles` filter to change the inline styles of the honeypot field — set it to an empty string and load the styles from a file instead if the site uses a strict CSP
-  * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
-  * Fix: Replace `strip_tags()` with `wp_strip_all_tags()` for WordPress-consistent tag stripping in spam notification email body (Refs #534) (Thanks @thisismyurl!)
-  * Fix: The plugin update notice is shown again — the `in_plugin_update_message-` hook used `__FILE__` instead of `plugin_basename( __FILE__ )`, and the notice text was read from an array key with a trailing space (Thanks @thisismyurl!)
-  * Fix: The `ANTISPAM_BEE_LOG_FILE` guard now rejects every invalid path `validate_file()` reports instead of only directory traversal, and validates the path before checking whether it is writable (Thanks @thisismyurl!)
-  * Fix: `_is_mobile()` returns a boolean again instead of the raw `strpos()` result (Thanks @thisismyurl!)
-  * Tweak: Use `wp_get_word_count_type()` when it is available (WordPress 6.2 and newer) to determine the word count type
+  * Enhancement: New filter to change the styles of the honeypot field
+  * Fix: Escape the URL of the settings link (Thanks @thisismyurl!)
+  * Fix: Strip tags in the spam notification email the WordPress way (Thanks @thisismyurl!)
+  * Fix: Show the plugin update notice again (Thanks @thisismyurl!)
+  * Fix: Reject more invalid paths for the spam log file (Thanks @thisismyurl!)
+  * Fix: Return a boolean from the mobile theme check (Thanks @thisismyurl!)
+  * Tweak: Use the WordPress function for the word count type
   * Maintenance: Tested up to WordPress 7.1
 
 ### 2.11.12 ###

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags:              anti-spam, antispam, comments, spam filter, spam protection
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
 * Requires at least: 4.6
-* Tested up to:      7.0
+* Tested up to:      7.1
 * Requires PHP:      5.2
 * Stable tag:        2.11.12
 * License:           GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Requires at least: 4.6
 * Tested up to:      7.1
 * Requires PHP:      5.2
-* Stable tag:        2.11.12
+* Stable tag:        2.11.13
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,6 +97,16 @@ A complete documentation is available on [pluginkollektiv.org](https://antispamb
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/445425e4-f5dd-4404-80a7-690999f5bcb3)
 
 ## Changelog ##
+
+### 2.11.13 ###
+  * Enhancement: New `antispam_bee_honeypot_styles` filter to change the inline styles of the honeypot field — set it to an empty string and load the styles from a file instead if the site uses a strict CSP
+  * Fix: Escape settings action link URL with `esc_url()` (Refs #534) (Thanks @thisismyurl!)
+  * Fix: Replace `strip_tags()` with `wp_strip_all_tags()` for WordPress-consistent tag stripping in spam notification email body (Refs #534) (Thanks @thisismyurl!)
+  * Fix: The plugin update notice is shown again — the `in_plugin_update_message-` hook used `__FILE__` instead of `plugin_basename( __FILE__ )`, and the notice text was read from an array key with a trailing space (Thanks @thisismyurl!)
+  * Fix: The `ANTISPAM_BEE_LOG_FILE` guard now rejects every invalid path `validate_file()` reports instead of only directory traversal, and validates the path before checking whether it is writable (Thanks @thisismyurl!)
+  * Fix: `_is_mobile()` returns a boolean again instead of the raw `strpos()` result (Thanks @thisismyurl!)
+  * Tweak: Use `wp_get_word_count_type()` when it is available (WordPress 6.2 and newer) to determine the word count type
+  * Maintenance: Tested up to WordPress 7.1
 
 ### 2.11.12 ###
   * Fix: Fatal error in the dashboard spam counter (Thanks @robertstaddon!)

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,27 @@ Whether Antispam Bee works with a comment form submitted via AJAX depends on how
 
 If the comments are sent to the `admin-ajax.php`, the `antispam_bee_disallow_ajax_calls` filter must be used to run ASB for requests to that file as well. If the script does not send all form data to the file, but only some selected ones, further customization is probably necessary, as [exemplified in this post by Torsten Landsiedel](https://torstenlandsiedel.de/2020/10/04/ajaxifizierte-kommentare-und-antispam-bee/) (in German).
 
+### The honeypot field is visible on my site, which uses a strict Content Security Policy. What can I do? ###
+Antispam Bee hides its honeypot field with inline styles. If your site sends a Content Security Policy that does not allow inline styles (a `style-src` directive without `'unsafe-inline'`), the browser drops those styles and the field becomes visible to your visitors.
+
+Use the `antispam_bee_honeypot_styles` filter to return an empty string, so no inline styles are rendered at all:
+
+> add_filter( 'antispam_bee_honeypot_styles', '__return_empty_string' );
+
+Then hide the field from your own stylesheet, which your policy already allows:
+
+> textarea[aria-label="hp-comment"] {
+>     padding: 0 !important;
+>     clip: rect(1px, 1px, 1px, 1px) !important;
+>     position: absolute !important;
+>     white-space: nowrap !important;
+>     height: 1px !important;
+>     width: 1px !important;
+>     overflow: hidden !important;
+> }
+
+The same filter can also be used to return a modified set of styles instead of an empty one. Do not hide the field with `display: none` or `visibility: hidden`, as many spam bots skip fields hidden that way, which is exactly what the honeypot needs them not to do.
+
 ### Does Antispam Bee store any private user data, and is it compliant with GDPR? ###
 Antispam Bee is developed in Europe. You might have heard we can be a bit nitpicky over here when it comes to privacy. The plugin does not save private user data and is 100% compliant with GDPR.
 
@@ -99,7 +120,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 ## Changelog ##
 
 ### 2.11.13 ###
-  * Enhancement: New filter to change the styles of the honeypot field
+  * Enhancement: New filter `antispam_bee_honeypot_styles` to change the styles of the honeypot field
   * Fix: Escape the URL of the settings link (Thanks @thisismyurl!)
   * Fix: Strip tags in the spam notification email the WordPress way (Thanks @thisismyurl!)
   * Fix: Show the plugin update notice again (Thanks @thisismyurl!)


### PR DESCRIPTION
Prepares the 2.11.13 release. WordPress 7.1 was released, so `readme.txt` needed a `Tested up to` bump; while preparing it, the open `2.11.13` section in `CHANGELOG.md` turned out to list only two of the eight user-facing changes merged since 2.11.12. This branch closes that gap and carries the version bump, so it is ready to tag.

## `CHANGELOG.md`

Six entries (English and German) are added to the existing `### 2.11.13 ###` section:

| Commit | Entry |
| --- | --- |
| 16d4fb3 (#624) | Enhancement: New filter `antispam_bee_honeypot_styles` to change the styles of the honeypot field |
| f620f36 (#669) | Fix: Show the plugin update notice again |
| 8a89f30 + 50bd77c | Fix: Reject more invalid paths for the spam log file (both commits harden the same guard, so they share one entry) |
| 6ea81e2 (#693) | Fix: Return a boolean from the mobile theme check |
| fab8c06 (#403) | Tweak: Use the WordPress function for the word count type |
| — | Maintenance: Tested up to WordPress 7.1 |

`bc0422c` (line-length lint) and `361c41f` (CI ZIP attachment) are not user-facing and are deliberately not logged. Entries follow the existing order (`Enhancement` → `Fix` → `Tweak` → `Maintenance`), and both language blocks have the same eight bullets.

The two entries that were already in the section, for `esc_url()` and `strip_tags()`, have been reworded too, so the whole section reads consistently on wordpress.org. The style applied throughout: one short line per entry saying what changed, plain text without inline code (the filter name is the one exception, since users need to search for it), no `(Refs #…)`, and the `(Thanks @…!)` credits kept.

## `readme.txt`

Beyond the version bump, a new FAQ entry documents the honeypot filter for sites with a strict Content Security Policy — the situation the filter was added for. It explains that a `style-src` directive without `'unsafe-inline'` makes the browser drop the honeypot's inline styles and expose the field, then gives the recipe:

- `add_filter( 'antispam_bee_honeypot_styles', '__return_empty_string' );` to stop rendering inline styles
- the CSS to move into a stylesheet, using the `textarea[aria-label="hp-comment"]` selector (the only distinctive attribute on that element — the honeypot deliberately carries `id="comment"` and `name="comment"` as well, so those would be ambiguous)
- a warning against hiding the field with `display: none` or `visibility: hidden`, which many spam bots skip and which would quietly defeat the honeypot

It is placed after the AJAX question, grouping it with the other developer-facing integration topics, and uses the `>` blockquote convention the Varnish entry already established.

## Release preparation

Following the convention of e0517a7 ("Prepare release 2.11.9"):

- `antispam_bee.php` — `Version:` `2.11.12` → `2.11.13` (the only version string in the PHP; `package.json` carries no `version` field)
- `readme.txt` — `Stable tag:` `2.11.12` → `2.11.13`, and `Tested up to:` `7.0` → `7.1`
- `readme.txt` — new `### 2.11.13 ###` changelog section in the flat English-only form the file uses, byte-identical to the English block in `CHANGELOG.md`
- `readme.txt` — the new FAQ entry described above

No `= 2.11.13 =` entry is added to `== Upgrade Notice ==`, since nothing in this release needs user action. Worth noting that f620f36 repairs `upgrade_notice()`, which never fired before, so such entries will actually be displayed from now on.

After merge, pushing the `2.11.13` tag triggers `wordpress-plugin-deploy.yml` and publishes to WordPress.org.

## Why `2.11.13` and not `2.12.0`

Checked against the 2.8–2.11 history. The new `antispam_bee_honeypot_styles` filter is the only item that could argue for a minor, but new public filters have shipped in patch releases twice before: `antispam_bee_disallow_ajax_calls` in `2.9.4` and `antispam_bee_trusted_ip` in `2.11.5`. Minor bumps here have been reserved for external-service swaps and new settings — `2.10.0` (`ip2country.info` → `iplocate.io`, new honeypot-injection option, +417/−243 across 4 files), `2.9.0` (franc language API, new trackback check), `2.8.0` (stopforumspam.com removal, GDPR IP handling). The code merged since 2.11.12 is 1 file, +46/−19, with no new setting, no service change, no minimum-requirement change and no behaviour change for existing installs.

## Spam-detection comparison

Not run, deliberately. Only fab8c06 touches the detection path — it sits in the language rule and swaps the translated `_x( 'words', … )` string for `wp_get_word_count_type()`. Core's `WP_Locale::get_word_count_type()` reads that very same string and then validates it to one of three values, and Antispam Bee only tests `strpos( $type, 'characters' ) === 0` — so the two are equivalent for every valid value, and the new call is strictly more correct where a translation is invalid.

A comparison run could not have shown this in any case: `asb-detection-compare` applies its option fixture only to 3.x builds (`scripts/ci-compare.sh` guards on `src/`), so both 2.x builds would run on defaults, where `'translate_api' => 0` leaves the language rule disabled and `_is_lang_spam()` never executes.
