### PR TITLE
fix: stop overwriting a supplied comment IP and drop the inert invalid-request key

### DIFF
--- a/src/Handlers/Comment.php
+++ b/src/Handlers/Comment.php
@@ -60,17 +60,25 @@ class Comment extends Reaction {
 			return $reaction;
 		}
 
-		$reaction['comment_author_IP'] = IpHelper::get_client_ip();
-
-		$request_uri  = isset( $_SERVER['SCRIPT_NAME'] ) ? esc_url_raw( wp_unslash( $_SERVER['SCRIPT_NAME'] ) ) : '';
-		$request_path = DataHelper::parse_url( $request_uri, 'path' );
-
-		if ( empty( $request_path ) ) {
-			$reaction['ab_spam__invalid_request'] = 1;
-		}
-
 		if ( self::skip_verification( $reaction ) ) {
 			return $reaction;
+		}
+
+		/*
+		 * Only filled in when the caller did not supply one. Core does the same
+		 * (`wp_new_comment()` falls back to REMOTE_ADDR only for an absent value), so
+		 * importers, migrations and plugins that pass a historical or explicit IP keep
+		 * it. An unusable REMOTE_ADDR is left alone rather than written back as an
+		 * empty string: `IpHelper::get_client_ip()` returns '' for anything
+		 * `FILTER_VALIDATE_IP` rejects, such as a zone-scoped IPv6 address, and storing
+		 * that would drop an IP core would have kept.
+		 */
+		if ( empty( $reaction['comment_author_IP'] ) ) {
+			$client_ip = IpHelper::get_client_ip();
+
+			if ( '' !== $client_ip ) {
+				$reaction['comment_author_IP'] = $client_ip;
+			}
 		}
 
 		parent::process( $reaction );

--- a/tests/Unit/Handlers/CommentTest.php
+++ b/tests/Unit/Handlers/CommentTest.php
@@ -80,7 +80,7 @@ class CommentTest extends TestCase {
 		$_SERVER['SCRIPT_NAME'] = '/wp-comments-post.php';
 		$_POST                  = [ 'comment' => 'Hello' ];
 		$result                 = Comment::process( $comment );
-		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'Unexpected author IP on wp-comments-post.php' );
+		self::assertSame( '192.0.2.100', $result['comment_author_IP'], 'The client IP fills an empty author IP' );
 		self::assertCount( 1, $processed, 'Comment should have been processed on wp-comments-post.php' );
 
 		/*
@@ -121,11 +121,30 @@ class CommentTest extends TestCase {
 		self::assertEmpty( $processed, 'The filter should have skipped the verification' );
 		$skip_filter = null;
 
-		// An unparsable request is still flagged.
+		/*
+		 * An IP supplied by the caller survives. Core only falls back to REMOTE_ADDR for
+		 * an absent value, so importers and plugins passing a historical IP must keep it.
+		 */
+		$processed = [];
+		$result    = Comment::process(
+			[
+				'comment_type'      => 'comment',
+				'comment_author_IP' => '198.51.100.7',
+			]
+		);
+		self::assertSame( '198.51.100.7', $result['comment_author_IP'], 'A supplied IP must not be overwritten' );
+
+		// An unusable REMOTE_ADDR is left alone instead of blanking the field.
 		$processed              = [];
-		$_SERVER['SCRIPT_NAME'] = '';
-		$result                 = Comment::process( $comment );
-		self::assertSame( 1, $result['ab_spam__invalid_request'], 'Invalid request not detected' );
+		$_SERVER['REMOTE_ADDR'] = 'fe80::1%eth0';
+		$result                 = Comment::process(
+			[
+				'comment_type'      => 'comment',
+				'comment_author_IP' => '203.0.113.9',
+			]
+		);
+		self::assertSame( '203.0.113.9', $result['comment_author_IP'], 'A valid IP must not be clobbered with an empty string' );
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.100';
 
 		// A reaction of another type is left untouched.
 		$linkback = [ 'comment_type' => 'linkback' ];


### PR DESCRIPTION
Two leftovers in `Comment::process()`.

`$reaction['ab_spam__invalid_request']` was written but never read. The rule that carries this name, `Rules\InvalidRequest::verify()`, reads `$_POST['ab_spam__invalid_request']`, and `build_payload()` does not copy the key into the normalized payload, so nothing consumed it. It is removed rather than wired up to the channel the rule reads: "SCRIPT_NAME did not parse, therefore definitive spam" is not a heuristic worth acting on now that the handler deliberately serves entry points other than the comment form, where SCRIPT_NAME semantics vary by SAPI. The rule keeps working through `Honeypot::precheck()`, which sets that key for real comment-form submissions missing the secret field — the meaningful signal.

`comment_author_IP` was replaced unconditionally, for every comment-type reaction, before the handler had decided whether it processes the reaction at all. Because the mutated array is what goes back to `preprocess_comment`, the overwrite applied even to comments the plugin never classifies. Core only falls back to `REMOTE_ADDR` for an absent value, so importers, migrations and plugins passing an explicit or historical IP had it silently replaced with the IP of whoever ran the request — and ASB hooks at priority 1, so it won against later filters. `IpHelper::get_client_ip()` also returns '' for anything `FILTER_VALIDATE_IP` rejects, such as a zone-scoped IPv6 address, so a value core would have stored could be blanked, degrading both core's disallowed-list IP matching and the `DbSpam` rule.

The assignment now happens after the skip check, fills only an empty value, and never writes an empty string over an existing one.
