### PR TITLE
fix: bound, surface and contain a failing v2 migration

### DIFF
--- a/src/Admin/MigrationFailureNotice.php
+++ b/src/Admin/MigrationFailureNotice.php
@@ -67,10 +67,13 @@ class MigrationFailureNotice {
 			esc_html__( 'Antispam Bee could not migrate your settings.', 'antispam-bee' )
 		);
 
-		printf(
-			'<p>%s</p>',
-			esc_html__( 'The plugin is currently running with its default settings. Your previous settings have not been lost — they are still stored in the database and will be applied as soon as the migration succeeds.', 'antispam-bee' )
-		);
+		if ( PluginUpdate::has_stored_settings() ) {
+			$intro = __( 'The plugin is running with the settings currently stored. Your previous settings have not been lost — they are still in the database, unmigrated.', 'antispam-bee' );
+		} else {
+			$intro = __( 'The plugin is currently running with its default settings. Your previous settings have not been lost — they are still stored in the database and will be applied as soon as the migration succeeds.', 'antispam-bee' );
+		}
+
+		printf( '<p>%s</p>', esc_html( $intro ) );
 
 		if ( '' !== $state['message'] ) {
 			printf(
@@ -79,17 +82,32 @@ class MigrationFailureNotice {
 			);
 		}
 
+		/*
+		 * The wording has to follow what the button actually does. Once settings are
+		 * stored — because the user gave up and configured the plugin by hand — a retry
+		 * can only get the old settings back by replacing them, and saying "retry" while
+		 * quietly leaving them in place would be a lie: the migration would skip its work
+		 * and simply report success.
+		 */
+		if ( PluginUpdate::has_stored_settings() ) {
+			$retry_label = __( 'Discard the current settings and migrate again', 'antispam-bee' );
+			$explanation = __( 'Migrating again replaces the settings currently stored with the result of migrating your previous ones. Choose “Keep the current settings” to stop retrying and leave your settings exactly as they are.', 'antispam-bee' );
+		} else {
+			$retry_label = __( 'Migrate again', 'antispam-bee' );
+			$explanation = __( 'Choose “Keep the current settings” to stop retrying for good and configure the plugin yourself.', 'antispam-bee' );
+		}
+
 		printf(
 			'<p><a class="button button-primary" href="%s">%s</a> <a class="button" href="%s">%s</a></p>',
 			esc_url( $retry_url ),
-			esc_html__( 'Retry migration', 'antispam-bee' ),
+			esc_html( $retry_label ),
 			esc_url( $dismiss_url ),
 			esc_html__( 'Keep the current settings', 'antispam-bee' )
 		);
 
 		printf(
 			'<p class="description">%s</p>',
-			esc_html__( 'Retrying never overwrites settings you have already saved. Choose “Keep the current settings” to stop retrying for good and configure the plugin yourself.', 'antispam-bee' )
+			esc_html( $explanation )
 		);
 
 		echo '</div>';
@@ -104,7 +122,7 @@ class MigrationFailureNotice {
 	public static function handle_retry(): void {
 		self::authorize( self::RETRY_ACTION );
 
-		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
+		PluginUpdate::reset_for_retry();
 
 		self::redirect_back();
 	}

--- a/src/Admin/MigrationFailureNotice.php
+++ b/src/Admin/MigrationFailureNotice.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Surface a migration that gave up, and offer a way to retry it.
+ *
+ * @package AntispamBee\Admin
+ */
+
+namespace AntispamBee\Admin;
+
+use AntispamBee\Handlers\PluginUpdate;
+
+/**
+ * Migration failure notice handler.
+ */
+class MigrationFailureNotice {
+
+	/**
+	 * Action name used for the manual retry request.
+	 */
+	const RETRY_ACTION = 'antispam_bee_retry_migration';
+
+	/**
+	 * Register the notice and the retry handler.
+	 */
+	public static function init(): void {
+		add_action( 'admin_notices', [ __CLASS__, 'render' ] );
+		add_action( 'admin_post_' . self::RETRY_ACTION, [ __CLASS__, 'handle_retry' ] );
+	}
+
+	/**
+	 * Render the notice once the migration has given up.
+	 *
+	 * Shown until the migration succeeds, because a site running on default settings
+	 * while its real configuration sits unmigrated is not a state to let pass quietly:
+	 * rules the user turned off are active again, and rules they relied on may not be.
+	 */
+	public static function render(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$state = PluginUpdate::get_failure_state();
+		if ( $state['attempts'] < PluginUpdate::MAX_UPDATE_ATTEMPTS ) {
+			return;
+		}
+
+		$retry_url = wp_nonce_url(
+			admin_url( 'admin-post.php?action=' . self::RETRY_ACTION ),
+			self::RETRY_ACTION
+		);
+
+		echo '<div class="notice notice-error">';
+
+		printf(
+			'<p><strong>%s</strong></p>',
+			esc_html__( 'Antispam Bee could not migrate your settings.', 'antispam-bee' )
+		);
+
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'The plugin is currently running with its default settings. Your previous settings have not been lost — they are still stored in the database and will be applied as soon as the migration succeeds.', 'antispam-bee' )
+		);
+
+		if ( '' !== $state['message'] ) {
+			printf(
+				'<p><code>%s</code></p>',
+				esc_html( $state['message'] )
+			);
+		}
+
+		printf(
+			'<p><a class="button button-primary" href="%s">%s</a></p>',
+			esc_url( $retry_url ),
+			esc_html__( 'Retry migration', 'antispam-bee' )
+		);
+
+		echo '</div>';
+	}
+
+	/**
+	 * Reset the failure state so the migration is attempted again.
+	 *
+	 * Clearing the state is all it takes: the database version is still the old one,
+	 * so the next read of the settings runs the migration with a fresh set of attempts.
+	 */
+	public static function handle_retry(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You are not allowed to do this.', 'antispam-bee' ), '', [ 'response' => 403 ] );
+		}
+
+		check_admin_referer( self::RETRY_ACTION );
+
+		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
+
+		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url() );
+		exit;
+	}
+}

--- a/src/Admin/MigrationFailureNotice.php
+++ b/src/Admin/MigrationFailureNotice.php
@@ -161,7 +161,7 @@ class MigrationFailureNotice {
 	private static function redirect_back(): void {
 		$referer = wp_get_referer();
 
-		wp_safe_redirect( $referer ? $referer : admin_url() );
+		wp_safe_redirect( $referer ?: admin_url() );
 		exit;
 	}
 }

