### PR TITLE
fix: verify comments that do not arrive through `wp-comments-post.php`

### DIFF
--- a/.github/workflows/spam-detection-comparison.yml
+++ b/.github/workflows/spam-detection-comparison.yml
@@ -151,9 +151,14 @@ jobs:
             -o corpus.sql.gz -d corpus.sql.gz.gpg
           echo "ASB_CORPUS_READY=true" >> "$GITHUB_ENV"
 
+      # v1.9.0 or newer is required: the harness replays the corpus in-process
+      # under WP-CLI, which `Comment::process()` treats as a trusted context, and
+      # only from that version does the harness pin
+      # `antispam_bee_skip_comment_verification` to false. On an older action every
+      # comment comes back unverified and the whole corpus flips to ham.
       - name: Compare spam detection
         id: compare
-        uses: 2ndkauboy/asb-detection-compare@05975dd833642599d023bdce5136fbc90399e411 # v1.8.0
+        uses: 2ndkauboy/asb-detection-compare@fae80ff70deaff7c82a94734e4459402d97c951e # v1.9.0
         with:
           # PR -> the PR's base branch. Manual -> the chosen baseline. Prepare
           # push -> empty, so the baseline is resolved from the branch name.

--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -69,15 +69,62 @@ class Comment extends Reaction {
 			$reaction['ab_spam__invalid_request'] = 1;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		// Everybody can post.
-		if ( strpos( $request_path, 'wp-comments-post.php' ) === false || empty( $_POST ) ) {
+		if ( self::skip_verification( $reaction ) ) {
 			return $reaction;
 		}
 
 		parent::process( $reaction );
 
 		return $reaction;
+	}
+
+	/**
+	 * Whether the spam verification is skipped for this comment.
+	 *
+	 * @param array<string, mixed> $reaction Comment to process.
+	 *
+	 * @return bool Whether to skip the verification.
+	 */
+	private static function skip_verification( array $reaction ): bool {
+		/**
+		 * Filters whether Antispam Bee skips the spam verification for a comment.
+		 *
+		 * Every caller of `wp_new_comment()` reaches this handler through
+		 * `preprocess_comment`, not just the front-end comment form, so the
+		 * decision is made from the request context rather than from the script
+		 * that happens to be executing.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool  $skip     Whether to skip the verification.
+		 * @param array $reaction The comment being processed.
+		 */
+		return (bool) apply_filters( 'antispam_bee_skip_comment_verification', self::is_trusted_context(), $reaction );
+	}
+
+	/**
+	 * Whether the comment originates from a context that is not a public submission.
+	 *
+	 * Comments inserted while WordPress installs, while an importer runs, from
+	 * WP-CLI, or by a moderator working in the admin are not visitor input and are
+	 * therefore not verified.
+	 *
+	 * @return bool Whether the current request is a trusted context.
+	 */
+	private static function is_trusted_context(): bool {
+		if ( wp_installing() ) {
+			return true;
+		}
+
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+			return true;
+		}
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return true;
+		}
+
+		return is_admin() && current_user_can( 'moderate_comments' );
 	}
 
 	/**

--- a/tests/Unit/Handlers/CommentTest.php
+++ b/tests/Unit/Handlers/CommentTest.php
@@ -121,7 +121,7 @@ class CommentTest extends TestCase {
 		self::assertEmpty( $processed, 'The filter should have skipped the verification' );
 		$skip_filter = null;
 
-		// An unparseable request is still flagged.
+		// An unparsable request is still flagged.
 		$processed              = [];
 		$_SERVER['SCRIPT_NAME'] = '';
 		$result                 = Comment::process( $comment );

--- a/tests/Unit/Handlers/CommentTest.php
+++ b/tests/Unit/Handlers/CommentTest.php
@@ -6,12 +6,19 @@ use AntispamBee\Handlers\Comment;
 use AntispamBee\Handlers\Reaction;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use function Brain\Monkey\Functions\stubs;
+use function Brain\Monkey\Functions\when;
 
 /**
  * Unit tests for {@see Comment}.
  */
 class CommentTest extends TestCase {
 
+	/**
+	 * The verification decision is driven by the request context, not by the executing script.
+	 *
+	 * Mockery's `overload:` may only be applied once per process, so the whole contract is
+	 * asserted in a single test method against one overloaded parent.
+	 */
 	public function test_process() {
 		global $_POST;
 		global $_SERVER;
@@ -20,6 +27,10 @@ class CommentTest extends TestCase {
 		$_SERVER = [
 			'REMOTE_ADDR' => '192.0.2.100',
 		];
+
+		$is_admin     = false;
+		$can_moderate = false;
+		$skip_filter  = null;
 
 		stubs(
 			[
@@ -30,12 +41,33 @@ class CommentTest extends TestCase {
 				'wp_unslash'   => function ( $value ) {
 					return $value;
 				},
+				'wp_installing' => false,
 			]
+		);
+
+		when( 'is_admin' )->alias(
+			function () use ( &$is_admin ) {
+				return $is_admin;
+			}
+		);
+		when( 'current_user_can' )->alias(
+			function () use ( &$can_moderate ) {
+				return $can_moderate;
+			}
+		);
+		when( 'apply_filters' )->alias(
+			function ( $hook, $value = null ) use ( &$skip_filter ) {
+				if ( 'antispam_bee_skip_comment_verification' === $hook && null !== $skip_filter ) {
+					return $skip_filter;
+				}
+
+				return $value;
+			}
 		);
 
 		$processed = [];
 		mock( 'overload:' . Reaction::class )
-			->expects( 'process' )
+			->allows( 'process' )
 			->withArgs( function ( $input ) use ( &$processed ) {
 				$processed[] = $input;
 
@@ -44,27 +76,60 @@ class CommentTest extends TestCase {
 
 		$comment = [ 'comment_type' => 'comment' ];
 
-		$result = Comment::process( $comment );
-		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'Unexpected author IP on index.php' );
-		self::assertEmpty( $processed, 'Comment should not have been processed on index.php' );
+		// The front-end comment form is verified, as it always was.
+		$_SERVER['SCRIPT_NAME'] = '/wp-comments-post.php';
+		$_POST                  = [ 'comment' => 'Hello' ];
+		$result                 = Comment::process( $comment );
+		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'Unexpected author IP on wp-comments-post.php' );
+		self::assertCount( 1, $processed, 'Comment should have been processed on wp-comments-post.php' );
 
+		/*
+		 * Every caller of `wp_new_comment()` reaches this handler through
+		 * `preprocess_comment`. XML-RPC's `wp.newComment` is served by /xmlrpc.php with
+		 * an empty $_POST (the payload is a raw XML body), and used to skip every rule.
+		 */
+		$processed              = [];
+		$_SERVER['SCRIPT_NAME'] = '/xmlrpc.php';
+		$_POST                  = [];
+		$result                 = Comment::process( $comment );
+		self::assertCount( 1, $processed, 'Comment submitted over XML-RPC should have been processed' );
+
+		// A REST or headless front-end submission is verified too.
+		$processed              = [];
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$result                 = Comment::process( $comment );
+		self::assertCount( 1, $processed, 'Comment submitted outside the comment form should have been processed' );
+
+		// A moderator working in the admin is not a public submission.
+		$processed    = [];
+		$is_admin     = true;
+		$can_moderate = true;
+		$result       = Comment::process( $comment );
+		self::assertEmpty( $processed, 'Comment created by a moderator in the admin should not have been processed' );
+
+		// A visitor hitting an admin-side endpoint is still verified.
+		$processed    = [];
+		$can_moderate = false;
+		$result       = Comment::process( $comment );
+		self::assertCount( 1, $processed, 'Comment from a non-moderator should have been processed' );
+
+		// The decision is filterable.
+		$processed   = [];
+		$is_admin    = false;
+		$skip_filter = true;
+		$result      = Comment::process( $comment );
+		self::assertEmpty( $processed, 'The filter should have skipped the verification' );
+		$skip_filter = null;
+
+		// An unparseable request is still flagged.
+		$processed              = [];
 		$_SERVER['SCRIPT_NAME'] = '';
 		$result                 = Comment::process( $comment );
-		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'Unexpected author IP on invalid request' );
 		self::assertSame( 1, $result['ab_spam__invalid_request'], 'Invalid request not detected' );
-		self::assertEmpty( $processed, 'Comment should not have been processed on invalid request' );
 
-		$_SERVER['SCRIPT_NAME'] = '/wp-comments-post.php';
-		$result                 = Comment::process( $comment );
-		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'Unexpected author IP on invalid request' );
-		self::assertArrayNotHasKey( 'processed', $result, 'Comment should not have been processed without POST data' );
-
-		$_POST  = 'test me';
-		$result = Comment::process( $comment );
-		self::assertSame( [ $result ], $processed, 'Comment was not processed' );
-
-		$comment = [ 'comment_type' => 'linkback' ];
-		$result  = Comment::process( $comment );
-		self::assertSame( $comment, $result, 'Linkback should not be modified by comment handler' );
+		// A reaction of another type is left untouched.
+		$linkback = [ 'comment_type' => 'linkback' ];
+		$result   = Comment::process( $linkback );
+		self::assertSame( $linkback, $result, 'Linkback should not be modified by comment handler' );
 	}
 }


### PR DESCRIPTION
`Comment::process()` ran the rule engine only when `$_SERVER['SCRIPT_NAME']` contained the literal substring `wp-comments-post.php` and `$_POST` was non-empty. Every other caller of `wp_new_comment()` reaches this handler through `preprocess_comment` and was returned completely unverified.

The reachable case is XML-RPC: `wp.newComment` ends in `wp_new_comment()` with `SCRIPT_NAME` of `/xmlrpc.php` and an empty `$_POST`, because the payload is a raw XML body. Honeypot, regexp, DB spam, country, language, BBCode, gravatar and too-fast-submit therefore never ran. XML-RPC is enabled by default and `wp.newComment` accepts any valid credentials, so any subscriber-level account could post unlimited unverified comments, batched through `system.multicall`; with `xmlrpc_allow_anonymous_comments` enabled it needs no account at all. The same gap applied to headless front-ends and to any plugin calling `wp_new_comment()` from its own endpoint. As a secondary matter `strpos()` is case-sensitive, so `/WP-Comments-Post.php` on a case-insensitive filesystem missed the gate as well.

The decision is now made from the request context instead of from the script that happens to be executing: everything reaching `preprocess_comment` is verified, except installation, importers, WP-CLI and a moderator working in the admin. `antispam_bee_skip_comment_verification` lets a site opt out.

No rule regresses on the newly covered requests. `Honeypot::verify()` only reports spam when `precheck()` set `ab_spam__hidden_field`, which it does solely for `wp-comments-post.php`, and `TooFastSubmit::verify()` returns 0 when `ab_init_time` is absent — so a request without the form fields is not flagged for lacking them.
