### PR TITLE
fix: validate the components registered through `antispam_bee_general_options`

### DIFF
--- a/src/Handlers/GeneralOptions.php
+++ b/src/Handlers/GeneralOptions.php
@@ -7,28 +7,13 @@
 
 namespace AntispamBee\Handlers;
 
+use AntispamBee\Helpers\ComponentsHelper;
 use AntispamBee\Interfaces\Controllable;
 
 /**
  * GeneralOptions handler.
  */
 class GeneralOptions {
-
-	/**
-	 * Reaction type.
-	 *
-	 * @var string
-	 */
-	protected $reaction_type;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string $reaction_type Reaction type.
-	 */
-	public function __construct( string $reaction_type ) {
-		$this->reaction_type = $reaction_type;
-	}
 
 	/**
 	 * Get the controllable items for this option.
@@ -52,6 +37,22 @@ class GeneralOptions {
 		 *
 		 * @param array $options A list of controllable general options.
 		 */
-		return apply_filters( 'antispam_bee_general_options', [] );
+		$options = apply_filters( 'antispam_bee_general_options', [] );
+
+		/*
+		 * Validated like the Rules and PostProcessors handlers validate theirs. This is
+		 * a public extension point, so the entries have to be checked before they reach
+		 * Sanitize::sanitize_controllables(), which calls static methods on them: an
+		 * entry that is not a Controllable would raise an uncaught Error inside the
+		 * `register_setting()` sanitize callback, breaking both the saving and the
+		 * rendering of the settings screen.
+		 */
+		return ComponentsHelper::filter(
+			$options,
+			[
+				'reaction_type' => $reaction_type,
+				'implements'    => Controllable::class,
+			]
+		);
 	}
 }

--- a/tests/Unit/Handlers/GeneralOptionsTest.php
+++ b/tests/Unit/Handlers/GeneralOptionsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\GeneralOptions\Statistics;
+use AntispamBee\Handlers\GeneralOptions;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Unit tests for {@see GeneralOptions}.
+ */
+class GeneralOptionsTest extends TestCase {
+
+	/**
+	 * Stub `apply_filters()` so the extension point returns a fixed list.
+	 *
+	 * @param array<mixed> $options Entries the filter yields.
+	 *
+	 * @return void
+	 */
+	private function stub_registered_options( array $options ): void {
+		when( 'apply_filters' )->alias(
+			function ( $hook, $value = null ) use ( $options ) {
+				return 'antispam_bee_general_options' === $hook ? $options : $value;
+			}
+		);
+	}
+
+	/**
+	 * An entry that does not implement Controllable must not be returned.
+	 *
+	 * Sanitize::sanitize_controllables() calls static methods on every entry, so an
+	 * unvalidated value raises an uncaught Error inside the `register_setting()`
+	 * sanitize callback.
+	 *
+	 * @return void
+	 */
+	public function test_entries_that_are_not_controllable_are_dropped(): void {
+		when( '_doing_it_wrong' )->justReturn( null );
+
+		$this->stub_registered_options(
+			[
+				Statistics::class,
+				\stdClass::class,
+			]
+		);
+
+		self::assertSame( [ Statistics::class ], GeneralOptions::get_controllables() );
+	}
+
+	/**
+	 * A reaction type other than `general` yields no options at all.
+	 *
+	 * @return void
+	 */
+	public function test_other_reaction_types_yield_no_options(): void {
+		$this->stub_registered_options( [ Statistics::class ] );
+
+		self::assertSame( [], GeneralOptions::get_controllables( 'comment' ) );
+	}
+}


### PR DESCRIPTION
`GeneralOptions::get_controllables()` returned the filter output verbatim, while both sibling handlers — `Rules` and `PostProcessors` — route theirs through `ComponentsHelper::filter()`. Three guarantees were missing here.

Interface validation: the filter is a documented public extension point, so third parties are invited to push values into it. An entry that is not a `Controllable` class-string reaches `Sanitize::sanitize_controllables()`, which immediately calls
`get_option_name()` and `get_options()` on it. That code runs as the `register_setting()` sanitize callback, so a bad entry means saving any setting raises an uncaught Error, and `SettingsPage::populate_tabs()` fatals on `admin_init` as well — the whole settings screen goes down.

The reserved-slug guard: `ComponentsHelper::filter()` drops third-party components whose slug starts with `asb-`. General options were exempt from that.

Supported-type filtering: the render path re-applies it at `SettingsPage.php:171` but the sanitize path did not, so the two lists could disagree — and `sanitize_controllables()` deletes the stored `active` flag of any controllable whose key is absent from the submitted form, so an option present in one list but not the other lost its setting on every save.

All four in-plugin general options declare `get_supported_types() === ['general']`, so nothing misbehaves today; this closes the gap on the public API. The unused constructor and `$reaction_type` property are dropped as well — the class is only ever used statically.
