### PR TITLE
Recruit 3.0.0 pre-release testers with an upgrade notice and admin notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog ##
 
+### 2.11.14 ###
+* **English**
+  * Enhancement: Admin notice recruiting testers for the Antispam Bee 3.0.0 pre-release
+
+* **Deutsch**
+  * Verbesserung: Hinweis im Backend, der Testerinnen und Tester für die Vorabversion von Antispam Bee 3.0.0 sucht
+
 ### 2.11.13 ###
 * **English**
   * Enhancement: New filter `antispam_bee_honeypot_styles` to change the styles of the honeypot field

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -45,36 +45,6 @@ defined( 'ABSPATH' ) || exit;
 class Antispam_Bee {
 
 	/**
-	 * Canonical announcement post for the 3.0.0 pre-release.
-	 *
-	 * Both the admin notice and the readme.txt upgrade notice point here, so the
-	 * target can be kept up to date while the pre-release progresses.
-	 *
-	 * @since 2.11.14
-	 *
-	 * @var string
-	 */
-	const PRERELEASE_ANNOUNCEMENT_URL = 'https://pluginkollektiv.org/antispam-bee-3-0-0-pre-release/';
-
-	/**
-	 * User meta key storing the dismissal of the 3.0.0 pre-release notice.
-	 *
-	 * @since 2.11.14
-	 *
-	 * @var string
-	 */
-	const PRERELEASE_NOTICE_USER_META = 'antispam_bee_dismissed_prerelease_notice_300';
-
-	/**
-	 * Query argument used by the dismiss link of the 3.0.0 pre-release notice.
-	 *
-	 * @since 2.11.14
-	 *
-	 * @var string
-	 */
-	const PRERELEASE_NOTICE_DISMISS_ARG = 'antispam_bee_dismiss_prerelease_notice';
-
-	/**
 	 * The option defaults.
 	 *
 	 * @var array
@@ -1174,14 +1144,17 @@ class Antispam_Bee {
 			return;
 		}
 
-		if ( get_user_meta( get_current_user_id(), self::PRERELEASE_NOTICE_USER_META, true ) ) {
+		if ( get_user_meta( get_current_user_id(), 'antispam_bee_dismissed_prerelease_notice_300', true ) ) {
 			return;
 		}
 
 		$dismiss_url = wp_nonce_url(
-			add_query_arg( self::PRERELEASE_NOTICE_DISMISS_ARG, '1' ),
-			self::PRERELEASE_NOTICE_DISMISS_ARG
+			add_query_arg( 'antispam_bee_dismiss_prerelease_notice', '1' ),
+			'antispam_bee_dismiss_prerelease_notice'
 		);
+
+		/* translators: Do not translate this URL, keep the English one. Only replace it if an announcement post in your language exists - so far there is only an English and a German post. */
+		$announcement_url = __( 'https://pluginkollektiv.org/antispam-bee-3-0-0-pre-release/', 'antispam-bee' );
 
 		echo '<div class="notice notice-info">';
 
@@ -1197,7 +1170,7 @@ class Antispam_Bee {
 
 		printf(
 			'<p><a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a> &middot; <a href="%3$s">%4$s</a></p>',
-			esc_url( self::PRERELEASE_ANNOUNCEMENT_URL ),
+			esc_url( $announcement_url ),
 			esc_html__( 'Get the pre-release and tell us how it went', 'antispam-bee' ),
 			esc_url( $dismiss_url ),
 			esc_html__( 'Dismiss this notice', 'antispam-bee' )
@@ -1217,7 +1190,7 @@ class Antispam_Bee {
 	 */
 	public static function dismiss_prerelease_notice() {
 		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
-		if ( empty( $_GET[ self::PRERELEASE_NOTICE_DISMISS_ARG ] ) ) {
+		if ( empty( $_GET['antispam_bee_dismiss_prerelease_notice'] ) ) {
 			return;
 		}
 		// phpcs:enable WordPress.CSRF.NonceVerification.NoNonceVerification
@@ -1226,14 +1199,14 @@ class Antispam_Bee {
 			return;
 		}
 
-		check_admin_referer( self::PRERELEASE_NOTICE_DISMISS_ARG );
+		check_admin_referer( 'antispam_bee_dismiss_prerelease_notice' );
 
-		update_user_meta( get_current_user_id(), self::PRERELEASE_NOTICE_USER_META, 1 );
+		update_user_meta( get_current_user_id(), 'antispam_bee_dismissed_prerelease_notice_300', 1 );
 
 		wp_safe_redirect(
 			remove_query_arg(
 				array(
-					self::PRERELEASE_NOTICE_DISMISS_ARG,
+					'antispam_bee_dismiss_prerelease_notice',
 					'_wpnonce',
 				)
 			)

--- a/antispam_bee.php
+++ b/antispam_bee.php
@@ -45,6 +45,36 @@ defined( 'ABSPATH' ) || exit;
 class Antispam_Bee {
 
 	/**
+	 * Canonical announcement post for the 3.0.0 pre-release.
+	 *
+	 * Both the admin notice and the readme.txt upgrade notice point here, so the
+	 * target can be kept up to date while the pre-release progresses.
+	 *
+	 * @since 2.11.14
+	 *
+	 * @var string
+	 */
+	const PRERELEASE_ANNOUNCEMENT_URL = 'https://pluginkollektiv.org/antispam-bee-3-0-0-pre-release/';
+
+	/**
+	 * User meta key storing the dismissal of the 3.0.0 pre-release notice.
+	 *
+	 * @since 2.11.14
+	 *
+	 * @var string
+	 */
+	const PRERELEASE_NOTICE_USER_META = 'antispam_bee_dismissed_prerelease_notice_300';
+
+	/**
+	 * Query argument used by the dismiss link of the 3.0.0 pre-release notice.
+	 *
+	 * @since 2.11.14
+	 *
+	 * @var string
+	 */
+	const PRERELEASE_NOTICE_DISMISS_ARG = 'antispam_bee_dismiss_prerelease_notice';
+
+	/**
 	 * The option defaults.
 	 *
 	 * @var array
@@ -176,6 +206,24 @@ class Antispam_Bee {
 					'add_sidebar_menu',
 				)
 			);
+
+			// Pre-release recruitment for 3.0.0, to be removed again in the next 2.11.x release. See #811.
+			if ( self::_current_page( 'plugins' ) || self::_current_page( 'options' ) ) {
+				add_action(
+					'admin_init',
+					array(
+						__CLASS__,
+						'dismiss_prerelease_notice',
+					)
+				);
+				add_action(
+					'admin_notices',
+					array(
+						__CLASS__,
+						'print_prerelease_notice',
+					)
+				);
+			}
 
 			if ( self::_current_page( 'dashboard' ) ) {
 				add_filter(
@@ -1107,6 +1155,90 @@ class Antispam_Bee {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Prints the admin notice recruiting testers for the 3.0.0 pre-release.
+	 *
+	 * Only rendered on the plugins list and on the Antispam Bee settings page, for
+	 * users who may install plugins and who have not dismissed the notice yet.
+	 *
+	 * @since 2.11.14
+	 *
+	 * @todo Remove again in the next 2.11.x release, once 3.0.0 has shipped. See #811.
+	 *
+	 * @return void
+	 */
+	public static function print_prerelease_notice() {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		if ( get_user_meta( get_current_user_id(), self::PRERELEASE_NOTICE_USER_META, true ) ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg( self::PRERELEASE_NOTICE_DISMISS_ARG, '1' ),
+			self::PRERELEASE_NOTICE_DISMISS_ARG
+		);
+
+		echo '<div class="notice notice-info">';
+
+		printf(
+			'<p><strong>%s</strong></p>',
+			esc_html__( 'Antispam Bee 3.0.0 is looking for testers', 'antispam-bee' )
+		);
+
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'The upcoming version 3.0.0 is a complete rewrite of Antispam Bee. Updating migrates your current settings to the new options, so please try the pre-release on a staging site first, not on a live site.', 'antispam-bee' )
+		);
+
+		printf(
+			'<p><a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a> &middot; <a href="%3$s">%4$s</a></p>',
+			esc_url( self::PRERELEASE_ANNOUNCEMENT_URL ),
+			esc_html__( 'Get the pre-release and tell us how it went', 'antispam-bee' ),
+			esc_url( $dismiss_url ),
+			esc_html__( 'Dismiss this notice', 'antispam-bee' )
+		);
+
+		echo '</div>';
+	}
+
+	/**
+	 * Stores the dismissal of the 3.0.0 pre-release notice for the current user.
+	 *
+	 * @since 2.11.14
+	 *
+	 * @todo Remove again in the next 2.11.x release, once 3.0.0 has shipped. See #811.
+	 *
+	 * @return void
+	 */
+	public static function dismiss_prerelease_notice() {
+		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
+		if ( empty( $_GET[ self::PRERELEASE_NOTICE_DISMISS_ARG ] ) ) {
+			return;
+		}
+		// phpcs:enable WordPress.CSRF.NonceVerification.NoNonceVerification
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		check_admin_referer( self::PRERELEASE_NOTICE_DISMISS_ARG );
+
+		update_user_meta( get_current_user_id(), self::PRERELEASE_NOTICE_USER_META, 1 );
+
+		wp_safe_redirect(
+			remove_query_arg(
+				array(
+					self::PRERELEASE_NOTICE_DISMISS_ARG,
+					'_wpnonce',
+				)
+			)
+		);
+		exit;
 	}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 ## Changelog ##
 
+### 2.11.14 ###
+  * Enhancement: Admin notice recruiting testers for the Antispam Bee 3.0.0 pre-release
+
 ### 2.11.13 ###
   * Enhancement: New filter `antispam_bee_honeypot_styles` to change the styles of the honeypot field
   * Fix: Escape the URL of the settings link (Thanks @thisismyurl!)
@@ -348,6 +351,9 @@ IMPORTANT: If you use the country check and are behind a proxy or similar, you n
 For the complete changelog, check out our [GitHub repository](https://github.com/pluginkollektiv/antispam-bee).
 
 == Upgrade Notice ==
+
+= 2.11.14 =
+Antispam Bee 3.0.0 is a complete rewrite and needs testers. Updating migrates your settings, so please try the pre-release on a staging site first: https://pluginkollektiv.org/antispam-bee-3-0-0-pre-release/
 
 = 2.11.5 =
 Instead of pre_comment_user_ip you need to use our new filter antispam_bee_trusted_ip to send the correct IP address


### PR DESCRIPTION
Recruits testers for the 3.0.0 pre-release through the two channels described in #811, both shipping in 2.11.14.

### 1. `readme.txt` upgrade notice

A `= 2.11.14 =` entry under `== Upgrade Notice ==`, kept to two sentences because WordPress truncates this hard. This channel renders in the plugins-list update row again since #698.

### 2. Dismissible admin notice

`Antispam_Bee::print_prerelease_notice()` on `admin_notices`, plus `Antispam_Bee::dismiss_prerelease_notice()` on `admin_init` for the dismiss link. Both are only hooked when `_current_page( 'plugins' )` or `_current_page( 'options' )` is true, so the notice stays off every other admin screen, and both are gated on `activate_plugins`.

The dismissal is stored in the user meta `antispam_bee_dismissed_prerelease_notice_300`, so it is persistent per user rather than per pageview. I used a nonce-protected dismiss link instead of WordPress' `is-dismissible` class, because that one only hides the notice for the current pageview unless an extra AJAX handler is added — a plain link is JS-free and matches the rest of the 2.11.x code.

The copy says plainly that 3.0.0 is a complete rewrite, that updating migrates the existing v2 options (#791, #798), and that it should be tried on a staging site first.

### Announcement URL

Both channels point at one canonical announcement post on the pluginkollektiv blog rather than a GitHub release URL, so the target can be updated as the pre-release progresses.

The URL is wrapped in `__()` so the German translation can point at the German post, with a `translators:` comment telling every other locale to keep the English one. Note that `readme.txt` can only ever carry the English URL — WordPress.org does not localise that field — so the English post should link prominently to the German version.

**The URL is still a placeholder** (`https://pluginkollektiv.org/antispam-bee-3-0-0-pre-release/`) and needs to be replaced in two places before release: the `__()` call in `antispam_bee.php` and the `readme.txt` entry.

### Removal

Both methods carry a `@todo` noting that this block gets removed again in the next 2.11.x release, as requested in the issue, so it does not linger after 3.0.0 ships.

### Notes

Inline strings rather than class constants: the 2.11.x codebase contains no `const` declarations at all, and repeats literal keys far more often than this does — `antispam_bee_reason` appears 11 times across two files. Constants would have been the outlier here.

### Testing

Verified in wp-env against a real WordPress:

- Notice renders on `plugins.php` and on the Antispam Bee settings page, with a valid nonce
- Not rendered on the dashboard or the comments screen
- Not rendered for an editor, i.e. the `activate_plugins` gate holds
- Dismiss link returns a 302 to a clean URL and writes the user meta, confirmed via WP-CLI; the notice stays gone afterwards
- `php -l` clean, and `phpcs --standard=phpcs.xml` reports only the four pre-existing `ab_` prefix errors

Closes #811