--- a/src/Admin/MigrationFailureNotice.php
+++ b/src/Admin/MigrationFailureNotice.php
@@ -20,11 +20,17 @@ class MigrationFailureNotice {
 	const RETRY_ACTION = 'antispam_bee_retry_migration';
 
 	/**
-	 * Register the notice and the retry handler.
+	 * Action name used to stop retrying and keep the current settings.
+	 */
+	const DISMISS_ACTION = 'antispam_bee_dismiss_migration';
+
+	/**
+	 * Register the notice and its handlers.
 	 */
 	public static function init(): void {
 		add_action( 'admin_notices', [ __CLASS__, 'render' ] );
 		add_action( 'admin_post_' . self::RETRY_ACTION, [ __CLASS__, 'handle_retry' ] );
+		add_action( 'admin_post_' . self::DISMISS_ACTION, [ __CLASS__, 'handle_dismiss' ] );
 	}
 
 	/**
@@ -49,6 +55,11 @@ class MigrationFailureNotice {
 			self::RETRY_ACTION
 		);
 
+		$dismiss_url = wp_nonce_url(
+			admin_url( 'admin-post.php?action=' . self::DISMISS_ACTION ),
+			self::DISMISS_ACTION
+		);
+
 		echo '<div class="notice notice-error">';
 
 		printf(
@@ -69,9 +80,16 @@ class MigrationFailureNotice {
 		}
 
 		printf(
-			'<p><a class="button button-primary" href="%s">%s</a></p>',
+			'<p><a class="button button-primary" href="%s">%s</a> <a class="button" href="%s">%s</a></p>',
 			esc_url( $retry_url ),
-			esc_html__( 'Retry migration', 'antispam-bee' )
+			esc_html__( 'Retry migration', 'antispam-bee' ),
+			esc_url( $dismiss_url ),
+			esc_html__( 'Keep the current settings', 'antispam-bee' )
+		);
+
+		printf(
+			'<p class="description">%s</p>',
+			esc_html__( 'Retrying never overwrites settings you have already saved. Choose “Keep the current settings” to stop retrying for good and configure the plugin yourself.', 'antispam-bee' )
 		);
 
 		echo '</div>';
@@ -84,15 +102,48 @@ class MigrationFailureNotice {
 	 * so the next read of the settings runs the migration with a fresh set of attempts.
 	 */
 	public static function handle_retry(): void {
+		self::authorize( self::RETRY_ACTION );
+
+		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
+
+		self::redirect_back();
+	}
+
+	/**
+	 * Stop retrying and keep whatever is configured now.
+	 *
+	 * For a site whose migration cannot be made to work: the user configures the
+	 * plugin by hand and takes the notice away for good. Nothing is overwritten —
+	 * the database is simply recorded as migrated.
+	 */
+	public static function handle_dismiss(): void {
+		self::authorize( self::DISMISS_ACTION );
+
+		PluginUpdate::mark_as_migrated();
+
+		self::redirect_back();
+	}
+
+	/**
+	 * Make sure the current request may act on the migration state.
+	 *
+	 * @param string $action The action being performed.
+	 */
+	private static function authorize( string $action ): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'You are not allowed to do this.', 'antispam-bee' ), '', [ 'response' => 403 ] );
 		}
 
-		check_admin_referer( self::RETRY_ACTION );
+		check_admin_referer( $action );
+	}
 
-		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
+	/**
+	 * Return to the page the notice was shown on.
+	 */
+	private static function redirect_back(): void {
+		$referer = wp_get_referer();
 
-		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url() );
+		wp_safe_redirect( $referer ? $referer : admin_url() );
 		exit;
 	}
 }

