### PR TITLE
docs: explain the honeypot styles filter for strict CSP setups

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,31 @@ Whether Antispam Bee works with a comment form submitted via AJAX depends on how
 
 If the comments are sent to the `admin-ajax.php`, the `antispam_bee_disallow_ajax_calls` filter must be used to run ASB for requests to that file as well. If the script does not send all form data to the file, but only some selected ones, further customization is probably necessary, as [exemplified in this post by Torsten Landsiedel](https://torstenlandsiedel.de/2020/10/04/ajaxifizierte-kommentare-und-antispam-bee/) (in German).
 
+### The honeypot field is visible on my site, which uses a strict Content Security Policy. What can I do? ###
+Antispam Bee hides its honeypot field with inline styles. If your site sends a Content Security Policy that does not allow inline styles (a `style-src` directive without `'unsafe-inline'`), the browser drops those styles and the field becomes visible to your visitors.
+
+Use the `antispam_bee_honeypot_styles` filter to return an empty string, so no inline styles are rendered at all:
+
+`
+add_filter( 'antispam_bee_honeypot_styles', '__return_empty_string' );
+`
+
+Then hide the field from your own stylesheet, which your policy already allows:
+
+`
+[aria-label="hp-comment"] {
+    padding: 0 !important;
+    clip: rect(1px, 1px, 1px, 1px) !important;
+    position: absolute !important;
+    white-space: nowrap !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden !important;
+}
+`
+
+The honeypot deliberately copies the id and the name of the real comment field, so `aria-label="hp-comment"` is the attribute to select it by. The same filter can also be used to return a modified set of styles instead of an empty one. Do not hide the field with `display: none` or `visibility: hidden`, as many spam bots skip fields hidden that way, which is exactly what the honeypot needs them not to do.
+
 ### How can I customize the regular expressions used for spam detection? ###
 The "Regular Expression" rule ships with a set of built-in patterns that can be adjusted via the `antispam_bee_patterns` filter. Every pattern is an array of subject fields (`ip`, `host`, `rawurl`, `body`, `email`, `author`, `useragent`) mapped to a regular expression without delimiters. All fields of a pattern must match for a reaction to be flagged as spam.
 


### PR DESCRIPTION
Adds a FAQ entry explaining the `antispam_bee_honeypot_styles` filter for sites with a strict Content Security Policy — the situation the filter was introduced for ([support topic](https://wordpress.org/support/topic/honeypot-textarea-visible-with-strict-csp-header/), referenced in the filter's own docblock in `src/Helpers/Honeypot.php`).

Documentation only, no code change. The counterpart for the 2.x line is in #847.

## What it says

A `style-src` directive without `'unsafe-inline'` makes the browser drop the honeypot's inline styles, so the field becomes visible to visitors. The entry then gives the way out:

- `add_filter( 'antispam_bee_honeypot_styles', '__return_empty_string' );` so no inline styles are rendered
- the equivalent CSS to move into a stylesheet the policy already allows
- a warning against hiding the field with `display: none` or `visibility: hidden`, which many spam bots skip — that would quietly defeat the honeypot

## Notes on the details

The selector is `[aria-label="hp-comment"]`, without an element name on purpose: `Helpers\Honeypot::get_honeypot_field()` copies the id and the name from the real comment field, and builds either a `textarea` or an `input` depending on what the form uses, so the `aria-label` is the only stable hook. The entry says so explicitly, since a reader would otherwise reach for `#comment`.

Placed after the AJAX question, next to the other developer-facing integration topics, and formatted with the same single-backtick code blocks as the neighbouring `antispam_bee_patterns` entry.
