### PR TITLE
fix: carry the linkback user agent into the payload and flatten nested values

### DIFF
--- a/src/Handlers/Linkback.php
+++ b/src/Handlers/Linkback.php
@@ -65,7 +65,7 @@ class Linkback extends Reaction {
 			'body'          => self::scalar( $reaction['comment_content'] ?? '' ),
 			'email'         => '',
 			'author'        => self::scalar( $reaction['comment_author'] ?? '' ),
-			'useragent'     => '',
+			'useragent'     => self::scalar( $reaction['comment_agent'] ?? '' ),
 			'post_id'       => self::scalar( $reaction['comment_post_ID'] ?? null ),
 		];
 	}
@@ -73,14 +73,19 @@ class Linkback extends Reaction {
 	/**
 	 * Normalize a possibly array-valued linkback field to a scalar.
 	 *
+	 * Nested arrays are flattened all the way down, because a single `reset()`
+	 * peels one level only and would hand an array to string-typed sinks such as
+	 * `DataHelper::parse_url()` or `preg_quote()`. An array that holds nothing
+	 * becomes an empty string rather than the `false` that `reset()` returns.
+	 *
 	 * @param mixed $value Raw field value.
-	 * @return mixed First element for arrays, the value otherwise.
+	 * @return mixed First scalar for arrays, the value otherwise.
 	 */
 	private static function scalar( $value ) {
-		if ( is_array( $value ) ) {
-			return reset( $value );
+		while ( is_array( $value ) ) {
+			$value = reset( $value );
 		}
 
-		return $value;
+		return false === $value ? '' : $value;
 	}
 }

--- a/tests/Unit/Handlers/LinkbackTest.php
+++ b/tests/Unit/Handlers/LinkbackTest.php
@@ -78,4 +78,87 @@ class LinkbackTest extends TestCase {
 
 		self::assertSame( '', $payload['author'] );
 	}
+
+	/**
+	 * Core populates comment_agent for linkbacks just as it does for comments, so the
+	 * payload must carry it: RegexpSpam requires a hit for every field of a pattern, so
+	 * an always-empty useragent makes any pattern naming that field unsatisfiable.
+	 */
+	public function test_payload_maps_useragent_from_comment_agent() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => 'Example Blog',
+				'comment_content'    => 'Some excerpt.',
+				'comment_author_url' => 'https://example.com/post/',
+				'comment_author_IP'  => '192.0.2.10',
+				'comment_agent'      => 'WordPress/6.9; https://example.com',
+				'comment_post_ID'    => 1,
+			]
+		);
+
+		self::assertSame(
+			'WordPress/6.9; https://example.com',
+			$payload['useragent'],
+			'useragent must be mapped from comment_agent'
+		);
+	}
+
+	/**
+	 * A missing user agent yields an empty string rather than a warning.
+	 */
+	public function test_payload_useragent_defaults_to_empty() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => 'Example Blog',
+				'comment_content'    => '',
+				'comment_author_url' => '',
+				'comment_author_IP'  => '192.0.2.10',
+				'comment_post_ID'    => 1,
+			]
+		);
+
+		self::assertSame( '', $payload['useragent'] );
+	}
+
+	/**
+	 * A nested array must be flattened all the way down, not peeled one level.
+	 *
+	 * A single reset() leaves an array in place, which then reaches string-typed sinks
+	 * such as DataHelper::parse_url() and raises an uncaught TypeError on the
+	 * unauthenticated trackback path.
+	 */
+	public function test_payload_flattens_nested_array_values() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => [ [ 'Example Blog' ] ],
+				'comment_content'    => '',
+				'comment_author_url' => [ [ 'https://example.com/post/' ] ],
+				'comment_author_IP'  => '192.0.2.10',
+				'comment_post_ID'    => 1,
+			]
+		);
+
+		self::assertSame( 'Example Blog', $payload['author'], 'a nested author must be flattened to a string' );
+		self::assertSame( 'https://example.com/post/', $payload['url'], 'a nested url must be flattened to a string' );
+		self::assertSame( 'example.com', $payload['host'] );
+	}
+
+	/**
+	 * An empty array must normalize to an empty string, not to the false that reset() returns.
+	 */
+	public function test_payload_empty_array_becomes_empty_string() {
+		$payload = self::build_payload(
+			[
+				'comment_author'     => [],
+				'comment_content'    => [],
+				'comment_author_url' => [],
+				'comment_author_IP'  => '192.0.2.10',
+				'comment_post_ID'    => 1,
+			]
+		);
+
+		self::assertSame( '', $payload['author'] );
+		self::assertSame( '', $payload['body'] );
+		self::assertSame( '', $payload['url'] );
+	}
 }


### PR DESCRIPTION
`Linkback::build_payload()` hard-coded `'useragent' => ''` even though core populates `comment_agent` from `HTTP_USER_AGENT` before firing `preprocess_comment` for trackbacks and pingbacks as well. The effect in
`RegexpSpam::verify()` is not just an empty field: the matcher skips empty subjects and then requires a hit for every field of the pattern, so an always-empty useragent makes any pattern naming that field unsatisfiable. This is the same bug class that 9e2f3bc fixed for `author`; the useragent case was carried over unfixed. `'email' => ''` stays as it is — core genuinely leaves `comment_author_email` empty for linkbacks.

`scalar()` also did not honour its own contract. `reset()` peels one level only, so a nested array stayed an array and reached string-typed sinks: `DataHelper::parse_url()` and `preg_quote()` both raise an uncaught `TypeError` on an array, and since this runs inside a `preprocess_comment` filter on the unauthenticated trackback path, that is a fatal that aborts comment insertion. `reset( [] )` also returns `false`, putting a boolean where the payload contract says string. Values are now flattened all the way down and an empty array normalizes to an empty string.

Current core flattens these fields before `wp_new_comment()`, so the nested case is reachable through other plugins and importers rather than over HTTP — which is exactly the scenario the helper's docblock says it exists to handle.