--- a/src/Handlers/PluginStateChangeHandler.php
+++ b/src/Handlers/PluginStateChangeHandler.php
@@ -81,6 +81,7 @@ class PluginStateChangeHandler {
 
 		delete_option( Settings::OPTION_NAME );
 		delete_option( PluginUpdate::DB_VERSION_OPTION_NAME );
+		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
 		// delete_option( 'antispam_bee' );
 		// See https://github.com/pluginkollektiv/antispam-bee/issues/744 - enable on stable 3.0 release.
 

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -8,6 +8,7 @@
 namespace AntispamBee\Handlers;
 
 use AntispamBee\Helpers\Settings;
+use Throwable;
 use const AntispamBee\MAIN_PLUGIN_FILE;
 
 /**
@@ -18,6 +19,16 @@ class PluginUpdate {
 	 * Name of the option holding the database version.
 	 */
 	const DB_VERSION_OPTION_NAME = 'antispambee_db_version';
+
+	/**
+	 * Name of the option holding the state of failed migration attempts.
+	 */
+	const FAILURE_OPTION_NAME = 'antispambee_db_update_failures';
+
+	/**
+	 * How often a migration to the same plugin version may be attempted before giving up.
+	 */
+	const MAX_UPDATE_ATTEMPTS = 3;
 
 	/**
 	 * Mapping of spam reason keys (key is pre-3.0, value 3.0 and later).
@@ -52,6 +63,13 @@ class PluginUpdate {
 	 * @var bool|null
 	 */
 	private static $db_version_is_current = null;
+
+	/**
+	 * Register the hooks of this handler.
+	 */
+	public static function init(): void {
+		add_action( 'admin_init', [ __CLASS__, 'maybe_run_plugin_updated_logic' ] );
+	}
 
 	/**
 	 * Run after Antispam Bee was upgraded.
@@ -96,10 +114,21 @@ class PluginUpdate {
 
 	/**
 	 * Make database changes, if needed.
+	 *
+	 * Runs for the current site only. In a multisite network every site migrates
+	 * lazily and independently, the first time something on that site reads a
+	 * setting — there is deliberately no network-wide loop, because migrating
+	 * thousands of sites synchronously inside one request cannot work. The attempt
+	 * cap below bounds the cost of a failing migration per site.
 	 */
 	private static function maybe_update_database(): void {
 		// Prevent further update triggers during the same request that run before the DB version is updated.
 		self::$db_update_triggered = true;
+
+		$failures = self::get_failure_state();
+		if ( $failures['attempts'] >= self::MAX_UPDATE_ATTEMPTS ) {
+			return;
+		}
 
 		$version_from_db = get_option( self::DB_VERSION_OPTION_NAME, null );
 
@@ -108,10 +137,34 @@ class PluginUpdate {
 		 * that is not a scalar cannot be compared against at all, and since the version
 		 * write below no longer happens first, retrying such a value would now fatal on
 		 * every request rather than once. Neither case has a migration to run, so both
-		 * fall through to the version write.
+		 * fall through to the version write without spending an attempt.
 		 */
 		if ( is_scalar( $version_from_db ) ) {
-			static::run_migration_steps( (string) $version_from_db );
+			/*
+			 * Recorded before the attempt, not after it: a step killed by a timeout or a
+			 * true fatal never returns here, so a counter raised afterwards would stay at
+			 * zero and the site would retry — and fatal — on every single request, forever.
+			 * Burning the attempt up front is what makes the cap hold for uncatchable
+			 * failures too.
+			 */
+			++$failures['attempts'];
+			self::save_failure_state( $failures );
+
+			try {
+				static::run_migration_steps( (string) $version_from_db );
+			} catch ( Throwable $throwable ) {
+				/*
+				 * Catchable failures are recorded and swallowed rather than propagated. The
+				 * request then continues on `Settings::$defaults`, which for a comment being
+				 * submitted means slightly wrong spam settings — far better than the fatal a
+				 * rethrow would turn every commenting visitor's request into.
+				 */
+				$failures['message'] = $throwable->getMessage();
+				$failures['time']    = time();
+				self::save_failure_state( $failures );
+
+				return;
+			}
 		}
 
 		/*
@@ -127,7 +180,43 @@ class PluginUpdate {
 		 * Deferring the write cannot make the migration run twice within a request,
 		 * because `self::$db_update_triggered` is already set above.
 		 */
+		delete_option( self::FAILURE_OPTION_NAME );
 		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+	}
+
+	/**
+	 * Read the recorded state of failed migration attempts.
+	 *
+	 * State recorded against a different plugin version is discarded: a release that
+	 * ships a fix for whatever made the migration fail has to get its own attempts,
+	 * so a site that gave up recovers on update instead of needing a manual retry.
+	 *
+	 * @return array{version: string, attempts: int, message: string, time: int} The failure state.
+	 */
+	public static function get_failure_state(): array {
+		$version = self::get_plugin_version();
+		$default = [
+			'version'  => $version,
+			'attempts' => 0,
+			'message'  => '',
+			'time'     => 0,
+		];
+
+		$state = get_option( self::FAILURE_OPTION_NAME, null );
+		if ( ! is_array( $state ) || ( $state['version'] ?? null ) !== $version ) {
+			return $default;
+		}
+
+		return array_merge( $default, $state );
+	}
+
+	/**
+	 * Persist the state of failed migration attempts.
+	 *
+	 * @param array{version: string, attempts: int, message: string, time: int} $state The failure state.
+	 */
+	private static function save_failure_state( array $state ): void {
+		update_option( self::FAILURE_OPTION_NAME, $state );
 	}
 
 	/**
@@ -190,6 +279,20 @@ class PluginUpdate {
 			'3.0.0-alpha.1',
 			'<'
 		) ) {
+			/*
+			 * This step creates `antispam_bee_options` out of the legacy option, so anything
+			 * already stored under that name is either a run that got this far or settings the
+			 * user saved by hand while the database version was still stale — and rebuilding
+			 * over either would throw away their configuration. The write below is the step's
+			 * last action, so a run cut short left nothing behind and a present array is always
+			 * one of those two. A stored value that is not an array is corrupt, not a
+			 * configuration, and is replaced.
+			 */
+			$existing_options = get_option( Settings::OPTION_NAME, null );
+			if ( is_array( $existing_options ) && ! empty( $existing_options ) ) {
+				return;
+			}
+
 			// Update options (we migrate to a new option name `antispam_bee_options` in this release).
 			$options = get_option( 'antispam_bee', [] );
 			if ( ! is_array( $options ) ) {

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -185,6 +185,19 @@ class PluginUpdate {
 	}
 
 	/**
+	 * Record the database as migrated without running the migration.
+	 *
+	 * For the user who gave up on the migration and configured the plugin by hand
+	 * instead: their settings are the ones that should survive, and nothing is left
+	 * to migrate. Writing the version is what actually stops the retries, because
+	 * `db_version_is_current()` then reports the database as up-to-date.
+	 */
+	public static function mark_as_migrated(): void {
+		delete_option( self::FAILURE_OPTION_NAME );
+		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+	}
+
+	/**
 	 * Read the recorded state of failed migration attempts.
 	 *
 	 * State recorded against a different plugin version is discarded: a release that

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -268,16 +268,52 @@ class PluginUpdate {
 	}
 
 	/**
+	 * Normalize a legacy multiselect option into a list of non-empty strings.
+	 *
+	 * These options were single-value settings before the multiselect rework, so a
+	 * 2.x install that never re-saved its settings can still hold a plain string
+	 * (`'translate_lang' => 'de'`) or an empty string where an array is expected.
+	 * PHP does not coerce a scalar into an `array` parameter even in weak mode, so
+	 * such a value used to raise an uncaught `TypeError`. 2.x itself cast at every
+	 * read site; this restores that tolerance.
+	 *
+	 * @param mixed $values Raw legacy option value.
+	 *
+	 * @return string[] Normalized list of selected values.
+	 */
+	private static function normalize_multiselect_values( $values ): array {
+		if ( ! is_array( $values ) ) {
+			$values = is_scalar( $values ) ? [ $values ] : [];
+		}
+
+		$normalized = [];
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$value = (string) $value;
+			if ( '' !== $value ) {
+				$normalized[] = $value;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
 	 * Convert multiselect values.
 	 * Takes an array of selected keys, applies optional mapping and generates a new array using
 	 * these values as keys and "on" as value.
 	 *
-	 * @param string[]                   $values  Selected values.
+	 * @param mixed                      $values  Selected values, in whatever shape the legacy option holds.
 	 * @param array<string, string|null> $mapping Key mapping (optional).
 	 *
 	 * @return array<string, string> Converted array of selected options.
 	 */
-	private static function convert_multiselect_values( array $values, array $mapping = [] ): array {
+	private static function convert_multiselect_values( $values, array $mapping = [] ): array {
+		$values = self::normalize_multiselect_values( $values );
+
 		if ( empty( $values ) ) {
 			return $values;
 		}

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -185,6 +185,31 @@ class PluginUpdate {
 	}
 
 	/**
+	 * Whether the plugin already has settings of its own stored.
+	 *
+	 * @return bool Whether `antispam_bee_options` holds a configuration.
+	 */
+	public static function has_stored_settings(): bool {
+		$stored = get_option( Settings::OPTION_NAME, null );
+
+		return is_array( $stored ) && ! empty( $stored );
+	}
+
+	/**
+	 * Throw away the stored settings so the next run migrates the legacy ones again.
+	 *
+	 * The automatic retries deliberately never touch a stored configuration — see the
+	 * guard in the 3.0.0 step. A retry the user asked for is the opposite situation:
+	 * they are looking at a notice that says their old settings were not migrated and
+	 * are choosing to have them back, so the settings standing in the way have to go,
+	 * or the retry would silently do nothing at all.
+	 */
+	public static function reset_for_retry(): void {
+		delete_option( Settings::OPTION_NAME );
+		delete_option( self::FAILURE_OPTION_NAME );
+	}
+
+	/**
 	 * Record the database as migrated without running the migration.
 	 *
 	 * For the user who gave up on the migration and configured the plugin by hand
@@ -299,10 +324,10 @@ class PluginUpdate {
 			 * over either would throw away their configuration. The write below is the step's
 			 * last action, so a run cut short left nothing behind and a present array is always
 			 * one of those two. A stored value that is not an array is corrupt, not a
-			 * configuration, and is replaced.
+			 * configuration, and is replaced. A retry the user explicitly asked for clears
+			 * the option first, so this guard only ever holds back the automatic retries.
 			 */
-			$existing_options = get_option( Settings::OPTION_NAME, null );
-			if ( is_array( $existing_options ) && ! empty( $existing_options ) ) {
+			if ( self::has_stored_settings() ) {
 				return;
 			}
 

--- a/src/Handlers/PluginUpdate.php
+++ b/src/Handlers/PluginUpdate.php
@@ -103,12 +103,47 @@ class PluginUpdate {
 
 		$version_from_db = get_option( self::DB_VERSION_OPTION_NAME, null );
 
-		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
-
-		if ( null === $version_from_db ) {
-			return;
+		/*
+		 * `null` is a fresh install, which has nothing to migrate. A recorded revision
+		 * that is not a scalar cannot be compared against at all, and since the version
+		 * write below no longer happens first, retrying such a value would now fatal on
+		 * every request rather than once. Neither case has a migration to run, so both
+		 * fall through to the version write.
+		 */
+		if ( is_scalar( $version_from_db ) ) {
+			static::run_migration_steps( (string) $version_from_db );
 		}
 
+		/*
+		 * Only now that every step has completed. Writing the version first would spend
+		 * the one chance a site gets: `db_version_is_current()` would report the database
+		 * as up-to-date on every later request, so a step interrupted by a fatal, a DB
+		 * error, a timeout or a warning promoted to an exception would never run again.
+		 * The legacy option would still be in place while `antispam_bee_options` was
+		 * never written, leaving the site on `Settings::$defaults` — the user's entire
+		 * configuration gone, with no way to retrigger the migration short of editing
+		 * the option by hand.
+		 *
+		 * Deferring the write cannot make the migration run twice within a request,
+		 * because `self::$db_update_triggered` is already set above.
+		 */
+		update_option( self::DB_VERSION_OPTION_NAME, self::get_plugin_version() );
+	}
+
+	/**
+	 * Bring an existing install up to the current database revision.
+	 *
+	 * Called for an install that has a recorded revision; a fresh install has nothing
+	 * to migrate and only gets the revision written.
+	 *
+	 * Every step has to tolerate running against an install that already passed it: a
+	 * later step may fail and bring the whole method back on the next request.
+	 *
+	 * @param string $version_from_db The database revision the install is on.
+	 *
+	 * @return void
+	 */
+	protected static function run_migration_steps( string $version_from_db ): void {
 		if ( $version_from_db < 1.01 ) {
 			global $wpdb;
 

--- a/src/load.php
+++ b/src/load.php
@@ -9,6 +9,7 @@ namespace AntispamBee;
 
 use AntispamBee\Admin\CommentsColumns;
 use AntispamBee\Admin\DashboardWidgets;
+use AntispamBee\Admin\MigrationFailureNotice;
 use AntispamBee\Admin\SettingsPage;
 use AntispamBee\Admin\UpgradeNotice;
 use AntispamBee\Crons\DeleteSpamCron;
@@ -19,6 +20,7 @@ use AntispamBee\GeneralOptions\Uninstall;
 use AntispamBee\Handlers\Comment;
 use AntispamBee\Handlers\Linkback;
 use AntispamBee\Handlers\PluginStateChangeHandler;
+use AntispamBee\Handlers\PluginUpdate;
 use AntispamBee\Helpers\Settings;
 use AntispamBee\Helpers\SpamReasonTextHelper;
 use AntispamBee\PostProcessors\Delete;
@@ -55,9 +57,11 @@ function init(): void {
 		new SettingsPage(),
 		CommentsColumns::class,
 		UpgradeNotice::class,
+		MigrationFailureNotice::class,
 		DeleteSpamCron::class,
 		Settings::class,
 		// Handlers.
+		PluginUpdate::class,
 		Comment::class,
 		Linkback::class,
 		// Helpers.

--- a/tests/Integration/Handlers/PluginUpdateTest.php
+++ b/tests/Integration/Handlers/PluginUpdateTest.php
@@ -10,7 +10,29 @@ namespace AntispamBee\Tests\Integration\Handlers;
 use AntispamBee\Handlers\PluginUpdate;
 use AntispamBee\Helpers\Settings;
 use ReflectionClass;
+use RuntimeException;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * A migration whose steps fail, standing in for a fatal, a DB error, a timeout or a
+ * warning promoted to an exception. `PluginUpdate` reaches the steps through
+ * `static::`, so overriding them here is enough to drive the failure path.
+ */
+final class FailingPluginUpdate extends PluginUpdate {
+
+	/**
+	 * Fail before anything is migrated.
+	 *
+	 * @param string $version_from_db The database revision the install is on.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException Always.
+	 */
+	protected static function run_migration_steps( string $version_from_db ): void {
+		throw new RuntimeException( 'A migration step failed at revision ' . $version_from_db );
+	}
+}
 
 /**
  * The migration runs once per site and its result becomes the user's configuration,
@@ -261,6 +283,56 @@ final class PluginUpdateTest extends TestCase {
 			$first_run,
 			get_option( Settings::OPTION_NAME ),
 			'Running the update logic twice must not change the migrated options.'
+		);
+	}
+
+	public function test_a_failed_migration_step_leaves_the_database_version_untouched(): void {
+		$this->seed_legacy_install();
+
+		$this->expectException( RuntimeException::class );
+
+		try {
+			FailingPluginUpdate::maybe_run_plugin_updated_logic();
+		} finally {
+			self::assertSame(
+				'1.02',
+				get_option( self::DB_VERSION_OPTION ),
+				'A migration that fails must not leave the database version bumped, or it is never retried.'
+			);
+			self::assertFalse(
+				get_option( Settings::OPTION_NAME ),
+				'Nothing was migrated, so the v3 option must not exist.'
+			);
+		}
+	}
+
+	public function test_a_failed_migration_is_retried_on_the_next_request(): void {
+		$this->seed_legacy_install();
+
+		try {
+			FailingPluginUpdate::maybe_run_plugin_updated_logic();
+		} catch ( RuntimeException $exception ) {
+			unset( $exception );
+		}
+
+		// The next request starts with the per-request guards cleared.
+		$this->reset_plugin_update_state();
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertNotFalse(
+			get_option( Settings::OPTION_NAME ),
+			'The retry has to migrate the options the failed run never wrote.'
+		);
+		self::assertSame(
+			4711,
+			get_option( Settings::OPTION_NAME )['spam_count'],
+			'The retry has to migrate from the legacy option, not from defaults.'
+		);
+		self::assertNotSame(
+			'1.02',
+			get_option( self::DB_VERSION_OPTION ),
+			'A successful retry has to record the current database version.'
 		);
 	}
 

--- a/tests/Integration/Handlers/PluginUpdateTest.php
+++ b/tests/Integration/Handlers/PluginUpdateTest.php
@@ -63,6 +63,7 @@ final class PluginUpdateTest extends TestCase {
 		parent::set_up();
 
 		$this->reset_plugin_update_state();
+		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
 	}
 
 	/**
@@ -72,6 +73,7 @@ final class PluginUpdateTest extends TestCase {
 	 */
 	public function tear_down(): void {
 		$this->reset_plugin_update_state();
+		delete_option( PluginUpdate::FAILURE_OPTION_NAME );
 
 		parent::tear_down();
 	}
@@ -289,31 +291,67 @@ final class PluginUpdateTest extends TestCase {
 	public function test_a_failed_migration_step_leaves_the_database_version_untouched(): void {
 		$this->seed_legacy_install();
 
-		$this->expectException( RuntimeException::class );
+		// The failure must not escape: a request that reads a setting carries on without it.
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
 
-		try {
+		self::assertSame(
+			'1.02',
+			get_option( self::DB_VERSION_OPTION ),
+			'A migration that fails must not leave the database version bumped, or it is never retried.'
+		);
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'Nothing was migrated, so the v3 option must not exist.'
+		);
+	}
+
+	public function test_a_failed_migration_step_is_recorded(): void {
+		$this->seed_legacy_install();
+
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
+
+		$failures = get_option( PluginUpdate::FAILURE_OPTION_NAME );
+
+		self::assertSame( 1, $failures['attempts'], 'The failed attempt has to be counted.' );
+		self::assertStringContainsString(
+			'A migration step failed',
+			$failures['message'],
+			'The reason has to be recorded, or the notice has nothing to show.'
+		);
+	}
+
+	public function test_the_migration_is_abandoned_once_the_attempts_run_out(): void {
+		$this->seed_legacy_install();
+
+		for ( $attempt = 0; $attempt < PluginUpdate::MAX_UPDATE_ATTEMPTS; $attempt++ ) {
 			FailingPluginUpdate::maybe_run_plugin_updated_logic();
-		} finally {
-			self::assertSame(
-				'1.02',
-				get_option( self::DB_VERSION_OPTION ),
-				'A migration that fails must not leave the database version bumped, or it is never retried.'
-			);
-			self::assertFalse(
-				get_option( Settings::OPTION_NAME ),
-				'Nothing was migrated, so the v3 option must not exist.'
-			);
+			$this->reset_plugin_update_state();
 		}
+
+		self::assertSame(
+			PluginUpdate::MAX_UPDATE_ATTEMPTS,
+			get_option( PluginUpdate::FAILURE_OPTION_NAME )['attempts'],
+			'Every request up to the cap has to spend an attempt.'
+		);
+
+		// A working migration is no longer even tried once the attempts are spent.
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		self::assertFalse(
+			get_option( Settings::OPTION_NAME ),
+			'Past the cap the migration must not run, so nothing is written.'
+		);
+		self::assertSame(
+			'1.02',
+			get_option( self::DB_VERSION_OPTION ),
+			'Past the cap the database version stays stale, so the notice keeps showing.'
+		);
 	}
 
 	public function test_a_failed_migration_is_retried_on_the_next_request(): void {
 		$this->seed_legacy_install();
 
-		try {
-			FailingPluginUpdate::maybe_run_plugin_updated_logic();
-		} catch ( RuntimeException $exception ) {
-			unset( $exception );
-		}
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
 
 		// The next request starts with the per-request guards cleared.
 		$this->reset_plugin_update_state();

--- a/tests/Unit/Handlers/FailingPluginUpdate.php
+++ b/tests/Unit/Handlers/FailingPluginUpdate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AntispamBee\Tests\Unit\Handlers;
+
+use AntispamBee\Handlers\PluginUpdate;
+use RuntimeException;
+
+/**
+ * A handler whose migration step always fails, to exercise the failure handling.
+ *
+ * `run_migration_steps()` is called through `static::`, so calling
+ * {@see PluginUpdate::maybe_run_plugin_updated_logic()} on this subclass runs the
+ * failing step below instead of the real one.
+ */
+class FailingPluginUpdate extends PluginUpdate {
+
+	/**
+	 * How often the step was entered.
+	 *
+	 * @var int
+	 */
+	public static $calls = 0;
+
+	/**
+	 * The failure state as it was stored at the moment the step ran.
+	 *
+	 * @var mixed
+	 */
+	public static $state_during_call = null;
+
+	/**
+	 * Fail the way an interrupted migration would.
+	 *
+	 * @param string $version_from_db The database revision the install is on.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException Always.
+	 */
+	protected static function run_migration_steps( string $version_from_db ): void {
+		++self::$calls;
+		self::$state_during_call = get_option( self::FAILURE_OPTION_NAME, null );
+
+		throw new RuntimeException( 'Migration exploded' );
+	}
+}

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -439,6 +439,39 @@ class PluginUpdateTest extends TestCase {
 	}
 
 	/**
+	 * Marking the database as migrated stops the retries without touching the settings.
+	 *
+	 * @return void
+	 */
+	public function test_marking_as_migrated_stops_the_retries(): void {
+		$saved_by_hand = [ 'comment' => [ 'rule_asb_regexp_active' => '' ] ];
+
+		$this->stub_options(
+			[
+				'antispam_bee'                   => [ 'regexp_check' => 1 ],
+				'antispam_bee_options'           => $saved_by_hand,
+				'antispambee_db_version'         => '1.02',
+				'antispambee_db_update_failures' => [
+					'version'  => '3.0.0-beta.1',
+					'attempts' => PluginUpdate::MAX_UPDATE_ATTEMPTS,
+					'message'  => 'Migration exploded',
+					'time'     => 1,
+				],
+			]
+		);
+
+		PluginUpdate::mark_as_migrated();
+
+		$this->assertContains( PluginUpdate::FAILURE_OPTION_NAME, $this->deleted_options );
+		$this->assertSame( '3.0.0-beta.1', $this->written_options[ PluginUpdate::DB_VERSION_OPTION_NAME ] );
+		$this->assertSame(
+			$saved_by_hand,
+			$this->stored_options[ Settings::OPTION_NAME ],
+			'The settings the user configured by hand are left untouched.'
+		);
+	}
+
+	/**
 	 * A stored value that is not an array is corrupt, not a configuration, and is replaced.
 	 *
 	 * @return void

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -439,6 +439,44 @@ class PluginUpdateTest extends TestCase {
 	}
 
 	/**
+	 * A retry the user asked for clears the stored settings, so the migration really runs.
+	 *
+	 * Without this the guard that protects the automatic retries would make the manual one
+	 * skip its work and report success, which is the opposite of what the button promises.
+	 *
+	 * @return void
+	 */
+	public function test_resetting_for_a_retry_clears_the_stored_settings(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'                   => [ 'regexp_check' => 1 ],
+				'antispam_bee_options'           => [ 'comment' => [ 'rule_asb_regexp_active' => '' ] ],
+				'antispambee_db_version'         => '1.02',
+				'antispambee_db_update_failures' => [
+					'version'  => '3.0.0-beta.1',
+					'attempts' => PluginUpdate::MAX_UPDATE_ATTEMPTS,
+					'message'  => 'Migration exploded',
+					'time'     => 1,
+				],
+			]
+		);
+
+		PluginUpdate::reset_for_retry();
+
+		$this->assertContains( Settings::OPTION_NAME, $this->deleted_options );
+		$this->assertContains( PluginUpdate::FAILURE_OPTION_NAME, $this->deleted_options );
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			'on',
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_regexp_active'],
+			'The legacy settings are migrated again instead of being skipped.'
+		);
+		$this->assertSame( '3.0.0-beta.1', $this->written_options[ PluginUpdate::DB_VERSION_OPTION_NAME ] );
+	}
+
+	/**
 	 * Marking the database as migrated stops the retries without touching the settings.
 	 *
 	 * @return void

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -26,6 +26,20 @@ class PluginUpdateTest extends TestCase {
 	private $written_options = [];
 
 	/**
+	 * Options removed via `delete_option()`.
+	 *
+	 * @var string[]
+	 */
+	private $deleted_options = [];
+
+	/**
+	 * The simulated option store that `get_option()` reads from.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $stored_options = [];
+
+	/**
 	 * Reset the memoized migration state and stub the option and plugin-file functions.
 	 *
 	 * @return void
@@ -36,12 +50,31 @@ class PluginUpdateTest extends TestCase {
 		$this->reset_static( 'db_update_triggered', false );
 		$this->reset_static( 'db_version_is_current', null );
 
+		FailingPluginUpdate::$calls             = 0;
+		FailingPluginUpdate::$state_during_call = null;
+
 		$this->written_options = [];
+		$this->deleted_options = [];
+		$this->stored_options  = [];
 
 		when( 'get_file_data' )->justReturn( [ 'Version' => '3.0.0-beta.1' ] );
+		when( 'get_option' )->alias(
+			function ( $name, $default = false ) {
+				return array_key_exists( $name, $this->stored_options ) ? $this->stored_options[ $name ] : $default;
+			}
+		);
 		when( 'update_option' )->alias(
 			function ( $name, $value ) {
 				$this->written_options[ $name ] = $value;
+				$this->stored_options[ $name ]  = $value;
+
+				return true;
+			}
+		);
+		when( 'delete_option' )->alias(
+			function ( $name ) {
+				$this->deleted_options[] = $name;
+				unset( $this->stored_options[ $name ] );
 
 				return true;
 			}
@@ -63,18 +96,14 @@ class PluginUpdateTest extends TestCase {
 	}
 
 	/**
-	 * Stub `get_option()` with a fixed set of stored options.
+	 * Seed the simulated option store.
 	 *
 	 * @param array<string, mixed> $stored Option values keyed by option name.
 	 *
 	 * @return void
 	 */
 	private function stub_options( array $stored ): void {
-		when( 'get_option' )->alias(
-			function ( $name, $default = false ) use ( $stored ) {
-				return array_key_exists( $name, $stored ) ? $stored[ $name ] : $default;
-			}
-		);
+		$this->stored_options = $stored;
 	}
 
 	/**
@@ -263,6 +292,171 @@ class PluginUpdateTest extends TestCase {
 		$this->assertSame(
 			[],
 			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_lang_spam_allowed']
+		);
+	}
+
+	/**
+	 * A migration that completes clears the failure state and records the new version.
+	 *
+	 * @return void
+	 */
+	public function test_a_successful_migration_clears_the_failure_state(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'                   => [ 'regexp_check' => 1 ],
+				'antispambee_db_version'         => '1.02',
+				'antispambee_db_update_failures' => [
+					'version'  => '3.0.0-beta.1',
+					'attempts' => 1,
+					'message'  => 'Migration exploded',
+					'time'     => 1,
+				],
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertContains( PluginUpdate::FAILURE_OPTION_NAME, $this->deleted_options );
+		$this->assertSame( '3.0.0-beta.1', $this->written_options[ PluginUpdate::DB_VERSION_OPTION_NAME ] );
+	}
+
+	/**
+	 * A failing step records the attempt and leaves the database version untouched.
+	 *
+	 * The version has to stay stale so the migration is retried, and the failure must not
+	 * escape: the request continues on the defaults rather than fataling.
+	 *
+	 * @return void
+	 */
+	public function test_a_failing_step_records_an_attempt_and_keeps_the_version_stale(): void {
+		$this->stub_options( [ 'antispambee_db_version' => '1.02' ] );
+
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
+
+		$state = $this->written_options[ PluginUpdate::FAILURE_OPTION_NAME ];
+
+		$this->assertSame( 1, $state['attempts'] );
+		$this->assertSame( 'Migration exploded', $state['message'] );
+		$this->assertArrayNotHasKey(
+			PluginUpdate::DB_VERSION_OPTION_NAME,
+			$this->written_options,
+			'A failed migration must not mark the database as up-to-date.'
+		);
+	}
+
+	/**
+	 * The attempt is persisted before the step runs, not after it.
+	 *
+	 * A step killed by a timeout or a fatal never returns, so a counter raised afterwards
+	 * would stay at zero and the migration would be retried forever.
+	 *
+	 * @return void
+	 */
+	public function test_the_attempt_is_recorded_before_the_step_runs(): void {
+		$this->stub_options( [ 'antispambee_db_version' => '1.02' ] );
+
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertIsArray( FailingPluginUpdate::$state_during_call );
+		$this->assertSame( 1, FailingPluginUpdate::$state_during_call['attempts'] );
+	}
+
+	/**
+	 * Once the cap is reached the migration is not attempted again.
+	 *
+	 * @return void
+	 */
+	public function test_the_migration_is_not_attempted_after_the_cap_is_reached(): void {
+		$this->stub_options(
+			[
+				'antispambee_db_version'         => '1.02',
+				'antispambee_db_update_failures' => [
+					'version'  => '3.0.0-beta.1',
+					'attempts' => PluginUpdate::MAX_UPDATE_ATTEMPTS,
+					'message'  => 'Migration exploded',
+					'time'     => 1,
+				],
+			]
+		);
+
+		FailingPluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame( 0, FailingPluginUpdate::$calls );
+		$this->assertSame( [], $this->written_options );
+	}
+
+	/**
+	 * A failure recorded against another plugin version does not block the migration.
+	 *
+	 * A release that fixes whatever made the migration fail has to get its own attempts,
+	 * so a site that gave up recovers on update instead of needing a manual retry.
+	 *
+	 * @return void
+	 */
+	public function test_a_failure_state_from_another_version_is_discarded(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'                   => [ 'regexp_check' => 1 ],
+				'antispambee_db_version'         => '1.02',
+				'antispambee_db_update_failures' => [
+					'version'  => '3.0.0-beta.0',
+					'attempts' => PluginUpdate::MAX_UPDATE_ATTEMPTS,
+					'message'  => 'Migration exploded',
+					'time'     => 1,
+				],
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertArrayHasKey( Settings::OPTION_NAME, $this->written_options );
+	}
+
+	/**
+	 * Settings the user saved while the database version was still stale are not overwritten.
+	 *
+	 * @return void
+	 */
+	public function test_existing_options_are_not_overwritten(): void {
+		$saved_by_hand = [ 'comment' => [ 'rule_asb_regexp_active' => '' ] ];
+
+		$this->stub_options(
+			[
+				'antispam_bee'           => [ 'regexp_check' => 1 ],
+				'antispam_bee_options'   => $saved_by_hand,
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertArrayNotHasKey( Settings::OPTION_NAME, $this->written_options );
+		$this->assertSame(
+			$saved_by_hand,
+			$this->stored_options[ Settings::OPTION_NAME ],
+			'The stored settings are left exactly as the user saved them.'
+		);
+	}
+
+	/**
+	 * A stored value that is not an array is corrupt, not a configuration, and is replaced.
+	 *
+	 * @return void
+	 */
+	public function test_corrupt_existing_options_are_replaced(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [ 'regexp_check' => 1 ],
+				'antispam_bee_options'   => 'corrupted',
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			'on',
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_regexp_active']
 		);
 	}
 }

--- a/tests/Unit/Handlers/PluginUpdateTest.php
+++ b/tests/Unit/Handlers/PluginUpdateTest.php
@@ -189,4 +189,80 @@ class PluginUpdateTest extends TestCase {
 		$this->assertSame( '', $comment['rule_asb_regexp_active'] );
 		$this->assertSame( 'on', $comment['rule_asb_honeypot_active'], 'The honeypot rule is always migrated as enabled.' );
 	}
+
+	/**
+	 * A legacy `translate_lang` that is still a plain string must not abort the migration.
+	 *
+	 * The option was a single value before the multiselect rework, so a 2.x install that
+	 * never re-saved its settings still holds a string here. Passing it into an `array`
+	 * parameter raised an uncaught `TypeError`.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_translate_lang_does_not_abort_the_migration(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'translate_lang' => 'de',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertArrayHasKey( Settings::OPTION_NAME, $this->written_options );
+		$this->assertSame(
+			[ 'de' => 'on' ],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_lang_spam_allowed'],
+			'A single legacy language is migrated as one selected value.'
+		);
+	}
+
+	/**
+	 * A legacy `ignore_reasons` that is still a plain string must migrate through the mapping.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_ignore_reasons_does_not_abort_the_migration(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'ignore_reasons' => 'css',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			[ 'asb-honeypot' => 'on' ],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['post_processor_asb_delete_for_reasons_reasons'],
+			'The legacy reason slug is mapped to its 3.0 equivalent.'
+		);
+	}
+
+	/**
+	 * An empty legacy multiselect value must migrate to an empty selection, not to an empty key.
+	 *
+	 * @return void
+	 */
+	public function test_empty_scalar_multiselect_migrates_to_an_empty_selection(): void {
+		$this->stub_options(
+			[
+				'antispam_bee'           => [
+					'translate_lang' => '',
+				],
+				'antispambee_db_version' => '1.02',
+			]
+		);
+
+		PluginUpdate::maybe_run_plugin_updated_logic();
+
+		$this->assertSame(
+			[],
+			$this->written_options[ Settings::OPTION_NAME ]['comment']['rule_asb_lang_spam_allowed']
+		);
+	}
 }


### PR DESCRIPTION
Rebased onto `v3` now that #857 has merged, so this contains only its own work. Addresses the open questions from #798 / #844 about what actually happens when the migration fails.

#857 made a failed migration retryable by writing `antispambee_db_version` only after the migration steps succeed. This PR moves those steps into `run_migration_steps()` — a seam #857's merged form does not have, so the extraction shows up in this diff — and builds the failure handling around that call. Retrying was still unbounded and completely invisible:


- `PluginUpdate::maybe_run_plugin_updated_logic()` is called from inside `Settings::get_options()`, so *any* request that reads a setting triggers it — every wp-admin page that touches settings, and a frontend comment POST as well. `self::$db_update_triggered` only guards a single request.
- A step that fatals, times out, or hits a DB error was therefore retried on every subsequent request, forever. For anonymous visitors that is a permanently broken comment form.
- Nothing told the site owner. No admin notice, no log entry — just a repeating 500 that could not be attributed to Antispam Bee.
- The v3 step rebuilt `antispam_bee_options` from the legacy option and wrote it unconditionally, so settings an admin saved by hand while the version was still stale were clobbered by the next attempt.

## What this changes

**A bounded, fatal-safe attempt cap.** The attempt is recorded in `antispambee_db_update_failures` *before* the steps run, not after. A step killed by a timeout or a true fatal never returns, so a counter raised afterwards would stay at zero and the site would keep retrying forever — burning the attempt up front is what makes the cap hold for uncatchable failures too. After ten attempts the migration is no longer tried. An attempt is spent per request rather than over time, so the cap buys tolerance of a fault that clears within a handful of requests, not of a longer outage. The state is keyed by the target plugin version, so a release that ships a fix gets its own attempts and a site that gave up recovers on update without manual intervention.

**Catchable failures degrade instead of fataling.** `run_migration_steps()` runs inside `try`/`catch ( Throwable )`. The message is recorded and the request continues on `Settings::$defaults` — for a comment being submitted that means slightly wrong spam settings, which is far better than turning every commenting visitor's request into a fatal.

**The user finds out.** `MigrationFailureNotice` shows an error notice to administrators from the **first** recorded failure, not only once the attempts are spent. Gating it on the cap meant a retry the user asked for reported nothing at all — clearing the failure state put the count back to one, below the cap, so the notice vanished instead of showing that the attempt had just failed again. Showing it earlier also surfaces a migration killed by a fatal rather than staying quiet until the cap. The notice explains the situation, confirming that the previous settings are still in the database and unharmed, and showing the recorded error message. It offers two nonce-protected actions, worded to match the state it is describing:

- **Migrate again** — or **Discard the current settings and migrate again** when settings are already stored. It clears `antispam_bee_options` and the failure state so the legacy settings are genuinely migrated again. Simply clearing the failure state would not do: the guard below would make the migration skip its work and report success, which is not what the button promises.
- **Keep the current settings** — records the database as migrated without running the migration, for the site whose migration cannot be made to work, so the user configures the plugin by hand and the notice goes away for good. Without it a site that hit the cap would show the notice forever, since nothing would ever write the version again.

**The copy answers two questions separately.** What the plugin is running with now, and what happens next. Folding them together is how the give-up state came to promise previous settings would be applied "as soon as the migration succeeds" while nothing was ever going to try again. The state line now reports what is in force; a second line either announces the next attempt (`Attempt 3 of 10`) or states that Antispam Bee stopped and will not retry on its own.

**No more clobbering.** The v3 step returns early when `antispam_bee_options` already holds a non-empty array. The write is the step's last action, so a run that was cut short left nothing behind — a present array is therefore always either a completed migration or settings the user saved deliberately, and neither should be rebuilt by a retry nobody asked for. A stored value that is not an array is corrupt rather than a configuration and is still replaced. The guard applies to the automatic retries only; a retry the user explicitly requested clears the option first, which is the whole difference between the two.

**Migration is attempted on `admin_init` too.** The lazy call in `Settings::get_options()` stays, so settings are never silently wrong, but in practice an admin page load now performs the migration rather than a visitor's comment.

**Cleanup.** `antispambee_db_update_failures` is deleted on uninstall alongside the other options.

`tests/Unit/Admin/MigrationFailureNoticeTest.php` also covers the two `admin-post` handlers, which are the only user-facing entry points and the riskiest code here — the retry deletes the settings option outright. It asserts what each does when allowed to run, and that neither reaches a delete or a write when the capability is missing or the nonce does not check out. Removing either check turns the suite red.

## Multisite

Every site migrates lazily and independently, the first time something on that site reads a setting. There is no network-wide loop, because migrating thousands of sites synchronously inside one request cannot work, and the per-site attempt cap bounds what a failing migration costs. The reasoning is recorded in the `maybe_update_database()` docblock.

That leaves a reporting problem. The network screens are served by the main site, so a per-site option read there describes the main site and nothing else — a migration that failed on any other site would be invisible to a network administrator, who is exactly the person running a migration across many sites at once. Hooking `network_admin_notices` alone does not fix it; the notice would simply report the wrong site.

So sites register themselves. A site that fails adds its ID to a network option, and removes itself when the migration succeeds, when the user retries, or when they keep the settings they have. The network notice reads that one option and names the affected sites, each linking to its own dashboard where the details and the two actions live. Only sites that actually failed are looked up, so the cost follows the number of failures rather than the size of the network. A deleted site is dropped from the list, and the list is removed on uninstall.

One limitation is worth stating: when Antispam Bee is activated per site and is not active on the main site, WordPress does not load it on the network screens at all, so nothing can be reported there by any means.

## Testing

211 unit tests, 18 single-site integration tests and 18 multisite integration tests pass; PHPCS is clean across `src/` and PHPStan reports no errors.

`tests/Unit/Handlers/PluginUpdateTest.php` covers a successful migration clearing the failure state, a failing step recording an attempt while leaving the version stale, the attempt being persisted *before* the step runs, no further attempts once the cap is reached, a failure state from another plugin version being discarded, existing settings not being overwritten by an automatic retry while corrupt values still are, `reset_for_retry()` clearing the stored settings so the manual retry really migrates again, and `mark_as_migrated()` stopping the retries without touching hand-saved settings.

`tests/Unit/Admin/MigrationFailureNoticeTest.php` is new — the notice previously had no tests, and every bug it has had was a question of which state it chose to describe and what it then claimed. It asserts which states render at all, that the first failure is reported immediately, that the give-up state never promises a retry, that the retry label warns only when there are stored settings to discard, and that a failure recorded against another plugin version stays silent.

Both suites also cover a failure raised **inside** the real step, through the `option_antispam_bee` filter. The `FailingPluginUpdate` subclasses replace `run_migration_steps()` wholesale, so nothing else exercises the real one; filtering the legacy read puts the fault where a broken stored value or an unserialize error would raise it. That same filter is the least invasive way to reproduce the failure by hand on a real site, with no plugin source to edit.

To reproduce a failure on a real site, drop a mu-plugin that throws from the legacy option read and toggle it with WP-CLI:

```php
add_filter( 'option_antispam_bee', static function ( $value ) {
    if ( ! get_option( 'asb_simulate_migration_failure' ) ) {
        return $value;
    }
    throw new RuntimeException( 'Simulated failure while reading the legacy option.' );
} );
```

```
wp option update antispambee_db_version 1.02
wp option delete antispam_bee_options
wp option update asb_simulate_migration_failure 1
```

Note that an attempt is spent per HTTP request, and a wp-admin page load is rarely a single request, so the attempts are consumed quickly — `wp option delete antispambee_db_update_failures` between page loads to watch the intermediate states.


