### PR TITLE
fix: tolerate non-array legacy multiselect values in the v2 migration

### DIFF
--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -103,9 +103,17 @@ class PluginUpdate {
 
 		$version_from_db = get_option( self::DB_VERSION_OPTION_NAME, null );
 
-		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
-
+		/*
+		 * The database version is written only after every migration step below has
+		 * succeeded. Raising it up front means a migration that aborts — a legacy
+		 * option of an unexpected shape, a failed query — is never retried, while
+		 * the new option was never written: the site silently falls back to the
+		 * defaults and every 2.x setting is lost. Writing it last turns such a
+		 * failure into a retry on the next request instead.
+		 */
 		if ( null === $version_from_db ) {
+			update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+
 			return;
 		}
 
@@ -230,6 +238,42 @@ class PluginUpdate {
 				$new_options
 			);
 		}
+
+		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+	}
+
+	/**
+	 * Normalize a legacy multiselect option into a list of non-empty strings.
+	 *
+	 * These options were single-value settings before the multiselect rework, so a
+	 * 2.x install that never re-saved its settings can still hold a plain string
+	 * (`'translate_lang' => 'de'`) or an empty string where an array is expected.
+	 * PHP does not coerce a scalar into an `array` parameter even in weak mode, so
+	 * such a value used to raise an uncaught `TypeError` and abort the migration.
+	 * 2.x itself cast at every read site; this restores that tolerance.
+	 *
+	 * @param mixed $values Raw legacy option value.
+	 *
+	 * @return string[] Normalized list of selected values.
+	 */
+	private static function normalize_multiselect_values( $values ): array {
+		if ( ! is_array( $values ) ) {
+			$values = is_scalar( $values ) ? [ $values ] : [];
+		}
+
+		$normalized = [];
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$value = (string) $value;
+			if ( '' !== $value ) {
+				$normalized[] = $value;
+			}
+		}
+
+		return $normalized;
 	}
 
 	/**
@@ -237,12 +281,14 @@ class PluginUpdate {
 	 * Takes an array of selected keys, applies optional mapping and generates a new array using
 	 * these values as keys and "on" as value.
 	 *
-	 * @param string[]                   $values  Selected values.
+	 * @param mixed                      $values  Selected values, in whatever shape the legacy option holds.
 	 * @param array<string, string|null> $mapping Key mapping (optional).
 	 *
 	 * @return array<string, string> Converted array of selected options.
 	 */
-	private static function convert_multiselect_values( array $values, array $mapping = [] ): array {
+	private static function convert_multiselect_values( $values, array $mapping = [] ): array {
+		$values = self::normalize_multiselect_values( $values );
+
 		if ( empty( $values ) ) {
 			return $values;
 		}

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -26,6 +26,13 @@ class PluginUpdateTest extends TestCase {
 	private $written_options = [];
 
 	/**
+	 * Names of the options written, in the order `update_option()` was called.
+	 *
+	 * @var string[]
+	 */
+	private $write_order = [];
+
+	/**
 	 * Reset the memoized migration state and stub the option and plugin-file functions.
 	 *
 	 * @return void
@@ -39,9 +46,12 @@ class PluginUpdateTest extends TestCase {
 		$this->written_options = [];
 
 		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0-beta.1' ] );
+		$this->write_order = [];
+
 		when( 'update_option' )->alias(
 			function ( $name, $value ) {
 				$this->written_options[ $name ] = $value;
+				$this->write_order[]            = $name;
 
 				return true;
 			}
@@ -188,5 +198,113 @@ class PluginUpdateTest extends TestCase {
 
 		$this->assertSame( '', $comment['rule_asb_regexp_active'] );
 		$this->assertSame( 'on', $comment['rule_asb_honeypot_active'], 'The honeypot rule is always migrated as enabled.' );
+	}
+
+	/**
+	 * A legacy `translate_lang` that is still a plain string must not abort the migration.
+	 *
+	 * The option was a single value before the multiselect rework, so a 2.x install that
+	 * never re-saved its settings still holds a string here. Passing it into an `array`
+	 * parameter raised an uncaught `TypeError`.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_translate_lang_does_not_abort_the_migration(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'translate_lang' => 'de',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertArrayHasKey( Settings::OPTION_NAME, $this->written_options );
+		$this->assertSame(
+			[ 'de' => 'on' ],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_lang_spam_allowed'],
+			'A single legacy language is migrated as one selected value.'
+		);
+	}
+
+	/**
+	 * A legacy `ignore_reasons` that is still a plain string must migrate through the mapping.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_ignore_reasons_does_not_abort_the_migration(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'ignore_reasons' => 'css',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			[ 'asb-honeypot' => 'on' ],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['post_processor_asb_delete_for_reasons_reasons'],
+			'The legacy reason slug is mapped to its 3.0 equivalent.'
+		);
+	}
+
+	/**
+	 * An empty legacy multiselect value must migrate to an empty selection, not to an empty key.
+	 *
+	 * @return void
+	 */
+	public function test_empty_scalar_multiselect_migrates_to_an_empty_selection(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'translate_lang' => '',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			[],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_lang_spam_allowed']
+		);
+	}
+
+	/**
+	 * The database version must be raised only after the migrated options were written.
+	 *
+	 * Raising it first means a migration that aborts is never retried while the new option
+	 * was never written, so the site silently falls back to the defaults.
+	 *
+	 * @return void
+	 */
+	public function test_db_version_is_raised_after_the_options_were_written(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'regexp_check' => 1,
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$options_position = array_search( Settings::OPTION_NAME, $this->write_order, true );
+		$version_position = array_search( PluginUpdate::DB_VERSION_OPTION_NAME, $this->write_order, true );
+
+		$this->assertNotFalse( $options_position, 'The migrated options were written.' );
+		$this->assertNotFalse( $version_position, 'The database version was written.' );
+		$this->assertGreaterThan(
+			$options_position,
+			$version_position,
+			'The database version is raised after the migrated options, so an aborted migration is retried.'
+		);
 	}
 }


### PR DESCRIPTION
`translate_lang` and `ignore_reasons` were single-value settings before the multiselect rework, so a 2.x install that never re-saved its settings still holds a plain string there. Both were passed straight into `convert_multiselect_values( array $values, ... )`, and PHP does not coerce a scalar into an `array` parameter even in weak mode, so the migration aborted with an uncaught `TypeError`. 2.x itself cast at every read site — the cast is
what got lost on the way to 3.0.

Because the database version was raised *before* the migration ran, that abort was unrecoverable: `db_version_is_current()` returned true from then on, so the migration was never retried, while  Settings::OPTION_NAME` had never been written. The site silently fell back to `Settings::$defaults` and every 2.x setting — country lists, language filter, delete-vs-flag, cronjob interval, spam counter,  general_delete_data_on_uninstall_active` — was lost. The first request after the update also fataled on the front end, since `Settings::get_options()` is reached from `Comment::init()` on `init`.

`normalize_multiselect_values()` now coerces whatever shape the legacy option holds into a list of non-empty strings, and the database version is written only after every migration step succeeded, so a future failure is retried
instead of silently discarding the site's configuration.

This is the same class of failure as #799, which hardened only *missing* keys: `?? []` triggers on `null`, never on a value of the wrong type.
