### PR TITLE
fix: clean every site of a network on uninstall, not just the first 100

### DIFF
--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -53,20 +53,36 @@ class PluginStateChangeHandler {
 			return;
 		}
 
-		$site_ids = get_sites(
-			[
-				'fields'                 => 'ids',
-				'number'                 => 100,
-				'update_site_cache'      => false,
-				'update_site_meta_cache' => false,
-			]
-		);
+		/*
+		 * Walked in pages rather than with a single unbounded query: uninstall runs in
+		 * one request, and a network can hold far more sites than one query should
+		 * return at once. Removing options does not change the set of sites, so the
+		 * offset stays stable across iterations.
+		 */
+		$batch_size = 100;
+		$offset     = 0;
 
-		foreach ( $site_ids as $site_id ) {
-			switch_to_blog( $site_id );
-			self::maybe_remove_antispam_bee_data();
-			restore_current_blog();
-		}
+		do {
+			$site_ids = get_sites(
+				[
+					'fields'                 => 'ids',
+					'number'                 => $batch_size,
+					'offset'                 => $offset,
+					'update_site_cache'      => false,
+					'update_site_meta_cache' => false,
+				]
+			);
+
+			$found = count( $site_ids );
+
+			foreach ( $site_ids as $site_id ) {
+				switch_to_blog( $site_id );
+				self::maybe_remove_antispam_bee_data();
+				restore_current_blog();
+			}
+
+			$offset += $batch_size;
+		} while ( $found === $batch_size );
 	}
 
 	/**

--- a/tests/Unit/Handlers/PluginStateChangeHandlerTest.php
+++ b/tests/Unit/Handlers/PluginStateChangeHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\GeneralOptions\Uninstall;
+use AntispamBee\Handlers\PluginStateChangeHandler;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\stubs;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see PluginStateChangeHandler}.
+ */
+class PluginStateChangeHandlerTest extends TestCase {
+
+	/**
+	 * Every site of a network is cleaned, not just the first page of them.
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_visits_every_site_of_a_large_network() {
+		$all_sites = range( 1, 250 );
+		$queried   = [];
+		$visited   = [];
+
+		stubs( [ 'is_multisite' => true ] );
+
+		when( 'get_sites' )->alias(
+			function ( array $args ) use ( $all_sites, &$queried ) {
+				$queried[] = $args;
+
+				return array_slice( $all_sites, $args['offset'], $args['number'] );
+			}
+		);
+		when( 'switch_to_blog' )->alias(
+			function ( $site_id ) use ( &$visited ) {
+				$visited[] = $site_id;
+			}
+		);
+		when( 'restore_current_blog' )->justReturn( true );
+		when( 'delete_option' )->justReturn( true );
+
+		mock( 'overload:' . Uninstall::class )
+			->allows( 'is_active' )
+			->andReturn( true );
+
+		PluginStateChangeHandler::uninstall();
+
+		self::assertSame( $all_sites, $visited, 'Every site of the network is cleaned.' );
+		self::assertSame( [ 0, 100, 200 ], array_column( $queried, 'offset' ), 'The site list is walked in pages.' );
+	}
+}


### PR DESCRIPTION
`uninstall()` fetched sites with `'number' => 100` and iterated that single page. On a network with more than 100 sites only the 100 lowest site IDs had `maybe_remove_antispam_bee_data()` applied; every remaining site kept
`antispam_bee_options` and `antispambee_db_version` in its options table after the plugin was deleted.

That silently contradicts `general_delete_data_on_uninstall_active`, which is enabled by default, and it cannot be corrected afterwards because the hook cannot run again once the plugin files are gone. The orphaned rows also resurface as stale configuration on a reinstall: a surviving `antispambee_db_version` makes `db_version_is_current()` skip the migration for those sites.

The site list is now walked in pages until a short page is returned. Uninstall runs in a single request, so paging is preferable to one unbounded query on a very large network; removing options does not change the set of sites, so the offset stays stable across iterations.
